### PR TITLE
Fix to Python Makefile so same compiler is used as when building QuantLib

### DIFF
--- a/Python/Makefile.am
+++ b/Python/Makefile.am
@@ -9,7 +9,7 @@ if BUILD_PYTHON
 all-local: .build-stamp
 
 .build-stamp: QuantLib/quantlib_wrap.cpp QuantLib/QuantLib.py
-	CXXFLAGS="$(CXXFLAGS) $(CXXWARNINGFLAGS)" CC="$(CC)" CXX="$(CXX)"$(PYTHON) setup.py build
+	CXXFLAGS="$(CXXFLAGS) $(CXXWARNINGFLAGS)" CC="$(CC)" CXX="$(CXX)" $(PYTHON) setup.py build
 	touch .build-stamp
 
 check-local: .build-stamp

--- a/Python/Makefile.am
+++ b/Python/Makefile.am
@@ -9,7 +9,7 @@ if BUILD_PYTHON
 all-local: .build-stamp
 
 .build-stamp: QuantLib/quantlib_wrap.cpp QuantLib/QuantLib.py
-	CXXFLAGS="$(CXXFLAGS) $(CXXWARNINGFLAGS)" $(PYTHON) setup.py build
+	CXXFLAGS="$(CXXFLAGS) $(CXXWARNINGFLAGS)" CC="$(CC)" CXX="$(CXX)"$(PYTHON) setup.py build
 	touch .build-stamp
 
 check-local: .build-stamp


### PR DESCRIPTION
The current Makefile does not pass on which compiler has been picked by configure. Instead, the compiler choice is left to setup.py. In some circumstances, this can result in a different compiler being picked, which in turn can lead to linker problems.