### PR TITLE
Update scheduler.i

### DIFF
--- a/SWIG/scheduler.i
+++ b/SWIG/scheduler.i
@@ -67,6 +67,7 @@ class Schedule {
     Size size() const;
     Date date(Size i) const;
     bool isRegular(Size i) const;
+    Schedule until(Date truncationDate) const;
     %extend {
         #if defined(SWIGPYTHON) || defined(SWIGRUBY)
         Date __getitem__(Integer i) {


### PR DESCRIPTION
The 'until' function isn't exposed by SWIG. Added a line to do that.