### PR TITLE
Add optional 'Calendar c' parameter Business252() class signature

### DIFF
--- a/Python/test/QuantLibTestSuite.py
+++ b/Python/test/QuantLibTestSuite.py
@@ -20,6 +20,7 @@ import sys
 import unittest
 
 from date import DateTest
+from daycounters import DayCountersTest
 from instruments import InstrumentTest
 from marketelements import MarketElementTest
 from integrals import IntegralTest
@@ -38,6 +39,7 @@ def test():
     suite = unittest.TestSuite()
 
     suite.addTest(DateTest())
+    suite.addTest(DayCountersTest())
     suite.addTest(unittest.makeSuite(InstrumentTest,'test'))
     suite.addTest(unittest.makeSuite(MarketElementTest,'test'))
     suite.addTest(unittest.makeSuite(IntegralTest,'test'))

--- a/Python/test/daycounters.py
+++ b/Python/test/daycounters.py
@@ -1,0 +1,21 @@
+import QuantLib
+import unittest
+
+class DayCountersTest(unittest.TestCase):
+    def runTest(self):
+        "Testing daycounters"
+
+        calendar    = QuantLib.UnitedStates()
+
+        #
+        # Check that SWIG signature for Business252 calendar allows to pass custom calendar into the class constructor.
+        # Old QuantLib-SWIG versions allow only to create Business252 calendar with default constructor parameter (Brazil calendar),
+        # and generate an exception when trying to pass a custom calendar as a parameter. So we just check here that no exception occurs.
+        #
+        day_counter = QuantLib.Business252(calendar)
+
+if __name__ == '__main__':
+    print('testing QuantLib ' + QuantLib.__version__) 
+    suite = unittest.TestSuite()
+    suite.addTest(DayCountersTest())
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/SWIG/daycounters.i
+++ b/SWIG/daycounters.i
@@ -22,6 +22,7 @@
 #define quantlib_day_counters_i
 
 %include common.i
+%include calendars.i
 %include date.i
 %include types.i
 %include stl.i
@@ -95,7 +96,10 @@ namespace QuantLib {
     };
     class OneDayCounter : public DayCounter {};
     class SimpleDayCounter : public DayCounter {};
-    class Business252 : public DayCounter {};
+    class Business252 : public DayCounter {
+      public:
+        Business252(Calendar c = Brazil());
+    };
 }
 
 


### PR DESCRIPTION
Original Business252() class in C++ has optional 'Calendar c' parameter:

    class Business252 : public DayCounter {
      [...]
      public:
        Business252(Calendar c = Brazil())
        : DayCounter(boost::shared_ptr<DayCounter::Impl>(
                                                 new Business252::Impl(c))) {}
    };

But QuantLib-SWIG signatures only allow to create Business252() class instance with default constructor parameters (Brazil calendar):

    class Business252 : public DayCounter {};

That is quite unfortunate if you want to use 252 business days day counting convention for option pricing, and a calendar other than Brazil.

This patch modifies SWIG signature for Business252() class to allow an optional calendar parameter for class constructor:

    class Business252 : public DayCounter {
      public:
        Business252(Calendar c = Brazil());
    };

A Python unittest is also provided.