### PR TITLE
Hide imported datetime module.

### DIFF
--- a/SWIG/date.i
+++ b/SWIG/date.i
@@ -285,7 +285,7 @@ using QuantLib::DateParser;
 
 #if defined(SWIGPYTHON)
 %pythoncode %{
-import datetime
+import datetime as _datetime
 %}
 #endif
 
@@ -590,7 +590,7 @@ class Date {
     #if defined(SWIGPYTHON)
     %pythoncode %{
     def to_date(self):
-        return datetime.date(self.year(), self.month(), self.dayOfMonth())
+        return _datetime.date(self.year(), self.month(), self.dayOfMonth())
 
     @staticmethod
     def from_date(date):


### PR DESCRIPTION
This avoids that importing all names from QuantLib overwrites a previously imported name.

Fixes https://github.com/lballabio/QuantLib/issues/394.