### PR TITLE
Add local variable and method paramter name debug to generate class stub files to make IDE introspection more pleasant.

### DIFF
--- a/Java/Makefile.am
+++ b/Java/Makefile.am
@@ -23,7 +23,7 @@ libQuantLibJNI.@JNILIB_EXTENSION@: quantlib_wrap.o
 
 QuantLib.jar: quantlib_wrap.cpp org/quantlib/*.java
 	mkdir -p bin
-	find org/quantlib -name '*.java' | xargs $(JAVAC) -d bin
+	find org/quantlib -name '*.java' | xargs $(JAVAC) -g -d bin
 	$(JAR) cf QuantLib.jar -C bin org
 
 install-exec-local:


### PR DESCRIPTION
Current Java Java SWIG wrappers just have arg0, arg1, arg2 as variable names.  This is painful especially given how many parameters some of the methods have.  -g enables local variables names to be included in the output.  Due to JIT the runtime performance is not affected by this change.  The .class files are slightly larger.
