### PR TITLE
Update Actual/Actual constructor binding to include Schedule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ Ruby/quantlib_wrap.cpp
 **/bin/*.xml
 **/bin/*.manifest
 
+# CLion
+.idea
+cmake-build-debug
+
 # Artifacts created in multiple directories
 Makefile
 Makefile.in

--- a/SWIG/daycounters.i
+++ b/SWIG/daycounters.i
@@ -92,7 +92,7 @@ namespace QuantLib {
     class ActualActual : public DayCounter {
       public:
         enum Convention { ISMA, Bond, ISDA, Historical, Actual365, AFB, Euro };
-        ActualActual(Convention c = ISDA);
+        ActualActual(Convention c = ISDA, const Schedule& schedule = Schedule());
     };
     class OneDayCounter : public DayCounter {};
     class SimpleDayCounter : public DayCounter {};


### PR DESCRIPTION
As title states. This exposes the recent changes to the actual/actual day counter to the SWIG bindings. Relevant QuantLib PR: https://github.com/lballabio/QuantLib/pull/216