### PR TITLE
Java callable bond example

### DIFF
--- a/Java/Makefile.am
+++ b/Java/Makefile.am
@@ -3,7 +3,7 @@ CLEANFILES = quantlib_wrap.cpp libQuantLibJNI.@JNILIB_EXTENSION@ QuantLib.jar
 
 BUILT_SOURCES = quantlib_wrap.cpp quantlib_wrap.h
 
-EXAMPLES = Bonds DiscreteHedging EquityOptions FRA UnaryFunctions
+EXAMPLES = Bonds CallableBonds DiscreteHedging EquityOptions FRA UnaryFunctions
 
 if HAVE_JAVA
 if BUILD_JAVA

--- a/Java/examples/Bonds.java
+++ b/Java/examples/Bonds.java
@@ -70,13 +70,6 @@ import org.quantlib.YieldTermStructureHandle;
 import org.quantlib.ZeroCouponBond;
 
 public class Bonds {
-    static {
-        try {
-            System.loadLibrary("QuantLibJNI");
-        } catch (RuntimeException e) {
-            e.printStackTrace();
-        }
-    }
     public static void main(String[] args) throws Exception {
 
         // MARKET DATA

--- a/Java/examples/CallableBonds.java
+++ b/Java/examples/CallableBonds.java
@@ -1,0 +1,246 @@
+/*
+  Copyright (C) 2008 Allen Kuo
+  Copyright (C) 2014 Wondersys Srl
+  Copyright (C) 2017 BN Algorithms Ltd
+
+  This file is part of QuantLib, a free-software/open-source library
+  for financial quantitative analysts and developers - http://quantlib.org/
+  
+  QuantLib is free software: you can redistribute it and/or modify it
+  under the terms of the QuantLib license.  You should have received a
+  copy of the license along with this program; if not, please email
+  <quantlib-dev@lists.sf.net>. The license is also available online at
+  <http://quantlib.org/license.shtml>.
+  
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+package examples;
+
+import org.quantlib.CallableFixedRateBond;
+import org.quantlib.Date;
+import org.quantlib.Period;
+import org.quantlib.Settings;
+import org.quantlib.DayCounter;
+import org.quantlib.ActualActual;
+import org.quantlib.Compounding;
+import org.quantlib.Frequency;
+import org.quantlib.FlatForward;
+import org.quantlib.QuoteHandle;
+import org.quantlib.Quote;
+import org.quantlib.SimpleQuote;
+import org.quantlib.YieldTermStructure;
+import org.quantlib.YieldTermStructureHandle;
+import org.quantlib.InterestRate;
+import org.quantlib.Month;
+import org.quantlib.Date;
+import org.quantlib.CallabilitySchedule;
+import org.quantlib.Schedule;
+import org.quantlib.NullCalendar;
+import org.quantlib.UnitedStates;
+import org.quantlib.Calendar;
+import org.quantlib.Callability;
+import org.quantlib.CallabilityPrice;
+import org.quantlib.TimeUnit;
+import org.quantlib.BusinessDayConvention;
+import org.quantlib.DateGeneration;
+import org.quantlib.ShortRateModel;
+import org.quantlib.HullWhite;
+import org.quantlib.PricingEngine;
+import org.quantlib.TreeCallableFixedRateBondEngine;
+import org.quantlib.DoubleVector;
+
+public class CallableBonds {
+
+    public static YieldTermStructure flatRate(Date today,
+					      Quote forward,
+					      DayCounter dc,
+					      Compounding compounding,
+					      Frequency frequency)
+    {
+	return new FlatForward(today,
+			       new QuoteHandle(forward),
+			       dc,
+			       compounding,
+			       frequency);
+    }
+
+    public static void priceCallable(double sigma,
+				     YieldTermStructureHandle termStructure,
+				     CallableFixedRateBond callableBond,
+				     Frequency frequency,				     
+				     DayCounter bondDayCounter)
+    {
+	long maxIterations = 1000;
+        double accuracy = 1e-8;
+        long gridIntervals = 40;
+        double reversionParameter = .03;
+	
+	ShortRateModel hw0 = 
+	    new HullWhite(termStructure,
+			  reversionParameter,
+			  sigma);
+	
+        PricingEngine engine0 =
+	    new TreeCallableFixedRateBondEngine(hw0,
+						gridIntervals);
+
+	callableBond.setPricingEngine(engine0);
+
+	System.out.printf("sigma/vol (%%) =  %6.2f \n",
+			  100.*sigma);
+	    
+	System.out.printf("QuantLib price/yld (%%)  %10.2f  /  %10.2f \n",
+			  callableBond.cleanPrice(),
+			  100.0 * callableBond.yield(bondDayCounter,
+						     Compounding.Compounded,
+						     frequency,
+						     accuracy,
+						     maxIterations));
+
+    }
+				     
+
+    public static void main(String[] args) throws Exception {
+	System.out.println("Callable Bonds example:");
+
+	Date today = new Date(16, Month.October, 2007);
+        Settings.instance().setEvaluationDate(today);
+
+        double bbCurveRate = 0.055;
+        DayCounter bbDayCounter =
+	    new ActualActual(ActualActual.Convention.Bond);
+
+        InterestRate bbIR =
+	    new InterestRate(bbCurveRate,
+			     bbDayCounter,
+			     Compounding.Compounded,
+			     Frequency.Semiannual);
+
+        YieldTermStructureHandle termStructure =
+	    new YieldTermStructureHandle(flatRate(today,
+						  new SimpleQuote(bbIR.rate()),
+						  bbIR.dayCounter(),
+						  bbIR.compounding(),
+						  bbIR.frequency()));
+
+
+        // set up the call schedule
+        CallabilitySchedule callSchedule =
+	    new CallabilitySchedule();
+        double callPrice = 100.;
+        long numberOfCallDates = 24;
+        Date callDate =
+	    new Date(15, Month.September, 2006);
+
+	Calendar nullCalendar = new NullCalendar();	
+
+        for (long i=0; i< numberOfCallDates; ++i) {
+
+            CallabilityPrice myPrice=
+		new CallabilityPrice(callPrice,
+				      CallabilityPrice.Type.Clean);
+            callSchedule.add(new Callability(myPrice,
+					     Callability.Call,
+					     callDate));
+            callDate = nullCalendar.advance(callDate, 3, TimeUnit.Months);
+        }
+
+        // set up the callable bond
+        Date dated =
+	    new Date(16, Month.September, 2004);
+        Date issue = dated;
+        Date maturity = new Date(15, Month.September, 2012);
+        int settlementDays = 3;  // Bloomberg OAS1 settle is Oct 19, 2007
+        Calendar bondCalendar = new
+	    UnitedStates(UnitedStates.Market.GovernmentBond);
+        double coupon = .0465;
+        Frequency frequency =  Frequency.Quarterly;
+        double redemption = 100.0;
+        double faceAmount = 100.0;
+
+        /* The 30/360 day counter Bloomberg uses for this bond cannot
+           reproduce the US Bond/ISMA (constant) cashflows used in PFC1.
+           Therefore use ActAct(Bond)
+        */
+        DayCounter bondDayCounter =
+	    new ActualActual(ActualActual.Convention.Bond);
+
+        // PFC1 shows no indication dates are being adjusted
+        // for weekends/holidays for vanilla bonds
+        BusinessDayConvention accrualConvention = BusinessDayConvention.Unadjusted;
+        BusinessDayConvention paymentConvention = BusinessDayConvention.Unadjusted;
+
+        Schedule sch =
+	    new Schedule(dated,
+			 maturity,
+			 new Period(frequency),
+			 bondCalendar,
+			 accrualConvention,
+			 accrualConvention,
+			 DateGeneration.Rule.Backward,
+			 false);
+
+	DoubleVector couponsVector = new DoubleVector();
+	couponsVector.add(coupon);
+	
+        CallableFixedRateBond callableBond =
+	    new CallableFixedRateBond(settlementDays,
+				      faceAmount,
+				      sch,
+				      couponsVector,
+				      bondDayCounter,
+				      paymentConvention,
+				      redemption,
+				      issue,
+				      callSchedule);
+
+	
+	priceCallable(1e-20,
+		      termStructure,
+		      callableBond,
+		      frequency,				     
+		      bondDayCounter);
+
+	System.out.printf("Bloomberg price/yld (%%) 96.50 / 5.47 \n");
+
+	priceCallable(0.01,
+		      termStructure,
+		      callableBond,
+		      frequency,				     
+		      bondDayCounter);
+
+	System.out.printf("Bloomberg price/yld (%%) 95.68 / 5.66 \n");	
+
+	priceCallable(0.03,
+		      termStructure,
+		      callableBond,
+		      frequency,				     
+		      bondDayCounter);
+
+	System.out.printf("Bloomberg price/yld (%%) 92.34 / 6.49 \n");	
+
+	priceCallable(0.06,
+		      termStructure,
+		      callableBond,
+		      frequency,				     
+		      bondDayCounter);
+
+	System.out.printf("Bloomberg price/yld (%%) 87.16 / 7.83 \n");
+	
+	priceCallable(0.12,
+		      termStructure,
+		      callableBond,
+		      frequency,				     
+		      bondDayCounter);
+
+	System.out.printf("Bloomberg price/yld (%%) 77.31 / 10.65 \n");		
+	
+
+        System.out.println("Done");	
+    }
+
+}
+

--- a/Java/examples/DiscreteHedging.java
+++ b/Java/examples/DiscreteHedging.java
@@ -54,10 +54,6 @@ import org.quantlib.YieldTermStructureHandle;
  **/
 public class DiscreteHedging {
 
-    static {  // Load QuantLib
-        try { System.loadLibrary("QuantLibJNI"); }
-        catch (RuntimeException e) { e.printStackTrace(); }
-    }
 
     public static void main(String[] args) throws Exception {
 

--- a/Java/examples/EquityOptions.java
+++ b/Java/examples/EquityOptions.java
@@ -74,14 +74,6 @@ import org.quantlib.YieldTermStructureHandle;
  */
 public class EquityOptions {
 
-    static {
-        try {
-            System.loadLibrary("QuantLibJNI");
-        } catch (RuntimeException e) {
-            e.printStackTrace();
-        }
-    }
-
     public static void main(String[] args) throws Exception {
         long beginTime = System.currentTimeMillis();
 

--- a/Java/examples/FRA.java
+++ b/Java/examples/FRA.java
@@ -14,13 +14,6 @@ import org.quantlib.Euribor3M;
 
 public class FRA {
 
-    static {
-        try {
-            System.loadLibrary("QuantLibJNI");
-        } catch (RuntimeException e) {
-            e.printStackTrace();
-        }
-    }
 
     public static void main(String[] args) throws Exception {
 

--- a/Java/examples/UnaryFunctions.java
+++ b/Java/examples/UnaryFunctions.java
@@ -5,14 +5,6 @@ import org.quantlib.UnaryFunctionDelegate;
 import org.quantlib.Brent;
 
 public class UnaryFunctions {
-    static {
-        try {
-            System.loadLibrary("QuantLibJNI");
-        } catch (RuntimeException e) {
-            e.printStackTrace();
-        }
-    }
-
 
     public static void main(String[] args) throws java.lang.InterruptedException {
     long beginTime = System.currentTimeMillis();

--- a/SWIG/quantlib.i
+++ b/SWIG/quantlib.i
@@ -58,6 +58,18 @@ const char* __version__;
 %mutable;
 #endif
 
+// Automatically load the shared library for JAVA binding
+%pragma(java) jniclasscode=%{
+  /// Load the JNI library
+  static {
+    try { System.loadLibrary("QuantLibJNI"); }
+    catch (RuntimeException e) {
+      e.printStackTrace();
+      System.exit(1);
+    }
+  }
+%}
+
 #if defined(SWIGGUILE)
 // code for loading shared library
 %scheme%{


### PR DESCRIPTION
Adds the Java equivalent of the CallableBonds example. Relies on the autloading JNI patch (#56)