### PR TITLE
Avoid using deprecated classes.

### DIFF
--- a/SWIG/common.i
+++ b/SWIG/common.i
@@ -147,4 +147,14 @@ a
 %enddef
 
 
+%define deprecate_feature(OldName, NewName)
+%pythoncode %{
+def OldName(*args, **kwargs):
+    from warnings import warn
+    warn('%s is deprecated; use %s' % (OldName.__name__, NewName.__name__))
+    return NewName(*args, **kwargs)
+%}
+%enddef
+
+
 #endif

--- a/SWIG/distributions.i
+++ b/SWIG/distributions.i
@@ -32,10 +32,10 @@ using QuantLib::BinomialDistribution;
 using QuantLib::CumulativeBinomialDistribution;
 using QuantLib::BivariateCumulativeNormalDistributionDr78;
 using QuantLib::BivariateCumulativeNormalDistributionWe04DP;
-using QuantLib::ChiSquareDistribution;
-using QuantLib::NonCentralChiSquareDistribution;
+using QuantLib::CumulativeChiSquareDistribution;
+using QuantLib::NonCentralCumulativeChiSquareDistribution;
 using QuantLib::InverseNonCentralChiSquareDistribution;
-using QuantLib::GammaDistribution;
+using QuantLib::CumulativeGammaDistribution;
 using QuantLib::GammaFunction;
 using QuantLib::PoissonDistribution;
 using QuantLib::CumulativePoissonDistribution;
@@ -129,21 +129,21 @@ class BivariateCumulativeNormalDistributionWe04DP {
     Real operator()(Real a, Real b);
 };
 
-class ChiSquareDistribution {
+class CumulativeChiSquareDistribution {
     #if defined(SWIGCSHARP) || defined(SWIGPERL)
     %rename(call) operator();
     #endif
   public:
-    ChiSquareDistribution(Real df);
+    CumulativeChiSquareDistribution(Real df);
     Real operator()(Real x);
 };
 
-class NonCentralChiSquareDistribution {
+class NonCentralCumulativeChiSquareDistribution {
     #if defined(SWIGCSHARP) || defined(SWIGPERL)
     %rename(call) operator();
     #endif
   public:
-    NonCentralChiSquareDistribution(Real df, Real ncp);
+    NonCentralCumulativeChiSquareDistribution(Real df, Real ncp);
     Real operator()(Real x);
 };
 
@@ -158,12 +158,12 @@ class InverseNonCentralChiSquareDistribution {
     Real operator()(Real x);
 };
 
-class GammaDistribution {
+class CumulativeGammaDistribution {
     #if defined(SWIGCSHARP) || defined(SWIGPERL)
     %rename(call) operator();
     #endif
   public:
-    GammaDistribution(Real a);
+    CumulativeGammaDistribution(Real a);
     Real operator()(Real x);
 };
 

--- a/SWIG/distributions.i
+++ b/SWIG/distributions.i
@@ -34,7 +34,7 @@ using QuantLib::BivariateCumulativeNormalDistributionDr78;
 using QuantLib::BivariateCumulativeNormalDistributionWe04DP;
 using QuantLib::CumulativeChiSquareDistribution;
 using QuantLib::NonCentralCumulativeChiSquareDistribution;
-using QuantLib::InverseNonCentralChiSquareDistribution;
+using QuantLib::InverseNonCentralCumulativeChiSquareDistribution;
 using QuantLib::CumulativeGammaDistribution;
 using QuantLib::GammaFunction;
 using QuantLib::PoissonDistribution;
@@ -147,14 +147,14 @@ class NonCentralCumulativeChiSquareDistribution {
     Real operator()(Real x);
 };
 
-class InverseNonCentralChiSquareDistribution {
+class InverseNonCentralCumulativeChiSquareDistribution {
     #if defined(SWIGCSHARP) || defined(SWIGPERL)
     %rename(call) operator();
     #endif
   public:
-    InverseNonCentralChiSquareDistribution(Real df, Real ncp,
-                                           Size maxEvaluations = 10,
-                                           Real accuracy = 1e-8);
+    InverseNonCentralCumulativeChiSquareDistribution(Real df, Real ncp,
+                                                     Size maxEvaluations = 10,
+                                                     Real accuracy = 1e-8);
     Real operator()(Real x);
 };
 

--- a/SWIG/distributions.i
+++ b/SWIG/distributions.i
@@ -22,6 +22,8 @@
 #ifndef quantlib_distributions_i
 #define quantlib_distributions_i
 
+%include common.i
+
 %{
 using QuantLib::NormalDistribution;
 using QuantLib::CumulativeNormalDistribution;
@@ -138,6 +140,9 @@ class CumulativeChiSquareDistribution {
     Real operator()(Real x);
 };
 
+deprecate_feature(ChiSquareDistribution,
+                  CumulativeChiSquareDistribution);
+
 class NonCentralCumulativeChiSquareDistribution {
     #if defined(SWIGCSHARP) || defined(SWIGPERL)
     %rename(call) operator();
@@ -146,6 +151,9 @@ class NonCentralCumulativeChiSquareDistribution {
     NonCentralCumulativeChiSquareDistribution(Real df, Real ncp);
     Real operator()(Real x);
 };
+
+deprecate_feature(NonCentralChiSquareDistribution,
+                  NonCentralCumulativeChiSquareDistribution);
 
 class InverseNonCentralCumulativeChiSquareDistribution {
     #if defined(SWIGCSHARP) || defined(SWIGPERL)
@@ -158,6 +166,9 @@ class InverseNonCentralCumulativeChiSquareDistribution {
     Real operator()(Real x);
 };
 
+deprecate_feature(InverseNonCentralChiSquareDistribution,
+                  InverseNonCentralCumulativeChiSquareDistribution);
+
 class CumulativeGammaDistribution {
     #if defined(SWIGCSHARP) || defined(SWIGPERL)
     %rename(call) operator();
@@ -166,6 +177,9 @@ class CumulativeGammaDistribution {
     CumulativeGammaDistribution(Real a);
     Real operator()(Real x);
 };
+
+deprecate_feature(GammaDistribution,
+                  CumulativeGammaDistribution);
 
 class GammaFunction {
     #if defined(SWIGCSHARP) || defined(SWIGPERL)


### PR DESCRIPTION
It's not clear how not to break old code.  In Python, we can add an alias; but we'll have the same problem when we remove it.  I don't know about the other languages.