### PR TITLE
adding  method vega() to swaption object

### DIFF
--- a/SWIG/swaption.i
+++ b/SWIG/swaption.i
@@ -82,6 +82,11 @@ class BlackSwaptionEnginePtr : public boost::shared_ptr<PricingEngine> {
             return new BlackSwaptionEnginePtr(
                                    new BlackSwaptionEngine(discountCurve, v));
         }
+
+	Real vega() {
+                return boost::dynamic_pointer_cast<Swaption>(*self)->result<Real>("vega");
+        }
+
     }
 };
 


### PR DESCRIPTION
Adding custom swig access method to make vega() available to the Python bindings.