### PR TITLE
Adding additional build instructions to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,22 @@ On Linux/Unix, you can run:
 
 to build, test and install al modules. 
 
-If you want to use your *local* QuantLib version (e.g. if you want to test
-your local dev or have no rights `make install` on your system) you need to 
-extend your compiler flags to include the relevant path:
+If you want to use your *local* QuantLib dev version without installing it (i.e.
+**no** `make install` after your `make` - e.g. if you want to test your 
+local dev or have no rights to `make install` on your system) you can do the 
+following:
 
-    export CPPFLAGS="-I/path/to/your/ql/include/dir -L/path/to/your/ql/lib/dir":$CPPFLAGS
-
-and update your PATH environment to include the quantlib-config like:
-
-    export PATH=/path/to/your/ql/dir:$PATH
+- configure QuantLib to use your dev include and lib path like
+    `$./configure --prefix=/path/to/your/qldir/ 
+    --libdir=/path/to/your/qldir/ql/.libs 
+    --includedir=/path/to/your/qldir/`
+    since you are not installing, this will only provide the necessary path
+    information for the quantlib-config file.
+- add *quantlib-config* to your path enviroment by extending it like
+    `$ export PATH:/path/to/your/qldir:$PATH`
+- add path to your QuantLib share object lib (.so extension) to your shared 
+object search path (temporarly - this should not be your production setting).
+    `$ export LD_LIBRARY_PATH=/path/to/your/qldir/ql/.libs`
 
 If you're only interested in a
 specific language, you can tell make to only work in its subdirectory,

--- a/README.md
+++ b/README.md
@@ -26,7 +26,19 @@ On Linux/Unix, you can run:
     make check
     sudo make install
 
-to build, test and install al modules. If you're only interested in a
+to build, test and install al modules. 
+
+If you want to use your *local* QuantLib version (e.g. if you want to test
+your local dev or have no rights `make install` on your system) you need to 
+extend your compiler flags to include the relevant path:
+
+    export CPPFLAGS="-I/path/to/your/ql/include/dir -L/path/to/your/ql/lib/dir":$CPPFLAGS
+
+and update your PATH environment to include the quantlib-config like:
+
+    export PATH=/path/to/your/ql/dir:$PATH
+
+If you're only interested in a
 specific language, you can tell make to only work in its subdirectory,
 as in:
 

--- a/README.md
+++ b/README.md
@@ -31,19 +31,20 @@ to build, test and install al modules.
 If you want to use your *local* QuantLib dev version without installing it (i.e.
 **no** `make install` after your `make` - e.g. if you want to test your 
 local dev or have no rights to `make install` on your system) you can do the 
-following:
+following (this needs to be done before `configure`):
 
-- configure QuantLib to use your dev include and lib path like
-    `$./configure --prefix=/path/to/your/qldir/ 
-    --libdir=/path/to/your/qldir/ql/.libs 
-    --includedir=/path/to/your/qldir/`
-    since you are not installing, this will only provide the necessary path
-    information for the quantlib-config file.
+- configure your QuantLib build to use your dev include and lib path like
+`$./configure --prefix=/path/to/your/qldir/ 
+--libdir=/path/to/your/qldir/ql/.libs 
+--includedir=/path/to/your/qldir/`
+since you are not installing, this will only provide the necessary path
+information for the quantlib-config file.
 - add *quantlib-config* to your path enviroment by extending it like
-    `$ export PATH:/path/to/your/qldir:$PATH`
-- add path to your QuantLib share object lib (.so extension) to your shared 
-object search path (temporarly - this should not be your production setting).
-    `$ export LD_LIBRARY_PATH=/path/to/your/qldir/ql/.libs`
+`$ export PATH:/path/to/your/qldir:$PATH`
+- add search path to your swigged QuantLib shared object lib (.so extension),
+so that it can find your dev libQuantLib.so.
+`$ export CPPFLAGS=-Wl,-rpath,/path/to/your/qldir/ql/.libs`
+This flag will include the absolute path to your dev lib.
 
 If you're only interested in a
 specific language, you can tell make to only work in its subdirectory,

--- a/Readme.txt
+++ b/Readme.txt
@@ -28,15 +28,22 @@ On Linux/Unix, you can run:
 
 to build, test and install al modules. 
 
-If you want to use your *local* QuantLib version (e.g. if you want to test
-your local dev or have no rights `make install` on your system) you need to 
-extend your compiler flags to include the relevant path:
+If you want to use your *local* QuantLib dev version without installing it (i.e.
+**no** `make install` after your `make` - e.g. if you want to test your 
+local dev or have no rights to `make install` on your system) you can do the 
+following:
 
-    export CPPFLAGS="-I/path/to/your/ql/include/dir -L/path/to/your/ql/lib/dir":$CPPFLAGS
-
-and update your PATH environment to include the quantlib-config like:
-
-    export PATH=/path/to/your/ql/dir:$PATH
+- configure QuantLib to use your dev include and lib path like
+    `$./configure --prefix=/path/to/your/qldir/ 
+    --libdir=/path/to/your/qldir/ql/.libs 
+    --includedir=/path/to/your/qldir/`
+    since you are not installing, this will only provide the necessary path
+    information for the quantlib-config file.
+- add *quantlib-config* to your path enviroment by extending it like
+    `$ export PATH:/path/to/your/qldir:$PATH`
+- add path to your QuantLib share object lib (.so extension) to your shared 
+object search path (temporarly - this should not be your production setting).
+    `$ export LD_LIBRARY_PATH=/path/to/your/qldir/ql/.libs`
 
 If you're only interested in a
 specific language, you can tell make to only work in its subdirectory,

--- a/Readme.txt
+++ b/Readme.txt
@@ -26,7 +26,19 @@ On Linux/Unix, you can run:
     make check
     sudo make install
 
-to build, test and install al modules. If you're only interested in a
+to build, test and install al modules. 
+
+If you want to use your *local* QuantLib version (e.g. if you want to test
+your local dev or have no rights `make install` on your system) you need to 
+extend your compiler flags to include the relevant path:
+
+    export CPPFLAGS="-I/path/to/your/ql/include/dir -L/path/to/your/ql/lib/dir":$CPPFLAGS
+
+and update your PATH environment to include the quantlib-config like:
+
+    export PATH=/path/to/your/ql/dir:$PATH
+
+If you're only interested in a
 specific language, you can tell make to only work in its subdirectory,
 as in:
 

--- a/Readme.txt
+++ b/Readme.txt
@@ -31,19 +31,20 @@ to build, test and install al modules.
 If you want to use your *local* QuantLib dev version without installing it (i.e.
 **no** `make install` after your `make` - e.g. if you want to test your 
 local dev or have no rights to `make install` on your system) you can do the 
-following:
+following (this needs to be done before `configure`):
 
-- configure QuantLib to use your dev include and lib path like
-    `$./configure --prefix=/path/to/your/qldir/ 
-    --libdir=/path/to/your/qldir/ql/.libs 
-    --includedir=/path/to/your/qldir/`
-    since you are not installing, this will only provide the necessary path
-    information for the quantlib-config file.
+- configure your QuantLib build to use your dev include and lib path like
+`$./configure --prefix=/path/to/your/qldir/ 
+--libdir=/path/to/your/qldir/ql/.libs 
+--includedir=/path/to/your/qldir/`
+since you are not installing, this will only provide the necessary path
+information for the quantlib-config file.
 - add *quantlib-config* to your path enviroment by extending it like
-    `$ export PATH:/path/to/your/qldir:$PATH`
-- add path to your QuantLib share object lib (.so extension) to your shared 
-object search path (temporarly - this should not be your production setting).
-    `$ export LD_LIBRARY_PATH=/path/to/your/qldir/ql/.libs`
+`$ export PATH:/path/to/your/qldir:$PATH`
+- add search path to your swigged QuantLib shared object lib (.so extension),
+so that it can find your dev libQuantLib.so.
+`$ export CPPFLAGS=-Wl,-rpath,/path/to/your/qldir/ql/.libs`
+This flag will include the absolute path to your dev lib.
 
 If you're only interested in a
 specific language, you can tell make to only work in its subdirectory,


### PR DESCRIPTION
As I don't use a local ql compile in connection with the swig interfaces on a regular basis, I keep forgetting how to setup the necessary variables. This reminder in the Readme should hopefully do this job for me.