### PR TITLE
Automatically load the Java shared library

### DIFF
--- a/Java/Makefile.am
+++ b/Java/Makefile.am
@@ -5,6 +5,12 @@ BUILT_SOURCES = quantlib_wrap.cpp quantlib_wrap.h
 
 EXAMPLES = Bonds DiscreteHedging EquityOptions FRA UnaryFunctions
 
+SWIGFLAGS =
+
+if JAVA_AUTOLOAD
+SWIGFLAGS += -DJAVA_AUTOLOAD
+endif
+
 if HAVE_JAVA
 if BUILD_JAVA
 
@@ -41,7 +47,7 @@ endif
 
 quantlib_wrap.cpp: ../SWIG/*.i
 	mkdir -p org/quantlib
-	$(SWIG) -java -c++ -outdir org/quantlib \
+	$(SWIG) $(SWIGFLAGS) -java -c++ -outdir org/quantlib \
             -package org.quantlib -o quantlib_wrap.cpp ../SWIG/quantlib.i
 
 dist-hook:

--- a/Java/examples/Bonds.java
+++ b/Java/examples/Bonds.java
@@ -70,13 +70,6 @@ import org.quantlib.YieldTermStructureHandle;
 import org.quantlib.ZeroCouponBond;
 
 public class Bonds {
-    static {
-        try {
-            System.loadLibrary("QuantLibJNI");
-        } catch (RuntimeException e) {
-            e.printStackTrace();
-        }
-    }
     public static void main(String[] args) throws Exception {
 
         // MARKET DATA

--- a/Java/examples/DiscreteHedging.java
+++ b/Java/examples/DiscreteHedging.java
@@ -54,10 +54,6 @@ import org.quantlib.YieldTermStructureHandle;
  **/
 public class DiscreteHedging {
 
-    static {  // Load QuantLib
-        try { System.loadLibrary("QuantLibJNI"); }
-        catch (RuntimeException e) { e.printStackTrace(); }
-    }
 
     public static void main(String[] args) throws Exception {
 

--- a/Java/examples/EquityOptions.java
+++ b/Java/examples/EquityOptions.java
@@ -74,14 +74,6 @@ import org.quantlib.YieldTermStructureHandle;
  */
 public class EquityOptions {
 
-    static {
-        try {
-            System.loadLibrary("QuantLibJNI");
-        } catch (RuntimeException e) {
-            e.printStackTrace();
-        }
-    }
-
     public static void main(String[] args) throws Exception {
         long beginTime = System.currentTimeMillis();
 

--- a/Java/examples/FRA.java
+++ b/Java/examples/FRA.java
@@ -14,13 +14,6 @@ import org.quantlib.Euribor3M;
 
 public class FRA {
 
-    static {
-        try {
-            System.loadLibrary("QuantLibJNI");
-        } catch (RuntimeException e) {
-            e.printStackTrace();
-        }
-    }
 
     public static void main(String[] args) throws Exception {
 

--- a/Java/examples/UnaryFunctions.java
+++ b/Java/examples/UnaryFunctions.java
@@ -5,14 +5,6 @@ import org.quantlib.UnaryFunctionDelegate;
 import org.quantlib.Brent;
 
 public class UnaryFunctions {
-    static {
-        try {
-            System.loadLibrary("QuantLibJNI");
-        } catch (RuntimeException e) {
-            e.printStackTrace();
-        }
-    }
-
 
     public static void main(String[] args) throws java.lang.InterruptedException {
     long beginTime = System.currentTimeMillis();

--- a/SWIG/quantlib.i
+++ b/SWIG/quantlib.i
@@ -58,6 +58,18 @@ const char* __version__;
 %mutable;
 #endif
 
+// Automatically load the shared library for JAVA binding
+%pragma(java) jniclasscode=%{
+  /// Load the JNI library
+  static {
+    try { System.loadLibrary("QuantLibJNI"); }
+    catch (RuntimeException e) {
+      e.printStackTrace();
+      System.exit(1);
+    }
+  }
+%}
+
 #if defined(SWIGGUILE)
 // code for loading shared library
 %scheme%{

--- a/SWIG/quantlib.i
+++ b/SWIG/quantlib.i
@@ -58,6 +58,7 @@ const char* __version__;
 %mutable;
 #endif
 
+#if defined(JAVA_AUTOLOAD)
 // Automatically load the shared library for JAVA binding
 %pragma(java) jniclasscode=%{
   /// Load the JNI library
@@ -65,6 +66,7 @@ const char* __version__;
     System.loadLibrary("QuantLibJNI");
   }
 %}
+#endif
 
 #if defined(SWIGGUILE)
 // code for loading shared library

--- a/SWIG/quantlib.i
+++ b/SWIG/quantlib.i
@@ -62,11 +62,7 @@ const char* __version__;
 %pragma(java) jniclasscode=%{
   /// Load the JNI library
   static {
-    try { System.loadLibrary("QuantLibJNI"); }
-    catch (RuntimeException e) {
-      e.printStackTrace();
-      System.exit(1);
-    }
+    System.loadLibrary("QuantLibJNI");
   }
 %}
 

--- a/configure.ac
+++ b/configure.ac
@@ -130,6 +130,13 @@ AC_ARG_ENABLE([java],
               [build_java=$enableval],
               [build_java=yes])
 AM_CONDITIONAL(BUILD_JAVA, test "$build_java" != "no")
+AC_ARG_ENABLE([java-autoload],
+              AC_HELP_STRING([--disable-java-autoload],
+                             [If disabled, the Java JNI shared library
+			     will not be automatically loaded]),
+              [java_autoload=$enableval],
+              [java_autoload=yes])
+AM_CONDITIONAL(JAVA_AUTOLOAD, test "$java_autoload" != "no")
 
 AC_ARG_WITH([jdk-include],
             AC_HELP_STRING([--with-jdk-include=INCLUDE_PATH],


### PR DESCRIPTION
Move the loading of the JNI shared library to the static initialisation
block of the QuantLibJNI. This should gurantee it is loaded without
having to insert this code in the client code