### PR TITLE
Topic normal cap floor engine

### DIFF
--- a/Python/test/QuantLibTestSuite.py
+++ b/Python/test/QuantLibTestSuite.py
@@ -29,6 +29,7 @@ from bonds import FixedRateBondTest
 from ratehelpers import FixedRateBondHelperTest
 from cms import CmsTest
 from assetswap import AssetSwapTest
+from capfloor import CapFloorTest
 
 def test():
     import QuantLib
@@ -46,6 +47,7 @@ def test():
     suite.addTest(unittest.makeSuite(FixedRateBondHelperTest, 'test'))
     suite.addTest(unittest.makeSuite(CmsTest, 'test'))
     suite.addTest(unittest.makeSuite(AssetSwapTest, 'test'))
+    suite.addTest(unittest.makeSuite(CapFloorTest, 'test'))
 
     result = unittest.TextTestRunner(verbosity=2).run(suite)
 

--- a/Python/test/capfloor.py
+++ b/Python/test/capfloor.py
@@ -37,7 +37,7 @@ class CapFloorTest(unittest.TestCase):
         self.interpolation = ql.Linear()
 
         self.start_date = ql.Date(13, 9, 2016)
-        self.maturity_date = ql.Date(14, 9, 2026)
+        self.maturity_date = ql.Date(13, 9, 2017)
         self.period = ql.Period(6, ql.Months)
         self.buss_convention = ql.ModifiedFollowing
         self.date_gen_rule = ql.DateGeneration.Forward
@@ -63,7 +63,7 @@ class CapFloorTest(unittest.TestCase):
                                    self.ibor_index)
         self.strike = 0.01
         self.cap = ql.Cap(self.ibor_leg, [self.strike])
-        self.cap_npv = 425.9
+        self.cap_npv = 8.54
 
         self.black_vol = ql.QuoteHandle(ql.SimpleQuote(0.6))
 

--- a/Python/test/capfloor.py
+++ b/Python/test/capfloor.py
@@ -1,0 +1,124 @@
+"""
+ Copyright (C) 2016 Wojciech Ślusarski
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+"""
+
+import QuantLib as ql
+import unittest
+
+class CapFloorTest(unittest.TestCase):
+    def setUp(self):
+        self.today_date = ql.Date(9, 9, 2016)
+        self.settlement_days = 2
+        self.notional = 1e4
+
+        self.calendar = ql.TARGET()
+        self.flat_forward_rate = 0.01
+        self.day_counter = ql.Actual360()
+
+        # self.sched = QuantLib.Schedule(self.issue_date, self.maturity_date,
+        #                                QuantLib.Period(QuantLib.Semiannual), self.calendar,
+        #                                QuantLib.Unadjusted, QuantLib.Unadjusted,
+        #                                QuantLib.DateGeneration.Backward, False)
+        self.strike = 0.01
+
+
+        self.flat_forward = ql.FlatForward(self.today_date,
+                                            self.flat_forward_rate,
+                                            self.day_counter,
+                                            ql.Continuous, ql.Annual)
+        self.term_structure_handle = \
+            ql.RelinkableYieldTermStructureHandle(self.flat_forward)
+
+        self.interpolation = ql.Linear()
+
+        self.start_date = ql.Date(13, 9, 2016)
+        self.maturity_date = ql.Date(14, 9, 2026)
+        self.period = ql.Period(6, ql.Months)
+        self.buss_convention = ql.ModifiedFollowing
+        self.date_gen_rule = ql.DateGeneration.Forward
+        self.eom_rule = False
+
+        self.schedule = ql.Schedule(self.start_date,
+                                    self.maturity_date,
+                                    self.period,
+                                    self.calendar,
+                                    self.buss_convention,
+                                    self.buss_convention,
+                                    self.date_gen_rule,
+                                    self.eom_rule)
+
+        ql.Settings.instance().evaluationDate = self.today_date
+
+        self.ibor_index = ql.Euribor(self.period, self.term_structure_handle)
+
+        self.ibor_index.addFixing(ql.Date(9, 9, 2016), 0.01)
+
+        self.ibor_leg = ql.IborLeg([self.notional],
+                                   self.schedule,
+                                   self.ibor_index)
+        self.strike = 0.01
+        self.cap = ql.Cap(self.ibor_leg, [self.strike])
+        self.cap_npv = 153.52
+
+        self.black_vol = ql.QuoteHandle(ql.SimpleQuote(0.2))
+
+    def testBlackCapFloorEngine(self):
+        """ Testing BlackCapFloorEngine """
+        black_engine = ql.BlackCapFloorEngine(self.term_structure_handle,
+                                        self.black_vol)
+
+        self.cap.setPricingEngine(black_engine)
+        npv = self.cap.NPV()
+        self.assertAlmostEqual(npv, self.cap_npv, places=2, msg="NPV method is broken")
+        vol_guess = 0.9
+        imp_vol = self.cap.impliedVolatility(npv,
+                                             self.term_structure_handle,
+                                             vol_guess)
+        self.assertAlmostEqual(self.black_vol.value(), 
+                               imp_vol, places=4, 
+                               msg="Implied volatility method is broken")
+
+
+    def testBachelierCapFloorEngine(self):
+        """ Testing BachelierCapFloorEngine """
+
+        bpvol = self.black_vol.value() * self.flat_forward_rate
+        bachelier_engine = ql.BachelierCapFloorEngine(self.term_structure_handle,
+                                                      ql.QuoteHandle(
+                                                         ql.SimpleQuote(bpvol)))
+                                                                    
+        self.cap.setPricingEngine(bachelier_engine)
+        npv = self.cap.NPV()
+        print(npv)
+        # self.assertAlmostEqual(npv, self.cap_npv, places=2, msg="NPV method is broken")
+        vol_guess = 0.005
+        imp_vol = self.cap.impliedVolatility(self.cap_npv, 
+                                             self.term_structure_handle,
+                                             vol_guess)
+
+
+        print("BPVOL = {}".format(bpvol))
+        print("IMPVOL = {}".format(imp_vol))
+        self.assertAlmostEqual(bpvol, imp_vol, places=4,
+                               msg="Normal Implied volatility method is broken")
+
+
+
+if __name__ == '__main__':
+    print('testing QuantLib ' + ql.__version__)
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(CapFloorTest,'test'))
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/SWIG/capfloor.i
+++ b/SWIG/capfloor.i
@@ -60,15 +60,15 @@ class CapFloorPtr : public boost::shared_ptr<Instrument> {
                 impliedVolatility(price, curve, guess, accuracy,
                                   maxEvaluations, minVol, maxVol);
         }
-        const Leg& floatingLeg() const { 
+        const Leg& floatingLeg() const {
      		return boost::dynamic_pointer_cast<CapFloor>(*self)->floatingLeg();
      	}
-     	
-        const std::vector<Rate>& capRates() const { 
-        	return boost::dynamic_pointer_cast<CapFloor>(*self)->capRates(); 
+
+        const std::vector<Rate>& capRates() const {
+        	return boost::dynamic_pointer_cast<CapFloor>(*self)->capRates();
         }
-        const std::vector<Rate>& floorRates() const { 
-        	return boost::dynamic_pointer_cast<CapFloor>(*self)->floorRates(); 
+        const std::vector<Rate>& floorRates() const {
+        	return boost::dynamic_pointer_cast<CapFloor>(*self)->floorRates();
         }
         Date startDate() const {
         	return boost::dynamic_pointer_cast<CapFloor>(*self)->startDate();
@@ -143,5 +143,28 @@ class BlackCapFloorEnginePtr : public boost::shared_ptr<PricingEngine> {
     }
 };
 
+%{
+using QuantLib::BachelierCapFloorEngine;
+typedef boost::shared_ptr<PricingEngine> BachelierCapFloorEnginePtr;
+%}
+
+%rename(BachelierCapFloorEngine) BachelierCapFloorEnginePtr;
+class BachelierCapFloorEnginePtr : public boost::shared_ptr<PricingEngine> {
+  public:
+    %extend {
+        BachelierCapFloorEnginePtr(
+                           const Handle<YieldTermStructure>& termStructure,
+                           const Handle<Quote>& vol) {
+            return new BachelierCapFloorEnginePtr(
+                                new BachelierCapFloorEngine(termStructure,vol));
+        }
+        BachelierCapFloorEnginePtr(
+                           const Handle<YieldTermStructure>& termStructure,
+                           const Handle<OptionletVolatilityStructure>& vol) {
+            return new BachelierCapFloorEnginePtr(
+                                new BachelierCapFloorEngine(termStructure,vol));
+        }
+    }
+};
 
 #endif

--- a/SWIG/capfloor.i
+++ b/SWIG/capfloor.i
@@ -50,15 +50,18 @@ class CapFloorPtr : public boost::shared_ptr<Instrument> {
   public:
      %extend {
         Volatility impliedVolatility(Real price,
-                                     const Handle<YieldTermStructure>& curve,
-                                     Volatility guess,
-                                     Real accuracy = 1.0e-4,
-                                     Size maxEvaluations = 100,
-                                     Volatility minVol = 1.0e-7,
-                                     Volatility maxVol = 4.0) const {
+	                                 const Handle<YieldTermStructure>& disc,
+	                                 Volatility guess,
+	                                 Real accuracy = 1.0e-4,
+	                                 Natural maxEvaluations = 100,
+	                                 Volatility minVol = 1.0e-7,
+	                                 Volatility maxVol = 4.0,
+	                                 VolatilityType type = ShiftedLognormal,
+	                                 Real displacement = 0.0) const {
             return boost::dynamic_pointer_cast<CapFloor>(*self)->
-                impliedVolatility(price, curve, guess, accuracy,
-                                  maxEvaluations, minVol, maxVol);
+                impliedVolatility(price, disc, guess, accuracy,
+                                  maxEvaluations, minVol, maxVol,
+                                  type, displacement);
         }
         const Leg& floatingLeg() const {
      		return boost::dynamic_pointer_cast<CapFloor>(*self)->floatingLeg();


### PR DESCRIPTION
The proposed branch exposes BachelierCapFloorEngine in SWIG.
Update of impliedVolatility method's signature to handle volatility type and shift value.
Added simple unit test in Python focusing on the fact that methods work rather than on the precise results (assumes that those were checked already in QuantLib).