### PR TITLE
Added protection start date for CDS

### DIFF
--- a/SWIG/creditdefaultswap.i
+++ b/SWIG/creditdefaultswap.i
@@ -44,11 +44,13 @@ class CreditDefaultSwapPtr : public boost::shared_ptr<Instrument> {
                              BusinessDayConvention paymentConvention,
                              const DayCounter& dayCounter,
                              bool settlesAccrual = true,
-                             bool paysAtDefaultTime = true) {
+                             bool paysAtDefaultTime = true,
+			     const Date& protectionStart = Date()) {
             return new CreditDefaultSwapPtr(
                     new CreditDefaultSwap(side, notional, spread, schedule,
                                           paymentConvention, dayCounter,
-                                          settlesAccrual, paysAtDefaultTime));
+                                          settlesAccrual, paysAtDefaultTime,
+					  protectionStart));
         }
         CreditDefaultSwapPtr(Protection::Side side,
                              Real notional,
@@ -58,12 +60,14 @@ class CreditDefaultSwapPtr : public boost::shared_ptr<Instrument> {
                              BusinessDayConvention paymentConvention,
                              const DayCounter& dayCounter,
                              bool settlesAccrual = true,
-                             bool paysAtDefaultTime = true) {
+                             bool paysAtDefaultTime = true,
+			     const Date& protectionStart = Date()) {
             return new CreditDefaultSwapPtr(
                     new CreditDefaultSwap(side, notional, upfront, spread,
                                           schedule, paymentConvention,
                                           dayCounter, settlesAccrual,
-                                          paysAtDefaultTime));
+                                          paysAtDefaultTime,
+					  protectionStart));
         }
         Protection::Side side() const {
             return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)


### PR DESCRIPTION
As discussed in https://sourceforge.net/p/quantlib/mailman/message/36392757/ , I added the protection start date for Credit Default Swaps analogue to the C++ part of QuantLib. I compared some sample CDS between C++ and the Python version of the above code and the numbers match perfectly.