### PR TITLE
Pass arbitrary solvers into yield bond functions

### DIFF
--- a/SWIG/bondfunctions.i
+++ b/SWIG/bondfunctions.i
@@ -146,12 +146,12 @@ class BondFunctions {
         }
         static Real accruedAmount(const BondPtr& bond,
                                   Date settlementDate = Date()){
-        
+
             return QuantLib::BondFunctions::accruedAmount(
                 *(boost::dynamic_pointer_cast<Bond>(bond)), 
                 settlementDate);
         }
-        
+
         static Real cleanPrice(
                    const BondPtr& bond,
                    const boost::shared_ptr<YieldTermStructure>& discountCurve,
@@ -245,6 +245,41 @@ class BondFunctions {
                         maxIterations,
                         guess);
         }
+
+        %define DefineYieldFunctionSolver(SolverType)
+        static Rate yield ## SolverType(SolverType solver,
+                                         const BondPtr& bond,
+                                         Real cleanPrice,
+                                         const DayCounter& dayCounter,
+                                         Compounding compounding,
+                                         Frequency frequency,
+                                         Date settlementDate = Date(),
+                                         Real accuracy = 1.0e-10,
+                                         Rate guess = 0.05) {
+            return QuantLib::BondFunctions::yield<SolverType>(
+                        solver,
+                        *(boost::dynamic_pointer_cast<Bond>(bond)),
+                        cleanPrice,
+                        dayCounter,
+                        compounding,
+                        frequency,
+                        settlementDate,
+                        accuracy,
+                        guess);
+        }
+        %enddef
+
+        // See optimizers.i for solver definitions.
+        DefineYieldFunctionSolver(Brent);
+        DefineYieldFunctionSolver(Bisection);
+        DefineYieldFunctionSolver(FalsePosition);
+        DefineYieldFunctionSolver(Ridder);
+        DefineYieldFunctionSolver(Secant);
+        #if defined(SWIGPYTHON)
+        DefineYieldFunctionSolver(Newton);
+        DefineYieldFunctionSolver(NewtonSafe);
+        #endif
+
         static Time duration(const BondPtr& bond,
                              const InterestRate& yield,
                              Duration::Type type = Duration::Modified,
@@ -349,8 +384,8 @@ class BondFunctions {
                               Rate guess = 0.0){
             return QuantLib::BondFunctions::zSpread(
                         *(boost::dynamic_pointer_cast<Bond>(bond)),
-                        cleanPrice, 
-                        discountCurve, 
+                        cleanPrice,
+                        discountCurve,
                         dayCounter,
                         compounding,
                         frequency,
@@ -358,9 +393,9 @@ class BondFunctions {
                         accuracy,
                         maxIterations,
                         guess);
-            
+
         }
-        
+
     }
 };
 

--- a/SWIG/optimizers.i
+++ b/SWIG/optimizers.i
@@ -121,6 +121,7 @@ class SolverName {
 };
 %enddef
 
+// Keep this list in sync with bondfunctions.i yield solvers.
 // Actual solvers
 DeclareSolver(Brent);
 DeclareSolver(Bisection);


### PR DESCRIPTION
This is the SWIG equivalent of my previous pull request in lballabio/QuantLib#152. I use a macro to generate several static `BondFunctions::yield` functions for each solver, i.e. `BondFunctions::yieldBrent`.

Admittedly, I only tested in Java but there is no reason it shouldn't work for any of the other exports.

Please let me know if there are any issues.