### PR TITLE
Topic swig version check

### DIFF
--- a/Python/setup.py
+++ b/Python/setup.py
@@ -68,6 +68,12 @@ class my_wrap(Command):
     def finalize_options(self): pass
     def run(self):
         print('Generating Python bindings for QuantLib...')
+        swig_version = os.popen("swig -version").read().split()[2]
+        major_swig_version = swig_version[0]
+        if major_swig_version < '3':
+           print('Warning: You have SWIG {} installed, but at least SWIG 3.0.1'
+                 ' is recommended. \nSome features may not work.'
+                 .format(swig_version))
         swig_dir = os.path.join("..","SWIG")
         if sys.version_info.major >= 3:
             os.system('swig -python -py3 -c++ -modern ' +

--- a/Python/setup.py.in
+++ b/Python/setup.py.in
@@ -68,6 +68,12 @@ class my_wrap(Command):
     def finalize_options(self): pass
     def run(self):
         print('Generating Python bindings for QuantLib...')
+        swig_version = os.popen("swig -version").read().split()[2]
+        major_swig_version = swig_version[0]
+        if major_swig_version < '3':
+           print('Warning: You have SWIG {} installed, but at least SWIG 3.0.1'
+                 ' is recommended. \nSome features may not work.'
+                 .format(swig_version))
         swig_dir = os.path.join("..","SWIG")
         if sys.version_info.major >= 3:
             os.system('swig -python -py3 -c++ -modern ' +

--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,14 @@ AC_MSG_RESULT([$ql_version])
 
 # check for tools
 AC_PATH_PROG([SWIG], [swig])
+if test "x$SWIG" != x; then
+	SWIG_VERSION=`swig -version 2>&1|grep Version|cut -d" " -f3`
+	SWIG_MAJOR=${SWIG_VERSION%%.*}
+	if test ${SWIG_MAJOR} = "2"; then
+		AC_MSG_WARN([You have SWIG $SWIG_VERSION installed, but at least SWIG 3.0.1 is recommended. Some features may not work. ])
+		#SWIG=
+	fi
+fi
 
 AC_PATH_PROG([PYTHON], [python])
 AM_CONDITIONAL(HAVE_PYTHON, test "x${PYTHON}" != "x")


### PR DESCRIPTION
This pull request resolves #44 
Swig major version is checked, if below 3, warning message is displayed. Please correct the version numbers to the ones you consider appropriate.
Both scenarios are covered, either through:
```
./configure
make
make check
sudo make install
```
or 
```
cd Python
python setup.py wrap
python setup.py build
python setup.py test
python setup.py install
```
I am not sure about line 46 in configure.ac, I saw something similar in other scripts, but finally decided to comment out and works good on my machine.