### PR TITLE
Open Source Risk Engine integration - fx vol surface

### DIFF
--- a/Python/examples/fxoptionvolsurfaceplot.py
+++ b/Python/examples/fxoptionvolsurfaceplot.py
@@ -22,6 +22,7 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 import matplotlib
 matplotlib.style.use('ggplot')
+
 ref_date = ql.Date(3, 9,  2018)
 dates = [ql.Date(3, 10, 2018),
          ql.Date(3, 12, 2018),

--- a/Python/examples/fxoptionvolsurfaceplot.py
+++ b/Python/examples/fxoptionvolsurfaceplot.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""
+ Copyright (C) 2018 Wojciech Ślusarski
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+"""
+
+import QuantLib as ql
+import numpy as np
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
+import matplotlib
+matplotlib.style.use('ggplot')
+ref_date = ql.Date(3, 9,  2018)
+dates = [ql.Date(3, 10, 2018),
+         ql.Date(3, 12, 2018),
+         ql.Date(3, 2, 2019)]
+t_nodes = [ql.Actual365Fixed().dayCount(ref_date, t) / 365
+           for t in dates]
+atm_vols = [0.05 * t_nodes[0] ** 0.5,
+            0.06 * t_nodes[1] ** 0.5,
+            0.1  * t_nodes[2] ** 0.5]
+rr25d = [0.02, 0.015, 0.01]
+bf25d = [0.02, 0.01, 0.005]
+day_counter = ql.Actual365Fixed()
+cal = ql.JointCalendar(ql.TARGET(), ql.Poland())
+
+fx = ql.QuoteHandle(ql.SimpleQuote(4.0))
+fore = ql.RelinkableYieldTermStructureHandle(ql.FlatForward(ref_date,
+                                                        0.005,
+                                                        day_counter))
+dom = ql.RelinkableYieldTermStructureHandle(ql.FlatForward(ref_date,
+                                                        0.005,
+                                                        day_counter))
+vol_surface = ql.FxBlackVannaVolgaVolatilitySurface(ref_date, dates,
+                                                    atm_vols, rr25d, bf25d,
+                                                    day_counter, cal,
+                                                    fx, dom, fore)
+vol_surface.enableExtrapolation()
+
+expiries = np.arange(20, 210) / 365
+strikes = np.linspace(3.7, 4.4, 100)
+
+
+interpolated_vols = np.array([vol_surface.blackVol(t, k)
+                              for t in expiries
+                                for k in strikes]).reshape(len(expiries),
+                                                            len(strikes)).T
+expiries, strikes = np.meshgrid(expiries, strikes)
+
+fig = plt.figure()
+ax = fig.gca(projection='3d')
+
+surface = ax.plot_surface(expiries, strikes, interpolated_vols,
+                          cmap='viridis')
+ax.set_xlabel("Expiry")
+ax.set_ylabel("Strike")
+ax.set_zlabel("Volatility")
+
+plt.show()
+
+

--- a/Python/examples/fxoptionvolsurfaceplot.py
+++ b/Python/examples/fxoptionvolsurfaceplot.py
@@ -23,15 +23,17 @@ from mpl_toolkits.mplot3d import Axes3D
 import matplotlib
 matplotlib.style.use('ggplot')
 
+"""
+This is a simple example how to build and interpolate 
+"""
+
 ref_date = ql.Date(3, 9,  2018)
 dates = [ql.Date(3, 10, 2018),
          ql.Date(3, 12, 2018),
          ql.Date(3, 2, 2019)]
 t_nodes = [ql.Actual365Fixed().dayCount(ref_date, t) / 365
            for t in dates]
-atm_vols = [0.05 * t_nodes[0] ** 0.5,
-            0.06 * t_nodes[1] ** 0.5,
-            0.1  * t_nodes[2] ** 0.5]
+atm_vols = [0.05, 0.06, 0.1]
 rr25d = [0.02, 0.015, 0.01]
 bf25d = [0.02, 0.01, 0.005]
 day_counter = ql.Actual365Fixed()

--- a/Python/test/QuantLibTestSuite.py
+++ b/Python/test/QuantLibTestSuite.py
@@ -34,6 +34,7 @@ from capfloor import CapFloorTest
 from blackformula import BlackFormulaTest
 from blackformula import BlackDeltaCalculatorTest
 from iborindex import IborIndexTest
+from fxvolsmile import FxVolSmileTest
 
 
 def test():
@@ -58,6 +59,7 @@ def test():
     suite.addTest(unittest.makeSuite(BlackFormulaTest, 'test'))
     suite.addTest(unittest.makeSuite(BlackDeltaCalculatorTest, 'test'))
     suite.addTest(unittest.makeSuite(IborIndexTest, 'test'))
+    suite.addTest(unittest.makeSuite(FxVolSmileTest, 'test'))
 
     result = unittest.TextTestRunner(verbosity=2).run(suite)
 

--- a/Python/test/fxvolsmile.py
+++ b/Python/test/fxvolsmile.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""
+ Copyright (C) 2018 Wojciech Ślusarski
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+"""
+import unittest
+import QuantLib as ql
+
+
+class FxVolSmileTest(unittest.TestCase):
+
+    def setUp(self):
+        # Castagna, Antonio and Mercurio, Fabio, Consistent Pricing of FX Options.
+        # Available at SSRN: https://ssrn.com/abstract=873788
+        # or http://dx.doi.org/10.2139/ssrn.873788
+        self.today = ql.Date(1, 7, 2005)
+        ql.Settings.instance().evaluationDate = self.today
+        self.t = 94 / 365.0
+        self.spot = ql.QuoteHandle(ql.SimpleQuote(1.205))
+        self.expiry = [ql.Date(3, 10, 2005),
+                       ql.Date(3, 7, 2006)]
+        """
+        Quotes of the 25-delta Risk Reversal and Vega Weighted ButterFly are 
+        missing in the paper. Values typed here were selected to approximately 
+        match results in Table 2.
+        This test was designed to automate check if the C++ implementation 
+        exposed to Python works.
+        For comprehensive tests check the unittest fxvolsmile.cpp in QuantLib, 
+        which was developed by Quaternion Risk Management Ltd.
+        In order to understand how FxBlackVannaVolgaVolatilitySurface works, 
+        have a look into examples/fxoptionvolsurfaceplot.py
+        """
+        self.sigma_atm = [0.0905, 0.0940]
+        self.sigma_rr = [-0.005, -0.0022]
+        self.sigma_vwb = [0.0013, 0.0014]
+
+        self.df_usd = [0.9902752, 0.9585801]
+        self.df_eur = [0.9945049, 0.9785056]
+        self.day_count = ql.Actual365Fixed()
+        self.crv_usd = ql.DiscountCurve([self.today] + self.expiry,
+                                        [1.0] + self.df_usd,
+                                        self.day_count)
+        self.crv_eur = ql.DiscountCurve([self.today] + self.expiry,
+                                        [1.0] + self.df_eur, self.day_count)
+        self.domcrv_handle = ql.RelinkableYieldTermStructureHandle()
+        self.forcrv_handle = ql.RelinkableYieldTermStructureHandle()
+        """
+        The paper does not mention calendar, TARGET does not disturb in 
+        calculations required by this test. Proper calendar handling for 
+        fx options is a separate issue, that should be carefully implemented 
+        (e.g. see implementation for FxSwapRateHelper class).
+        """
+        self.calendar = ql.TARGET()
+
+
+    def test_recover_standard_delta_strikes_volatility(self):
+        """Testing fx volatility at volatility surface nodes"""
+        self.domcrv_handle.linkTo(self.crv_usd)
+        self.forcrv_handle.linkTo(self.crv_eur)
+        vol_surface = ql.FxBlackVannaVolgaVolatilitySurface(self.today,
+                                                            self.expiry,
+                                                            self.sigma_atm,
+                                                            self.sigma_rr,
+                                                            self.sigma_vwb,
+                                                            self.day_count,
+                                                            self.calendar,
+                                                            self.spot,
+                                                            self.domcrv_handle,
+                                                            self.forcrv_handle)
+        # Table 2, page 10 in the article
+        strikes_3M = [1.1733, 1.2114, 1.2487]
+        strikes_1Y = [1.1597, 1.2355, 1.3148]
+        expected_vols_3M = [0.0943, 0.0905,  0.0893]
+        expected_vols_1Y = [0.0965, 0.0940, 0.0943]
+        expiry_3M =  self.expiry[0]
+        expiry_1Y = self.expiry[1]
+        diff_vols_3M = [vol_surface.blackVol(expiry_3M, strike) - expected_vol
+                        for strike, expected_vol in zip(strikes_3M,
+                                                        expected_vols_3M)]
+        diff_vols_1Y = [vol_surface.blackVol(expiry_1Y, strike) - expected_vol
+                        for strike, expected_vol in zip(strikes_1Y,
+                                                        expected_vols_1Y)]
+        for difference, strike in zip(diff_vols_3M, strikes_3M):
+            self.assertAlmostEqual(0.0, difference, delta=0.00001,
+                                   msg="Failed to determine volatility at 3M "
+                                       "expiry, strike: {},\n"
+                                       "observed difference: "
+                                       "{}".format(strike, difference))
+        for difference, strike in zip(diff_vols_1Y, strikes_1Y):
+            self.assertAlmostEqual(0.0, difference, delta=0.00001,
+                                   msg="Failed to determine volatility at 1Y "
+                                       "expiry, strike: {},\n"
+                                       "observed difference: "
+                                       "{}".format(strike, difference))
+
+if __name__ == '__main__':
+    print('testing QuantLib ' + ql.QuantLib.__version__)
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(FxVolSmileTest, 'test'))
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/SWIG/daycounters.i
+++ b/SWIG/daycounters.i
@@ -92,12 +92,4 @@ namespace QuantLib {
     };
 }
 
-%inline %{
-    /* avoid deprecation warnings */
-    DayCounter Actual365NoLeap() {
-        return QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap);
-    }
-%}
-
-
 #endif

--- a/SWIG/volatilities.i
+++ b/SWIG/volatilities.i
@@ -63,6 +63,8 @@ else
 
 %{
 using QuantLib::BlackVolTermStructure;
+//using QuantLib::BlackVolatilityTermStructure;
+using QuantExt::FxBlackVolatilitySurface;
 using QuantLib::LocalVolTermStructure;
 using QuantLib::OptionletVolatilityStructure;
 using QuantLib::SwaptionVolatilityStructure;
@@ -421,6 +423,34 @@ class LocalVolSurfacePtr : public boost::shared_ptr<LocalVolTermStructure> {
                     dividendTS, underlying));
         }
     }
+};
+
+// fx vol surface
+%{
+using QuantExt::FxBlackVannaVolgaVolatilitySurface;
+using QuantExt::VannaVolgaSmileSection;
+typedef boost::shared_ptr<BlackVolTermStructure> FxBlackVannaVolgaVolatilitySurfacePtr;
+%}
+%rename(FxBlackVannaVolgaVolatilitySurface) FxBlackVannaVolgaVolatilitySurfacePtr; 
+// class FxBlackVannaVolgaVolatilitySurfacePtr : public boost::shared_ptr<FxBlackVolatilitySurface>  {
+class FxBlackVannaVolgaVolatilitySurfacePtr : public boost::shared_ptr<BlackVolTermStructure>  {
+    public:
+        %extend {
+            FxBlackVannaVolgaVolatilitySurfacePtr(const Date& refDate, 
+                                    const std::vector<Date>& dates,
+                                    const std::vector<Volatility>& atmVols, 
+                                    const std::vector<Volatility>& rr25d,
+                                    const std::vector<Volatility>& bf25d, 
+                                    const DayCounter& dc, const Calendar& cal,
+                                    const Handle<Quote>& fx, 
+                                    const Handle<YieldTermStructure>& dom,
+                                    const Handle<YieldTermStructure>& fore) { 
+                return new FxBlackVannaVolgaVolatilitySurfacePtr(
+                    new FxBlackVannaVolgaVolatilitySurface(refDate, dates,
+                            atmVols, rr25d, bf25d, dc, cal, fx, dom, fore)
+                    );
+                }
+        }   
 };
 
 

--- a/SWIG/volatilities.i
+++ b/SWIG/volatilities.i
@@ -64,7 +64,7 @@ else
 %{
 using QuantLib::BlackVolTermStructure;
 //using QuantLib::BlackVolatilityTermStructure;
-using QuantExt::FxBlackVolatilitySurface;
+using QuantLib::FxBlackVolatilitySurface;
 using QuantLib::LocalVolTermStructure;
 using QuantLib::OptionletVolatilityStructure;
 using QuantLib::SwaptionVolatilityStructure;
@@ -427,8 +427,8 @@ class LocalVolSurfacePtr : public boost::shared_ptr<LocalVolTermStructure> {
 
 // fx vol surface
 %{
-using QuantExt::FxBlackVannaVolgaVolatilitySurface;
-using QuantExt::VannaVolgaSmileSection;
+using QuantLib::FxBlackVannaVolgaVolatilitySurface;
+using QuantLib::VannaVolgaSmileSection;
 typedef boost::shared_ptr<BlackVolTermStructure> FxBlackVannaVolgaVolatilitySurfacePtr;
 %}
 %rename(FxBlackVannaVolgaVolatilitySurface) FxBlackVannaVolgaVolatilitySurfacePtr; 


### PR DESCRIPTION
This pull request is conditional on approving PR https://github.com/lballabio/QuantLib/pull/553
in QuantLib repository. Main additions are:
- exposing FxBlackVannaVolgaVolatilitySurface added from ORE's QuantExt to QuantLib
- adding simple unit test to check if it works
- adding simple example script to visualize the volatility surface interpolated with VannaVolga method