### PR TITLE
Expose next and previouscashflowdate in SWIG interface.

### DIFF
--- a/SWIG/cashflows.i
+++ b/SWIG/cashflows.i
@@ -711,6 +711,15 @@ class CashFlows {
   public:
     static Date startDate(const Leg &);
     static Date maturityDate(const Leg &);
+    static Date
+        previousCashFlowDate(const Leg& leg,
+                             bool includeSettlementDateFlows,
+                             Date settlementDate = Date());
+    static Date
+        nextCashFlowDate(const Leg& leg,
+                         bool includeSettlementDateFlows,
+                         Date settlementDate = Date());
+
     %extend {
         static Real npv(
                    const Leg& leg,


### PR DESCRIPTION
Closes #100 - Exposing `CashFlows::previousCashFlowDate` and `CashFlows::nextCashFlowDate` in the SWIG cashflows interface

Signed-off-by: Weston Steimel <weston.steimel@gmail.com>