### PR TITLE
wrap MakeSchedule helper class

### DIFF
--- a/SWIG/scheduler.i
+++ b/SWIG/scheduler.i
@@ -29,6 +29,7 @@
 %{
 using QuantLib::Schedule;
 using QuantLib::DateGeneration;
+using QuantLib::MakeSchedule;
 %}
 
 struct DateGeneration {
@@ -121,5 +122,35 @@ class Schedule {
     }
 };
 
+/*! This class provides a more comfortable interface to the
+    argument list of Schedule's constructor.
+*/
+class MakeSchedule {
+  public:
+    MakeSchedule();
+#if defined(SWIGPYTHON)
+    // 'from' can't be overridden in python
+    %rename("fromDate") from;
+#endif
+    MakeSchedule& from(const Date& effectiveDate);
+    MakeSchedule& to(const Date& terminationDate);
+    MakeSchedule& withTenor(const Period&);
+    MakeSchedule& withFrequency(Frequency);
+    MakeSchedule& withCalendar(const Calendar&);
+    MakeSchedule& withConvention(BusinessDayConvention);
+    MakeSchedule& withTerminationDateConvention(BusinessDayConvention);
+    MakeSchedule& withRule(DateGeneration::Rule);
+    MakeSchedule& forwards();
+    MakeSchedule& backwards();
+    MakeSchedule& endOfMonth(bool flag=true);
+    MakeSchedule& withFirstDate(const Date& d);
+    MakeSchedule& withNextToLastDate(const Date& d);
+
+    %extend{
+      Schedule schedule(){
+        return (Schedule)(* $self);
+      }
+    }
+};
 
 #endif

--- a/SWIG/scheduler.i
+++ b/SWIG/scheduler.i
@@ -122,6 +122,10 @@ class Schedule {
     }
 };
 
+#if defined(SWIGPYTHON)
+%rename (MakeScheduleObject) MakeSchedule;
+#endif
+
 /*! This class provides a more comfortable interface to the
     argument list of Schedule's constructor.
 */
@@ -152,5 +156,42 @@ class MakeSchedule {
       }
     }
 };
+
+#if defined(SWIGPYTHON)
+%pythoncode{
+def MakeSchedule(effectiveDate=None,terminationDate=None,tenor=None,
+    frequency=None,calendar=None,convention=None,terminalDateConvention=None,
+    rule=None,forwards=False,backwards=False,
+    endOfMonth=None,firstDate=None,nextToLastDate=None):
+    ms = MakeScheduleObject()
+    if effectiveDate is not None:
+        ms.fromDate(effectiveDate)
+    if terminationDate is not None:
+        ms.to(terminationDate)
+    if tenor is not None:
+        ms.withTenor(tenor)
+    if frequency is not None:
+        ms.withFrequency(frequency)
+    if calendar is not None:
+        ms.withCalendar(calendar)
+    if convention is not None:
+        ms.withConvention(convention)
+    if terminalDateConvention is not None:
+        ms.withTerminationDateConvention(terminalDateConvention)
+    if rule is not None:
+        ms.withRule(rule)
+    if forwards:
+        ms.forwards()
+    if backwards:
+        ms.backwards()
+    if endOfMonth is not None:
+        ms.endOfMonth(endOfMonth)
+    if firstDate is not None:
+        ms.withFirstDate(firstDate)
+    if nextToLastDate is not None:
+        ms.withNextToLastDate(nextToLastDate)
+    return ms.schedule()
+}
+#endif
 
 #endif


### PR DESCRIPTION
python sample code
```python
from QuantLib import *

issue = Date(15, January,2018);
maturity = issue + Period(5, Years)
print(issue, maturity)
period = Period("2W")
calendar = Canada()
schedule = MakeSchedule().fromDate(issue).to(maturity) \
    .withTenor(period).forwards().withCalendar(calendar) \
    .withConvention(Following) \
    .withTerminationDateConvention(Following) \
    .schedule()

for i in range(len(schedule)):
    print (i, ":", schedule[i])
```

java sample code

```java
import org.quantlib.*;

public class MSTest{
  public static void main(String[] args){
    Date issue = new Date(31, Month.May, 2015);
    Date maturity = new Date(31, Month.May, 2025);
    Calendar calendar = new UnitedStates(UnitedStates.Market.GovernmentBond);
    Frequency frequency = Frequency.Semiannual;
    BusinessDayConvention roll = BusinessDayConvention.ModifiedFollowing;
    Schedule schedule = (new MakeSchedule()).from(issue)
      .to(maturity).backwards().withFrequency(frequency)
      .endOfMonth(true).withConvention(roll)
      .withTerminationDateConvention(roll)
      .withCalendar(calendar).schedule();
    for (int i=0; i<schedule.size(); i++){
      Date d = schedule.date(i);
      System.out.printf("%d, %s\n",i,d);
    }
  }
}
```