### PR TITLE
Native boost shared ptr

### DIFF
--- a/Python/test/bonds.py
+++ b/Python/test/bonds.py
@@ -97,7 +97,7 @@ class FixedRateBondTest(unittest.TestCase):
 
     def testPrevCoupon(self):
         """ Testing FixedRateBond correct previous coupon amount. """
-        self.assertEqual(self.bond.previousCouponRate(self.issue_date), 0.05)
+        self.assertEqual(self.bond.previousCouponRate(), 0.05)
 
     def testCleanPrice(self):
         """ Testing FixedRateBond clean price. """

--- a/SWIG/basketoptions.i
+++ b/SWIG/basketoptions.i
@@ -4,6 +4,7 @@
  Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008 StatPro Italia srl
  Copyright (C) 2005 Dominic Thuillier
  Copyright (C) 2007 Joseph Wang
+ Copyright (C) 2018 Matthias Lungwitz
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -32,49 +33,34 @@ using QuantLib::MinBasketPayoff;
 using QuantLib::MaxBasketPayoff;
 using QuantLib::AverageBasketPayoff;
 typedef boost::shared_ptr<Instrument> BasketOptionPtr;
-typedef boost::shared_ptr<Payoff> BasketPayoffPtr;
-typedef boost::shared_ptr<Payoff> MinBasketPayoffPtr;
-typedef boost::shared_ptr<Payoff> MaxBasketPayoffPtr;
-typedef boost::shared_ptr<Payoff> AverageBasketPayoffPtr;
 %}
 
-%rename(BasketPayoff) BasketPayoffPtr;
-class BasketPayoffPtr : public boost::shared_ptr<Payoff> {};
-
-%rename(MinBasketPayoff) MinBasketPayoffPtr;
-class MinBasketPayoffPtr : public BasketPayoffPtr  {
-  public:
-    %extend {
-        MinBasketPayoffPtr(const boost::shared_ptr<Payoff> p) {
-            return new MinBasketPayoffPtr(new MinBasketPayoff(p));
-        }
-    }
+%shared_ptr(BasketPayoff)
+class BasketPayoff : public Payoff {
+  private:
+    BasketPayoff();
 };
 
-%rename(MaxBasketPayoff) MaxBasketPayoffPtr;
-class MaxBasketPayoffPtr : public BasketPayoffPtr  {
+%shared_ptr(MinBasketPayoff)
+class MinBasketPayoff : public BasketPayoff  {
   public:
-    %extend {
-        MaxBasketPayoffPtr(const boost::shared_ptr<Payoff> p) {
-            return new MaxBasketPayoffPtr(new MaxBasketPayoff(p));
-        }
-    }
+    MinBasketPayoff(const boost::shared_ptr<Payoff> p);
 };
 
-%rename(AverageBasketPayoff) AverageBasketPayoffPtr;
-class AverageBasketPayoffPtr :
-      public BasketPayoffPtr  {
+%shared_ptr(MaxBasketPayoff)
+class MaxBasketPayoff : public BasketPayoff  {
   public:
-    %extend {
-        AverageBasketPayoffPtr(const boost::shared_ptr<Payoff> p,
-                               const Array &a) {
-            return new AverageBasketPayoffPtr(new AverageBasketPayoff(p, a));
-        }
-        AverageBasketPayoffPtr(const boost::shared_ptr<Payoff> p,
-                               Size n) {
-            return new AverageBasketPayoffPtr(new AverageBasketPayoff(p, n));
-        }
-    }
+    MaxBasketPayoff(const boost::shared_ptr<Payoff> p);
+};
+
+%shared_ptr(AverageBasketPayoff)
+class AverageBasketPayoff :
+      public BasketPayoff  {
+  public:
+    AverageBasketPayoff(const boost::shared_ptr<Payoff> p,
+                           const Array &a);
+    AverageBasketPayoff(const boost::shared_ptr<Payoff> p,
+                           Size n);
 };
 
 

--- a/SWIG/basketoptions.i
+++ b/SWIG/basketoptions.i
@@ -32,7 +32,6 @@ using QuantLib::BasketPayoff;
 using QuantLib::MinBasketPayoff;
 using QuantLib::MaxBasketPayoff;
 using QuantLib::AverageBasketPayoff;
-typedef boost::shared_ptr<Instrument> BasketOptionPtr;
 %}
 
 %shared_ptr(BasketPayoff)
@@ -64,19 +63,12 @@ class AverageBasketPayoff :
 };
 
 
-%rename(BasketOption) BasketOptionPtr;
-class BasketOptionPtr : public MultiAssetOptionPtr {
+%shared_ptr(BasketOption)
+class BasketOption : public MultiAssetOption {
   public:
-    %extend {
-        BasketOptionPtr(
-                const boost::shared_ptr<Payoff>& payoff,
-                const boost::shared_ptr<Exercise>& exercise) {
-            boost::shared_ptr<BasketPayoff> stPayoff =
-                 boost::dynamic_pointer_cast<BasketPayoff>(payoff);
-            QL_REQUIRE(stPayoff, "wrong payoff given");
-            return new BasketOptionPtr(new BasketOption(stPayoff,exercise));
-        }
-    }
+    BasketOption(
+            const boost::shared_ptr<BasketPayoff>& payoff,
+            const boost::shared_ptr<Exercise>& exercise);
 };
 
 
@@ -92,7 +84,7 @@ class MCEuropeanBasketEnginePtr : public boost::shared_ptr<PricingEngine> {
     #endif
   public:
     %extend {
-        MCEuropeanBasketEnginePtr(const StochasticProcessArrayPtr& process,
+        MCEuropeanBasketEnginePtr(const boost::shared_ptr<StochasticProcessArray>& process,
                                   const std::string& traits,
                                   Size timeSteps = Null<Size>(),
                                   Size timeStepsPerYear = Null<Size>(),
@@ -102,13 +94,11 @@ class MCEuropeanBasketEnginePtr : public boost::shared_ptr<PricingEngine> {
                                   doubleOrNull requiredTolerance = Null<Real>(),
                                   intOrNull maxSamples = Null<Size>(),
                                   BigInteger seed = 0) {
-            boost::shared_ptr<StochasticProcessArray> processes =
-                 boost::dynamic_pointer_cast<StochasticProcessArray>(process);
-            QL_REQUIRE(processes, "stochastic-process array required");
+
             std::string s = boost::algorithm::to_lower_copy(traits);
             if (s == "pseudorandom" || s == "pr")
                 return new MCEuropeanBasketEnginePtr(
-                   new MCEuropeanBasketEngine<PseudoRandom>(processes,
+                   new MCEuropeanBasketEngine<PseudoRandom>(process,
                                                             timeSteps,
                                                             timeStepsPerYear,
                                                             brownianBridge,
@@ -119,7 +109,7 @@ class MCEuropeanBasketEnginePtr : public boost::shared_ptr<PricingEngine> {
                                                             seed));
             else if (s == "lowdiscrepancy" || s == "ld")
                 return new MCEuropeanBasketEnginePtr(
-                   new MCEuropeanBasketEngine<LowDiscrepancy>(processes,
+                   new MCEuropeanBasketEngine<LowDiscrepancy>(process,
                                                               timeSteps,
                                                               timeStepsPerYear,
                                                               brownianBridge,
@@ -146,7 +136,7 @@ class MCAmericanBasketEnginePtr : public boost::shared_ptr<PricingEngine> {
     #endif
   public:
     %extend {
-        MCAmericanBasketEnginePtr(const StochasticProcessArrayPtr& process,
+        MCAmericanBasketEnginePtr(const boost::shared_ptr<StochasticProcessArray>& process,
                                   const std::string& traits,
                                   Size timeSteps = Null<Size>(),
                                   Size timeStepsPerYear = Null<Size>(),
@@ -156,13 +146,11 @@ class MCAmericanBasketEnginePtr : public boost::shared_ptr<PricingEngine> {
                                   doubleOrNull requiredTolerance = Null<Real>(),
                                   intOrNull maxSamples = Null<Size>(),
                                   BigInteger seed = 0) {
-            boost::shared_ptr<StochasticProcessArray> processes =
-                 boost::dynamic_pointer_cast<StochasticProcessArray>(process);
-            QL_REQUIRE(processes, "stochastic-process array required");
+
             std::string s = boost::algorithm::to_lower_copy(traits);
             if (s == "pseudorandom" || s == "pr")
                   return new MCAmericanBasketEnginePtr(
-                  new MCAmericanBasketEngine<PseudoRandom>(processes,
+                  new MCAmericanBasketEngine<PseudoRandom>(process,
                                                            timeSteps,
                                                            timeStepsPerYear,
                                                            brownianBridge,
@@ -173,7 +161,7 @@ class MCAmericanBasketEnginePtr : public boost::shared_ptr<PricingEngine> {
                                                            seed));
             else if (s == "lowdiscrepancy" || s == "ld")
                 return new MCAmericanBasketEnginePtr(
-                new MCAmericanBasketEngine<LowDiscrepancy>(processes,
+                new MCAmericanBasketEngine<LowDiscrepancy>(process,
                                                            timeSteps,
                                                            timeStepsPerYear,
                                                            brownianBridge,
@@ -199,19 +187,11 @@ class StulzEnginePtr
     : public boost::shared_ptr<PricingEngine> {
   public:
     %extend {
-        StulzEnginePtr(const GeneralizedBlackScholesProcessPtr& process1,
-                       const GeneralizedBlackScholesProcessPtr& process2,
+        StulzEnginePtr(const boost::shared_ptr<GeneralizedBlackScholesProcess>& process1,
+                       const boost::shared_ptr<GeneralizedBlackScholesProcess>& process2,
                        Real correlation) {
-            boost::shared_ptr<GeneralizedBlackScholesProcess> bsProcess1 =
-                 boost::dynamic_pointer_cast<GeneralizedBlackScholesProcess>(
-                                                                    process1);
-            QL_REQUIRE(bsProcess1, "Black-Scholes process required");
-            boost::shared_ptr<GeneralizedBlackScholesProcess> bsProcess2 =
-                 boost::dynamic_pointer_cast<GeneralizedBlackScholesProcess>(
-                                                                    process2);
-            QL_REQUIRE(bsProcess2, "Black-Scholes process required");
             return new StulzEnginePtr(
-                          new StulzEngine(bsProcess1,bsProcess2,correlation));
+                          new StulzEngine(process1,process2,correlation));
         }
     }
 };
@@ -219,22 +199,16 @@ class StulzEnginePtr
 
 %{
 using QuantLib::EverestOption;
-typedef boost::shared_ptr<Instrument> EverestOptionPtr;
 using QuantLib::MCEverestEngine;
 typedef boost::shared_ptr<PricingEngine> MCEverestEnginePtr;
 %}
 
-%rename(EverestOption) EverestOptionPtr;
-class EverestOptionPtr : public MultiAssetOptionPtr {
+%shared_ptr(EverestOption)
+class EverestOption : public MultiAssetOption {
   public:
-    %extend {
-        EverestOptionPtr(Real notional,
-                         Rate guarantee,
-                         const boost::shared_ptr<Exercise>& exercise) {
-            return new EverestOptionPtr(new EverestOption(notional,guarantee,
-                                                          exercise));
-        }
-    }
+    EverestOption(Real notional,
+                     Rate guarantee,
+                     const boost::shared_ptr<Exercise>& exercise);
 };
 
 %rename(MCEverestEngine) MCEverestEnginePtr;
@@ -244,7 +218,7 @@ class MCEverestEnginePtr : public boost::shared_ptr<PricingEngine> {
     #endif
   public:
     %extend {
-        MCEverestEnginePtr(const StochasticProcessArrayPtr& process,
+        MCEverestEnginePtr(const boost::shared_ptr<StochasticProcessArray>& process,
                            const std::string& traits,
                            Size timeSteps = Null<Size>(),
                            Size timeStepsPerYear = Null<Size>(),
@@ -254,13 +228,10 @@ class MCEverestEnginePtr : public boost::shared_ptr<PricingEngine> {
                            doubleOrNull requiredTolerance = Null<Real>(),
                            intOrNull maxSamples = Null<Size>(),
                            BigInteger seed = 0) {
-            boost::shared_ptr<StochasticProcessArray> processes =
-                 boost::dynamic_pointer_cast<StochasticProcessArray>(process);
-            QL_REQUIRE(processes, "stochastic-process array required");
             std::string s = boost::algorithm::to_lower_copy(traits);
             if (s == "pseudorandom" || s == "pr")
                 return new MCEverestEnginePtr(
-                        new MCEverestEngine<PseudoRandom>(processes,
+                        new MCEverestEngine<PseudoRandom>(process,
                                                           timeSteps,
                                                           timeStepsPerYear,
                                                           brownianBridge,
@@ -271,7 +242,7 @@ class MCEverestEnginePtr : public boost::shared_ptr<PricingEngine> {
                                                           seed));
             else if (s == "lowdiscrepancy" || s == "ld")
                 return new MCEverestEnginePtr(
-                      new MCEverestEngine<LowDiscrepancy>(processes,
+                      new MCEverestEngine<LowDiscrepancy>(process,
                                                           timeSteps,
                                                           timeStepsPerYear,
                                                           brownianBridge,
@@ -289,21 +260,15 @@ class MCEverestEnginePtr : public boost::shared_ptr<PricingEngine> {
 
 %{
 using QuantLib::HimalayaOption;
-typedef boost::shared_ptr<Instrument> HimalayaOptionPtr;
 using QuantLib::MCHimalayaEngine;
 typedef boost::shared_ptr<PricingEngine> MCHimalayaEnginePtr;
 %}
 
-%rename(HimalayaOption) HimalayaOptionPtr;
-class HimalayaOptionPtr : public MultiAssetOptionPtr {
+%shared_ptr(HimalayaOption)
+class HimalayaOption : public MultiAssetOption {
   public:
-    %extend {
-        HimalayaOptionPtr(const std::vector<Date>& fixingDates,
-                          Real strike) {
-            return new HimalayaOptionPtr(new HimalayaOption(fixingDates,
-                                                            strike));
-        }
-    }
+    HimalayaOption(const std::vector<Date>& fixingDates,
+                      Real strike);
 };
 
 %rename(MCHimalayaEngine) MCHimalayaEnginePtr;
@@ -313,7 +278,7 @@ class MCHimalayaEnginePtr : public boost::shared_ptr<PricingEngine> {
     #endif
   public:
     %extend {
-        MCHimalayaEnginePtr(const StochasticProcessArrayPtr& process,
+        MCHimalayaEnginePtr(const boost::shared_ptr<StochasticProcessArray>& process,
                             const std::string& traits,
                             bool brownianBridge = false,
                             bool antitheticVariate = false,
@@ -321,13 +286,10 @@ class MCHimalayaEnginePtr : public boost::shared_ptr<PricingEngine> {
                             doubleOrNull requiredTolerance = Null<Real>(),
                             intOrNull maxSamples = Null<Size>(),
                             BigInteger seed = 0) {
-            boost::shared_ptr<StochasticProcessArray> processes =
-                 boost::dynamic_pointer_cast<StochasticProcessArray>(process);
-            QL_REQUIRE(processes, "stochastic-process array required");
             std::string s = boost::algorithm::to_lower_copy(traits);
             if (s == "pseudorandom" || s == "pr")
                 return new MCHimalayaEnginePtr(
-                       new MCHimalayaEngine<PseudoRandom>(processes,
+                       new MCHimalayaEngine<PseudoRandom>(process,
                                                           brownianBridge,
                                                           antitheticVariate,
                                                           requiredSamples,
@@ -336,7 +298,7 @@ class MCHimalayaEnginePtr : public boost::shared_ptr<PricingEngine> {
                                                           seed));
             else if (s == "lowdiscrepancy" || s == "ld")
                 return new MCHimalayaEnginePtr(
-                     new MCHimalayaEngine<LowDiscrepancy>(processes,
+                     new MCHimalayaEngine<LowDiscrepancy>(process,
                                                           brownianBridge,
                                                           antitheticVariate,
                                                           requiredSamples,

--- a/SWIG/bondfunctions.i
+++ b/SWIG/bondfunctions.i
@@ -36,93 +36,93 @@ class BondFunctions {
     #endif
   public:
     %extend {
-        static Date startDate(const BondPtr& bond) {
+        static Date startDate(const boost::shared_ptr<Bond>& bond) {
             return QuantLib::BondFunctions::startDate(
                     *(boost::dynamic_pointer_cast<Bond>(bond)));
         }
-        static Date maturityDate(const BondPtr& bond) {
+        static Date maturityDate(const boost::shared_ptr<Bond>& bond) {
             return QuantLib::BondFunctions::maturityDate(
                     *(boost::dynamic_pointer_cast<Bond>(bond)));
         }
-        static bool isTradable(const BondPtr& bond,
+        static bool isTradable(const boost::shared_ptr<Bond>& bond,
                                Date settlementDate = Date()) {
             return QuantLib::BondFunctions::isTradable(
                     *(boost::dynamic_pointer_cast<Bond>(bond)),
                     settlementDate);
         }
-        static Date previousCashFlowDate(const BondPtr& bond,
+        static Date previousCashFlowDate(const boost::shared_ptr<Bond>& bond,
                                          Date refDate = Date()) {
             return QuantLib::BondFunctions::previousCashFlowDate(
                     *(boost::dynamic_pointer_cast<Bond>(bond)),
                     refDate);
         }
-        static Date nextCashFlowDate(const BondPtr& bond,
+        static Date nextCashFlowDate(const boost::shared_ptr<Bond>& bond,
                                      Date refDate = Date()) {
             return QuantLib::BondFunctions::nextCashFlowDate(
                     *(boost::dynamic_pointer_cast<Bond>(bond)),
                     refDate);
         }
-        static Real previousCashFlowAmount(const BondPtr& bond,
+        static Real previousCashFlowAmount(const boost::shared_ptr<Bond>& bond,
                                            Date refDate = Date()) {
             return QuantLib::BondFunctions::previousCashFlowAmount(
                     *(boost::dynamic_pointer_cast<Bond>(bond)),
                     refDate);
         }
-        static Real nextCashFlowAmount(const BondPtr& bond,
+        static Real nextCashFlowAmount(const boost::shared_ptr<Bond>& bond,
                                        Date refDate = Date()) {
             return QuantLib::BondFunctions::nextCashFlowAmount(
                     *(boost::dynamic_pointer_cast<Bond>(bond)),
                     refDate);
         }
-        static Rate previousCouponRate(const BondPtr& bond,
+        static Rate previousCouponRate(const boost::shared_ptr<Bond>& bond,
                                        Date settlementDate = Date()) {
             return QuantLib::BondFunctions::previousCouponRate(
                     *(boost::dynamic_pointer_cast<Bond>(bond)),
                     settlementDate);
         }
-        static Rate nextCouponRate(const BondPtr& bond,
+        static Rate nextCouponRate(const boost::shared_ptr<Bond>& bond,
                                    Date settlementDate = Date()) {
             return QuantLib::BondFunctions::nextCouponRate(
                     *(boost::dynamic_pointer_cast<Bond>(bond)),
                     settlementDate);
         }
-        static Date accrualStartDate(const BondPtr& bond,
+        static Date accrualStartDate(const boost::shared_ptr<Bond>& bond,
                                      Date settlementDate = Date()) {
             return QuantLib::BondFunctions::accrualStartDate(
                     *(boost::dynamic_pointer_cast<Bond>(bond)),
                     settlementDate);
         }
-        static Date accrualEndDate(const BondPtr& bond,
+        static Date accrualEndDate(const boost::shared_ptr<Bond>& bond,
                                    Date settlementDate = Date()) {
             return QuantLib::BondFunctions::accrualEndDate(
                     *(boost::dynamic_pointer_cast<Bond>(bond)),
                     settlementDate);
         }
-        static Time accrualPeriod(const BondPtr& bond,
+        static Time accrualPeriod(const boost::shared_ptr<Bond>& bond,
                                   Date settlementDate = Date()) {
             return QuantLib::BondFunctions::accrualPeriod(
                     *(boost::dynamic_pointer_cast<Bond>(bond)),
                     settlementDate);
         }
-        static BigInteger accrualDays(const BondPtr& bond,
+        static BigInteger accrualDays(const boost::shared_ptr<Bond>& bond,
                                       Date settlementDate = Date()) {
             return QuantLib::BondFunctions::accrualDays(
                     *(boost::dynamic_pointer_cast<Bond>(bond)),
                     settlementDate);
         }
-        static Time accruedPeriod(const BondPtr& bond,
+        static Time accruedPeriod(const boost::shared_ptr<Bond>& bond,
                                   Date settlementDate = Date()) {
             return QuantLib::BondFunctions::accruedPeriod(
                 *(boost::dynamic_pointer_cast<Bond>(bond)),
                 settlementDate);
         }
-        static BigInteger accruedDays(const BondPtr& bond,
+        static BigInteger accruedDays(const boost::shared_ptr<Bond>& bond,
                                       Date settlementDate = Date()) {
             return QuantLib::BondFunctions::accruedDays(
                 *(boost::dynamic_pointer_cast<Bond>(bond)),
                 settlementDate);
         }
-        static Real accruedAmount(const BondPtr& bond,
+        static Real accruedAmount(const boost::shared_ptr<Bond>& bond,
                                   Date settlementDate = Date()){
 
             return QuantLib::BondFunctions::accruedAmount(
@@ -131,7 +131,7 @@ class BondFunctions {
         }
 
         static Real cleanPrice(
-                   const BondPtr& bond,
+                   const boost::shared_ptr<Bond>& bond,
                    const boost::shared_ptr<YieldTermStructure>& discountCurve,
                    Date settlementDate = Date()) {
             return QuantLib::BondFunctions::cleanPrice(
@@ -140,7 +140,7 @@ class BondFunctions {
                     settlementDate);
         }
         static Real bps(
-                   const BondPtr& bond,
+                   const boost::shared_ptr<Bond>& bond,
                    const boost::shared_ptr<YieldTermStructure>& discountCurve,
                    Date settlementDate = Date()) {
             return QuantLib::BondFunctions::bps(
@@ -149,7 +149,7 @@ class BondFunctions {
                     settlementDate);
         }
         static Rate atmRate(
-                   const BondPtr& bond,
+                   const boost::shared_ptr<Bond>& bond,
                    const boost::shared_ptr<YieldTermStructure>& discountCurve,
                    Date settlementDate = Date(),
                    Real cleanPrice = Null<Real>()) {
@@ -159,7 +159,7 @@ class BondFunctions {
                     settlementDate,
                     cleanPrice);
         }
-        static Real cleanPrice(const BondPtr& bond,
+        static Real cleanPrice(const boost::shared_ptr<Bond>& bond,
                                const InterestRate& yield,
                                Date settlementDate = Date()) {
             return QuantLib::BondFunctions::cleanPrice(
@@ -167,7 +167,7 @@ class BondFunctions {
                     yield,
                     settlementDate);
         }
-        static Real cleanPrice(const BondPtr& bond,
+        static Real cleanPrice(const boost::shared_ptr<Bond>& bond,
                                Rate yield,
                                const DayCounter& dayCounter,
                                Compounding compounding,
@@ -181,7 +181,7 @@ class BondFunctions {
                     frequency,
                     settlementDate);
         }
-        static Real bps(const BondPtr& bond,
+        static Real bps(const boost::shared_ptr<Bond>& bond,
                         const InterestRate& yield,
                         Date settlementDate = Date()) {
             return QuantLib::BondFunctions::bps(
@@ -189,7 +189,7 @@ class BondFunctions {
                         yield,
                         settlementDate);
         }
-        static Real bps(const BondPtr& bond,
+        static Real bps(const boost::shared_ptr<Bond>& bond,
                         Rate yield,
                         const DayCounter& dayCounter,
                         Compounding compounding,
@@ -203,7 +203,7 @@ class BondFunctions {
                         frequency,
                         settlementDate);
         }
-        static Rate yield(const BondPtr& bond,
+        static Rate yield(const boost::shared_ptr<Bond>& bond,
                           Real cleanPrice,
                           const DayCounter& dayCounter,
                           Compounding compounding,
@@ -226,7 +226,7 @@ class BondFunctions {
 
         %define DefineYieldFunctionSolver(SolverType)
         static Rate yield ## SolverType(SolverType solver,
-                                         const BondPtr& bond,
+                                         const boost::shared_ptr<Bond>& bond,
                                          Real cleanPrice,
                                          const DayCounter& dayCounter,
                                          Compounding compounding,
@@ -258,7 +258,7 @@ class BondFunctions {
         DefineYieldFunctionSolver(NewtonSafe);
         #endif
 
-        static Time duration(const BondPtr& bond,
+        static Time duration(const boost::shared_ptr<Bond>& bond,
                              const InterestRate& yield,
                              Duration::Type type = Duration::Modified,
                              Date settlementDate = Date() ) {
@@ -268,7 +268,7 @@ class BondFunctions {
                         type,
                         settlementDate);
         }
-        static Time duration(const BondPtr& bond,
+        static Time duration(const boost::shared_ptr<Bond>& bond,
                         Rate yield,
                         const DayCounter& dayCounter,
                         Compounding compounding,
@@ -284,7 +284,7 @@ class BondFunctions {
                         type,
                         settlementDate);
         }
-        static Real convexity(const BondPtr& bond,
+        static Real convexity(const boost::shared_ptr<Bond>& bond,
                               const InterestRate& yield,
                               Date settlementDate = Date()) {
             return QuantLib::BondFunctions::convexity(
@@ -292,7 +292,7 @@ class BondFunctions {
                         yield,
                         settlementDate);
         }
-        static Real convexity(const BondPtr& bond,
+        static Real convexity(const boost::shared_ptr<Bond>& bond,
                               Rate yield,
                               const DayCounter& dayCounter,
                               Compounding compounding,
@@ -306,7 +306,7 @@ class BondFunctions {
                         frequency,
                         settlementDate);
         }
-        static Real basisPointValue(const BondPtr& bond,
+        static Real basisPointValue(const boost::shared_ptr<Bond>& bond,
                                     const InterestRate& yield,
                                     Date settlementDate = Date()) {
             return QuantLib::BondFunctions::basisPointValue(
@@ -314,7 +314,7 @@ class BondFunctions {
                         yield,
                         settlementDate);
         }
-        static Real basisPointValue(const BondPtr& bond,
+        static Real basisPointValue(const boost::shared_ptr<Bond>& bond,
                                     Rate yield,
                                     const DayCounter& dayCounter,
                                     Compounding compounding,
@@ -328,7 +328,7 @@ class BondFunctions {
                         frequency,
                         settlementDate);
         }
-        static Real yieldValueBasisPoint(const BondPtr& bond,
+        static Real yieldValueBasisPoint(const boost::shared_ptr<Bond>& bond,
                                          const InterestRate& yield,
                                          Date settlementDate = Date()) {
             return QuantLib::BondFunctions::yieldValueBasisPoint(
@@ -336,7 +336,7 @@ class BondFunctions {
                         yield,
                         settlementDate);
         }
-        static Real yieldValueBasisPoint(const BondPtr& bond,
+        static Real yieldValueBasisPoint(const boost::shared_ptr<Bond>& bond,
                                          Rate yield,
                                          const DayCounter& dayCounter,
                                          Compounding compounding,
@@ -350,7 +350,7 @@ class BondFunctions {
                         frequency,
                         settlementDate);
         }
-        static Spread zSpread(const BondPtr& bond,
+        static Spread zSpread(const boost::shared_ptr<Bond>& bond,
                               Real cleanPrice,
                               const boost::shared_ptr<YieldTermStructure>& discountCurve,
                               const DayCounter& dayCounter,

--- a/SWIG/bonds.i
+++ b/SWIG/bonds.i
@@ -44,151 +44,74 @@ using QuantLib::FloatingRateBond;
 using QuantLib::AmortizingFloatingRateBond;
 using QuantLib::DiscountingBondEngine;
 
-typedef boost::shared_ptr<Instrument> BondPtr;
-typedef boost::shared_ptr<Instrument> ZeroCouponBondPtr;
-typedef boost::shared_ptr<Instrument> FixedRateBondPtr;
-typedef boost::shared_ptr<Instrument> AmortizingFixedRateBondPtr;
-typedef boost::shared_ptr<Instrument> FloatingRateBondPtr;
-typedef boost::shared_ptr<Instrument> AmortizingFloatingRateBondPtr;
 typedef boost::shared_ptr<PricingEngine> DiscountingBondEnginePtr;
 %}
 
-%rename(Bond) BondPtr;
-class BondPtr : public boost::shared_ptr<Instrument> {
+%shared_ptr(Bond)
+class Bond : public Instrument {
     #if defined(SWIGPYTHON) || defined (SWIGRUBY)
     %rename(bondYield) yield;
     #endif
   public:
-    %extend {
-        BondPtr(Natural settlementDays,
-                const Calendar& calendar,
-                Real faceAmount,
-                const Date& maturityDate,
-                const Date& issueDate = Date(),
-                const Leg& cashflows = Leg()) {
-            return new BondPtr(new Bond(settlementDays,
-                                        calendar,
-                                        faceAmount,
-                                        maturityDate,
-                                        issueDate,
-                                        cashflows));
-        }
-        BondPtr(Natural settlementDays,
-                const Calendar& calendar,
-                const Date& issueDate = Date(),
-                const Leg& coupons = Leg()) {
-            return new BondPtr(new Bond(settlementDays,
-                                        calendar,
-                                        issueDate,
-                                        coupons));
-        }
-        // public functions
-        Rate nextCouponRate(const Date& d = Date()) {
-            return boost::dynamic_pointer_cast<Bond>(*self)
-                ->nextCouponRate();
-        }
-        Rate previousCouponRate(const Date& d = Date()) {
-            return boost::dynamic_pointer_cast<Bond>(*self)
-                ->previousCouponRate();
-        }
-        // inspectors
-        Natural settlementDays() const {
-            return boost::dynamic_pointer_cast<Bond>(*self)
-                ->settlementDays();
-        }
-        Date settlementDate(Date d = Date()) {
-            return boost::dynamic_pointer_cast<Bond>(*self)->settlementDate(d);
-        }
-        Date startDate() const {
-            return boost::dynamic_pointer_cast<Bond>(*self)->startDate();
-        }
-        Date maturityDate() const {
-            return boost::dynamic_pointer_cast<Bond>(*self)->maturityDate();
-        }
-        Date issueDate() const {
-            return boost::dynamic_pointer_cast<Bond>(*self)->issueDate();
-        }
-        std::vector<boost::shared_ptr<CashFlow> > cashflows() const {
-            return boost::dynamic_pointer_cast<Bond>(*self)->cashflows();
-        }
-        std::vector<boost::shared_ptr<CashFlow> > redemptions() const {
-            return boost::dynamic_pointer_cast<Bond>(*self)->redemptions();
-        }
-        boost::shared_ptr<CashFlow> redemption() const {
-            return boost::dynamic_pointer_cast<Bond>(*self)->redemption();
-        }
-        Calendar calendar() const {
-            return boost::dynamic_pointer_cast<Bond>(*self)->calendar();
-        }
-        std::vector<Real> notionals() const {
-            return boost::dynamic_pointer_cast<Bond>(*self)->notionals();
-        }
-        Real notional(Date d = Date()) const {
-            return boost::dynamic_pointer_cast<Bond>(*self)->notional(d);
-        }
-        // calculations
-        Real cleanPrice() {
-            return boost::dynamic_pointer_cast<Bond>(*self)->cleanPrice();
-        }
-        Real cleanPrice(Rate yield,
-                        const DayCounter &dc,
-                        Compounding compounding,
-                        Frequency frequency,
-                        const Date& settlement = Date()) {
-            return boost::dynamic_pointer_cast<Bond>(*self)
-                ->cleanPrice(yield,dc, compounding, frequency, settlement);
-        }
-        Real dirtyPrice() {
-            return boost::dynamic_pointer_cast<Bond>(*self)->dirtyPrice();
-        }
-        Real dirtyPrice(Rate yield,
-                        const DayCounter &dc,
-                        Compounding compounding,
-                        Frequency frequency,
-                        const Date& settlement = Date()) {
-            return boost::dynamic_pointer_cast<Bond>(*self)
-                ->dirtyPrice(yield,dc, compounding,
-                             frequency, settlement);
-        }
-        Real yield(const DayCounter& dc,
-                   Compounding compounding,
-                   Frequency freq,
-                   Real accuracy = 1.0e-8,
-                   Size maxEvaluations = 100) {
-            return boost::dynamic_pointer_cast<Bond>(*self)
-                ->yield(dc,compounding,freq,accuracy,maxEvaluations);
-        }
-        Real yield(Real cleanPrice,
-                   const DayCounter& dc,
-                   Compounding compounding,
-                   Frequency freq,
-                   const Date& settlement = Date(),
-                   Real accuracy = 1.0e-8,
-                   Size maxEvaluations = 100) {
-            return boost::dynamic_pointer_cast<Bond>(*self)
-                ->yield(cleanPrice,dc,compounding,freq,
-                        settlement,accuracy,maxEvaluations);
-        }
-        Real accruedAmount(const Date& settlement = Date()) {
-            return boost::dynamic_pointer_cast<Bond>(*self)
-                ->accruedAmount(settlement);
-        }
-        Real settlementValue() const {
-            return boost::dynamic_pointer_cast<Bond>(*self)
-                ->settlementValue();
-        }
-        Real settlementValue(Real cleanPrice) const {
-            return boost::dynamic_pointer_cast<Bond>(*self)
-                ->settlementValue(cleanPrice);
-        }
-    }
+    Bond(Natural settlementDays,
+            const Calendar& calendar,
+            Real faceAmount,
+            const Date& maturityDate,
+            const Date& issueDate = Date(),
+            const Leg& cashflows = Leg());
+    Bond(Natural settlementDays,
+            const Calendar& calendar,
+            const Date& issueDate = Date(),
+            const Leg& coupons = Leg());
+    // public functions
+    Rate nextCouponRate(const Date& d = Date());
+    Rate previousCouponRate(const Date& d = Date());
+    // inspectors
+    Natural settlementDays() const;
+    Date settlementDate(Date d = Date());
+    Date startDate() const;
+    Date maturityDate() const;
+    Date issueDate() const;
+    std::vector<boost::shared_ptr<CashFlow> > cashflows() const;
+    std::vector<boost::shared_ptr<CashFlow> > redemptions() const;
+    boost::shared_ptr<CashFlow> redemption() const;
+    Calendar calendar() const;
+    std::vector<Real> notionals() const;
+    Real notional(Date d = Date()) const;
+    // calculations
+    Real cleanPrice();
+    Real cleanPrice(Rate yield,
+                    const DayCounter &dc,
+                    Compounding compounding,
+                    Frequency frequency,
+                    const Date& settlement = Date());
+    Real dirtyPrice();
+    Real dirtyPrice(Rate yield,
+                    const DayCounter &dc,
+                    Compounding compounding,
+                    Frequency frequency,
+                    const Date& settlement = Date());
+    Real yield(const DayCounter& dc,
+               Compounding compounding,
+               Frequency freq,
+               Real accuracy = 1.0e-8,
+               Size maxEvaluations = 100);
+    Real yield(Real cleanPrice,
+               const DayCounter& dc,
+               Compounding compounding,
+               Frequency freq,
+               const Date& settlement = Date(),
+               Real accuracy = 1.0e-8,
+               Size maxEvaluations = 100);
+    Real accruedAmount(const Date& settlement = Date());
+    Real settlementValue() const;
+    Real settlementValue(Real cleanPrice) const;
 };
 
 
 %inline %{
-
     Real cleanPriceFromZSpread(
-                   const BondPtr& bond,
+                   const boost::shared_ptr<Bond>& bond,
                    const boost::shared_ptr<YieldTermStructure>& discountCurve,
                    Spread zSpread,
                    const DayCounter& dc,
@@ -206,287 +129,179 @@ class BondPtr : public boost::shared_ptr<Instrument> {
 
 
 
-%rename(ZeroCouponBond) ZeroCouponBondPtr;
-class ZeroCouponBondPtr : public BondPtr {
+%shared_ptr(ZeroCouponBond)
+class ZeroCouponBond : public Bond {
     #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
-    %feature("kwargs") ZeroCouponBondPtr;
+    %feature("kwargs") ZeroCouponBond;
     #endif
   public:
-    %extend {
-        ZeroCouponBondPtr(
-                Natural settlementDays,
-                const Calendar &calendar,
-                Real faceAmount,
-                const Date & maturityDate,
-                BusinessDayConvention paymentConvention = QuantLib::Following,
-                Real redemption = 100.0,
-                const Date& issueDate = Date()) {
-            return new ZeroCouponBondPtr(
-                new ZeroCouponBond(settlementDays, calendar, faceAmount,
-                                   maturityDate,
-                                   paymentConvention, redemption,
-                                   issueDate));
-        }
-    }
-};
-
-%rename(FixedRateBond) FixedRateBondPtr;
-class FixedRateBondPtr : public BondPtr {
-  public:
-    %extend {
-        FixedRateBondPtr(
-                Integer settlementDays,
-                Real faceAmount,
-                const Schedule &schedule,
-                const std::vector<Rate>& coupons,
-                const DayCounter& paymentDayCounter,
-                BusinessDayConvention paymentConvention = QuantLib::Following,
-                Real redemption = 100.0,
-                Date issueDate = Date(),
-                const Calendar& paymentCalendar = Calendar(),
-                const Period& exCouponPeriod = Period(),
-                const Calendar& exCouponCalendar = Calendar(),
-                BusinessDayConvention exCouponConvention = Unadjusted,
-                bool exCouponEndOfMonth = false) {
-            return new FixedRateBondPtr(
-                new FixedRateBond(settlementDays, faceAmount,
-                                  schedule, coupons, paymentDayCounter,
-                                  paymentConvention, redemption,
-                                  issueDate, paymentCalendar,
-                                  exCouponPeriod, exCouponCalendar,
-                                  exCouponConvention, exCouponEndOfMonth));
-        }
-        //! generic compounding and frequency InterestRate coupons 
-        FixedRateBondPtr(
-              Integer settlementDays,
-              Real faceAmount,
-              const Schedule& schedule,
-              const std::vector<InterestRate>& coupons,
-              BusinessDayConvention paymentConvention = Following,
-              Real redemption = 100.0,
-              const Date& issueDate = Date(),
-              const Calendar& paymentCalendar = Calendar(),
-              const Period& exCouponPeriod = Period(),
-              const Calendar& exCouponCalendar = Calendar(),
-              BusinessDayConvention exCouponConvention = Unadjusted,
-              bool exCouponEndOfMonth = false) {
-	       return new FixedRateBondPtr(
-		      new FixedRateBond(settlementDays, faceAmount,
-		                  schedule, coupons, paymentConvention,
-		                  redemption, issueDate, paymentCalendar,
-		                  exCouponPeriod, exCouponCalendar,
-		                  exCouponConvention, exCouponEndOfMonth));
-		}
-        //! simple annual compounding coupon rates with internal schedule calculation 
-        FixedRateBondPtr(
-              Integer settlementDays,
-              const Calendar& couponCalendar,
-              Real faceAmount,
-              const Date& startDate,
-              const Date& maturityDate,
-              const Period& tenor,
-              const std::vector<Rate>& coupons,
-              const DayCounter& accrualDayCounter,
-              BusinessDayConvention accrualConvention = QuantLib::Following,
-              BusinessDayConvention paymentConvention = QuantLib::Following,
-              Real redemption = 100.0,
-              const Date& issueDate = Date(),
-              const Date& stubDate = Date(),
-              DateGeneration::Rule rule = QuantLib::DateGeneration::Backward,
-              bool endOfMonth = false,
-              const Calendar& paymentCalendar = Calendar(),
-              const Period& exCouponPeriod = Period(),
-              const Calendar& exCouponCalendar = Calendar(),
-              const BusinessDayConvention exCouponConvention = Unadjusted,
-              bool exCouponEndOfMonth = false) {
-	       return new FixedRateBondPtr(
-		      new FixedRateBond(settlementDays, couponCalendar, faceAmount,
-                          startDate, maturityDate, tenor, coupons, accrualDayCounter,
-                          accrualConvention, paymentConvention, 
-		                  redemption, issueDate, stubDate, rule, endOfMonth, paymentCalendar,
-		                  exCouponPeriod, exCouponCalendar,
-		                  exCouponConvention, exCouponEndOfMonth));
-		}
-
-
-        Frequency frequency() const {
-            return boost::dynamic_pointer_cast<FixedRateBond>(*self)
-                ->frequency();
-        }
-        DayCounter dayCounter() const {
-            return boost::dynamic_pointer_cast<FixedRateBond>(*self)
-                ->dayCounter();
-        }
-    }
-};
-
-
-%rename(AmortizingFixedRateBond) AmortizingFixedRateBondPtr;
-class AmortizingFixedRateBondPtr : public BondPtr {
-  public:
-    %extend {
-        AmortizingFixedRateBondPtr(
-                Integer settlementDays,
-                const std::vector<Real>& notionals,
-                const Schedule& schedule,
-                const std::vector<Rate>& coupons,
-                const DayCounter& accrualDayCounter,
-                BusinessDayConvention paymentConvention = QuantLib::Following,
-                Date issueDate = Date()) {
-            return new AmortizingFixedRateBondPtr(
-                new AmortizingFixedRateBond(settlementDays, notionals,
-                                  schedule, coupons, accrualDayCounter,
-                                  paymentConvention, issueDate));
-        }
-        AmortizingFixedRateBondPtr(
-                Integer settlementDays,
-                const Calendar& paymentCalendar,
-                Real faceAmount,
-                Date startDate,
-                const Period& bondTenor,
-                const Frequency& sinkingFrequency,
-                Real coupon,
-                const DayCounter& accrualDayCounter,
-                BusinessDayConvention paymentConvention = QuantLib::Following,
-                Date issueDate = Date()) {
-            return new AmortizingFixedRateBondPtr(
-                new AmortizingFixedRateBond(settlementDays, paymentCalendar,
-                                  faceAmount, startDate, bondTenor,
-                                  sinkingFrequency,
-                                  coupon, accrualDayCounter,
-                                  paymentConvention, issueDate));
-        }
-        Frequency frequency() const {
-            return boost::dynamic_pointer_cast<AmortizingFixedRateBond>(*self)
-                ->frequency();
-        }
-        DayCounter dayCounter() const {
-            return boost::dynamic_pointer_cast<AmortizingFixedRateBond>(*self)
-                ->dayCounter();
-        }
-    }
-};
-
-
-%rename(AmortizingFloatingRateBond) AmortizingFloatingRateBondPtr;
-class AmortizingFloatingRateBondPtr : public BondPtr {
-    #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
-    %feature("kwargs") AmortizingFloatingRateBondPtr;
-    #endif
-  public:
-    %extend {
-        AmortizingFloatingRateBondPtr(
-            Size settlementDays,
-            const std::vector<Real>& notional,
-            const Schedule& schedule,
-            const boost::shared_ptr<IborIndex>& index,
-            const DayCounter& accrualDayCounter,
-            BusinessDayConvention paymentConvention = Following,
-            Size fixingDays = Null<Size>(),
-            const std::vector<Real>& gearings = std::vector<Real>(1, 1.0),
-            const std::vector<Spread>& spreads = std::vector<Spread>(1, 1.0),
-            const std::vector<Rate>& caps = std::vector<Rate>(),
-            const std::vector<Rate>& floors = std::vector<Rate>(),
-            bool inArrears = false,
-            const Date& issueDate = Date()) {
-            return new AmortizingFloatingRateBondPtr(
-                new AmortizingFloatingRateBond(settlementDays, notional,
-                                                schedule, index,
-                                                accrualDayCounter,
-                                                paymentConvention,
-                                                fixingDays, gearings,
-                                                spreads, caps, floors,
-                                                inArrears, issueDate));
-        }
-    }
-};
-
-
-%rename(FloatingRateBond) FloatingRateBondPtr;
-class FloatingRateBondPtr : public BondPtr {
-    #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
-    %feature("kwargs") FloatingRateBondPtr;
-    #endif
-  public:
-    %extend {
-        FloatingRateBondPtr(
-            Size settlementDays,
+    ZeroCouponBond(
+            Natural settlementDays,
+            const Calendar &calendar,
             Real faceAmount,
-            const Schedule& schedule,
-            const boost::shared_ptr<IborIndex>& index,
-            const DayCounter& paymentDayCounter,
-            BusinessDayConvention paymentConvention = Following,
-            Size fixingDays = Null<Size>(),
-            const std::vector<Real>& gearings = std::vector<Real>(),
-            const std::vector<Spread>& spreads = std::vector<Spread>(),
-            const std::vector<Rate>& caps = std::vector<Rate>(),
-            const std::vector<Rate>& floors = std::vector<Rate>(),
-            bool inArrears = false,
+            const Date & maturityDate,
+            BusinessDayConvention paymentConvention = QuantLib::Following,
             Real redemption = 100.0,
-            const Date& issueDate = Date()) {
-            return new FloatingRateBondPtr(
-                new FloatingRateBond(settlementDays,
-                                     faceAmount,
-                                     schedule,
-                                     index,
-                                     paymentDayCounter,
-                                     paymentConvention,
-                                     fixingDays,
-                                     gearings,
-                                     spreads,
-                                     caps,
-                                     floors,
-                                     inArrears,
-                                     redemption,
-                                     issueDate));
-        }
-    }
+            const Date& issueDate = Date());
+};
+
+%shared_ptr(FixedRateBond)
+class FixedRateBond : public Bond {
+  public:
+    FixedRateBond(
+            Integer settlementDays,
+            Real faceAmount,
+            const Schedule &schedule,
+            const std::vector<Rate>& coupons,
+            const DayCounter& paymentDayCounter,
+            BusinessDayConvention paymentConvention = QuantLib::Following,
+            Real redemption = 100.0,
+            Date issueDate = Date(),
+            const Calendar& paymentCalendar = Calendar(),
+            const Period& exCouponPeriod = Period(),
+            const Calendar& exCouponCalendar = Calendar(),
+            BusinessDayConvention exCouponConvention = Unadjusted,
+            bool exCouponEndOfMonth = false);
+    //! generic compounding and frequency InterestRate coupons 
+    FixedRateBond(
+          Integer settlementDays,
+          Real faceAmount,
+          const Schedule& schedule,
+          const std::vector<InterestRate>& coupons,
+          BusinessDayConvention paymentConvention = Following,
+          Real redemption = 100.0,
+          const Date& issueDate = Date(),
+          const Calendar& paymentCalendar = Calendar(),
+          const Period& exCouponPeriod = Period(),
+          const Calendar& exCouponCalendar = Calendar(),
+          BusinessDayConvention exCouponConvention = Unadjusted,
+          bool exCouponEndOfMonth = false);
+    //! simple annual compounding coupon rates with internal schedule calculation 
+    FixedRateBond(
+          Integer settlementDays,
+          const Calendar& couponCalendar,
+          Real faceAmount,
+          const Date& startDate,
+          const Date& maturityDate,
+          const Period& tenor,
+          const std::vector<Rate>& coupons,
+          const DayCounter& accrualDayCounter,
+          BusinessDayConvention accrualConvention = QuantLib::Following,
+          BusinessDayConvention paymentConvention = QuantLib::Following,
+          Real redemption = 100.0,
+          const Date& issueDate = Date(),
+          const Date& stubDate = Date(),
+          DateGeneration::Rule rule = QuantLib::DateGeneration::Backward,
+          bool endOfMonth = false,
+          const Calendar& paymentCalendar = Calendar(),
+          const Period& exCouponPeriod = Period(),
+          const Calendar& exCouponCalendar = Calendar(),
+          const BusinessDayConvention exCouponConvention = Unadjusted,
+          bool exCouponEndOfMonth = false);
+
+    Frequency frequency() const;
+    DayCounter dayCounter() const;
+};
+
+
+%shared_ptr(AmortizingFixedRateBond)
+class AmortizingFixedRateBond : public Bond {
+  public:
+    AmortizingFixedRateBond(
+            Integer settlementDays,
+            const std::vector<Real>& notionals,
+            const Schedule& schedule,
+            const std::vector<Rate>& coupons,
+            const DayCounter& accrualDayCounter,
+            BusinessDayConvention paymentConvention = QuantLib::Following,
+            Date issueDate = Date());
+    AmortizingFixedRateBond(
+            Integer settlementDays,
+            const Calendar& paymentCalendar,
+            Real faceAmount,
+            Date startDate,
+            const Period& bondTenor,
+            const Frequency& sinkingFrequency,
+            Real coupon,
+            const DayCounter& accrualDayCounter,
+            BusinessDayConvention paymentConvention = QuantLib::Following,
+            Date issueDate = Date());
+    Frequency frequency() const;
+    DayCounter dayCounter() const;
+};
+
+
+%shared_ptr(AmortizingFloatingRateBond)
+class AmortizingFloatingRateBond : public Bond {
+    #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
+    %feature("kwargs") AmortizingFloatingRateBond;
+    #endif
+  public:
+    AmortizingFloatingRateBond(
+        Size settlementDays,
+        const std::vector<Real>& notional,
+        const Schedule& schedule,
+        const boost::shared_ptr<IborIndex>& index,
+        const DayCounter& accrualDayCounter,
+        BusinessDayConvention paymentConvention = Following,
+        Size fixingDays = Null<Size>(),
+        const std::vector<Real>& gearings = std::vector<Real>(1, 1.0),
+        const std::vector<Spread>& spreads = std::vector<Spread>(1, 1.0),
+        const std::vector<Rate>& caps = std::vector<Rate>(),
+        const std::vector<Rate>& floors = std::vector<Rate>(),
+        bool inArrears = false,
+        const Date& issueDate = Date());
+};
+
+
+%shared_ptr(FloatingRateBond)
+class FloatingRateBond : public Bond {
+    #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
+    %feature("kwargs") FloatingRateBond;
+    #endif
+  public:
+    FloatingRateBond(
+        Size settlementDays,
+        Real faceAmount,
+        const Schedule& schedule,
+        const boost::shared_ptr<IborIndex>& index,
+        const DayCounter& paymentDayCounter,
+        BusinessDayConvention paymentConvention = Following,
+        Size fixingDays = Null<Size>(),
+        const std::vector<Real>& gearings = std::vector<Real>(),
+        const std::vector<Spread>& spreads = std::vector<Spread>(),
+        const std::vector<Rate>& caps = std::vector<Rate>(),
+        const std::vector<Rate>& floors = std::vector<Rate>(),
+        bool inArrears = false,
+        Real redemption = 100.0,
+        const Date& issueDate = Date());
 };
 
 
 %{
 using QuantLib::CmsRateBond;
-typedef boost::shared_ptr<Instrument> CmsRateBondPtr;
 %}
 
-%rename(CmsRateBond) CmsRateBondPtr;
-class CmsRateBondPtr : public BondPtr {
+%shared_ptr(CmsRateBond)
+class CmsRateBond : public Bond {
     #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
-    %feature("kwargs") CmsRateBondPtr;
+    %feature("kwargs") CmsRateBond;
     #endif
   public:
-    %extend {
-        CmsRateBondPtr(Size settlementDays,
-                       Real faceAmount,
-                       const Schedule& schedule,
-                       const boost::shared_ptr<SwapIndex>& index,
-                       const DayCounter& paymentDayCounter,
-                       BusinessDayConvention paymentConvention,
-                       Natural fixingDays,
-                       const std::vector<Real>& gearings,
-                       const std::vector<Spread>& spreads,
-                       const std::vector<Rate>& caps,
-                       const std::vector<Rate>& floors,
-                       bool inArrears = false,
-                       Real redemption = 100.0,
-                       const Date& issueDate = Date()) {
-            return new CmsRateBondPtr(
-                new CmsRateBond(settlementDays,
-                                faceAmount,
-                                schedule,
-                                index,
-                                paymentDayCounter,
-                                paymentConvention,
-                                fixingDays,
-                                gearings,
-                                spreads,
-                                caps,
-                                floors,
-                                inArrears,
-                                redemption,
-                                issueDate));
-        }
-    }
+    CmsRateBond(Size settlementDays,
+                   Real faceAmount,
+                   const Schedule& schedule,
+                   const boost::shared_ptr<SwapIndex>& index,
+                   const DayCounter& paymentDayCounter,
+                   BusinessDayConvention paymentConvention,
+                   Natural fixingDays,
+                   const std::vector<Real>& gearings,
+                   const std::vector<Spread>& spreads,
+                   const std::vector<Rate>& caps,
+                   const std::vector<Rate>& floors,
+                   bool inArrears = false,
+                   Real redemption = 100.0,
+                   const Date& issueDate = Date());
 };
 
 
@@ -508,102 +323,57 @@ using QuantLib::CallableBond;
 using QuantLib::CallableFixedRateBond;
 using QuantLib::TreeCallableFixedRateBondEngine;
 using QuantLib::BlackCallableFixedRateBondEngine;
-typedef boost::shared_ptr<Instrument> CallableFixedRateBondPtr;
 typedef boost::shared_ptr<PricingEngine> TreeCallableFixedRateBondEnginePtr;
 typedef boost::shared_ptr<PricingEngine> BlackCallableFixedRateBondEnginePtr;
 %}
 
-%rename(CallableFixedRateBond) CallableFixedRateBondPtr;
-class CallableFixedRateBondPtr : public BondPtr {
+%shared_ptr(CallableFixedRateBond)
+class CallableFixedRateBond : public Bond {
     #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
-    %feature("kwargs") CallableFixedRateBondPtr;
+    %feature("kwargs") CallableFixedRateBond;
     #endif
   public:
-    %extend {
-        CallableFixedRateBondPtr(
-                Integer settlementDays,
-                Real faceAmount,
-                const Schedule &schedule,
-                const std::vector<Rate>& coupons,
-                const DayCounter& accrualDayCounter,
-                BusinessDayConvention paymentConvention,
-                Real redemption,
-                Date issueDate,
-                const std::vector<boost::shared_ptr<Callability> > &putCallSchedule) {
-            return new CallableFixedRateBondPtr(
-                new CallableFixedRateBond(settlementDays, faceAmount,
-                                          schedule, coupons, accrualDayCounter,
-                                          paymentConvention, redemption,
-                                          issueDate, putCallSchedule));
-        }
+    CallableFixedRateBond(
+            Integer settlementDays,
+            Real faceAmount,
+            const Schedule &schedule,
+            const std::vector<Rate>& coupons,
+            const DayCounter& accrualDayCounter,
+            BusinessDayConvention paymentConvention,
+            Real redemption,
+            Date issueDate,
+            const std::vector<boost::shared_ptr<Callability> > &putCallSchedule);
 
-        Real OAS(Real cleanPrice,
-                 const Handle<YieldTermStructure>& engineTS,
-                 const DayCounter& dc,
-                 Compounding compounding,
-                 Frequency freq,
-                 const Date& settlementDate = Date(),
-                 Real accuracy =1e-10,
-                 Size maxIterations = 100,
-                 Spread guess = 0.0)
-        {
-            return boost::dynamic_pointer_cast<CallableBond>(*self)
-                ->OAS(cleanPrice,
-                      engineTS,
-                      dc, compounding, freq, settlementDate,
-                      accuracy,
-                      maxIterations,
-                      guess);
-        }
+    Real OAS(Real cleanPrice,
+             const Handle<YieldTermStructure>& engineTS,
+             const DayCounter& dc,
+             Compounding compounding,
+             Frequency freq,
+             const Date& settlementDate = Date(),
+             Real accuracy =1e-10,
+             Size maxIterations = 100,
+             Spread guess = 0.0);
 
-        Real cleanPriceOAS(Real oas,
+    Real cleanPriceOAS(Real oas,
+                       const Handle<YieldTermStructure>& engineTS,
+                       const DayCounter& dayCounter,
+                       Compounding compounding,
+                       Frequency frequency,
+                       Date settlementDate = Date());
+
+    Real effectiveDuration(Real oas,
                            const Handle<YieldTermStructure>& engineTS,
                            const DayCounter& dayCounter,
                            Compounding compounding,
                            Frequency frequency,
-                           Date settlementDate = Date())
-        {
-            return boost::dynamic_pointer_cast<CallableBond>(*self)
-                ->cleanPriceOAS(oas,
-                                engineTS,
-                                dayCounter,
-                                compounding,
-                                frequency,
-                                settlementDate);
-        }
+                           Real bump=2e-4);
 
-        Real effectiveDuration(Real oas,
-                               const Handle<YieldTermStructure>& engineTS,
-                               const DayCounter& dayCounter,
-                               Compounding compounding,
-                               Frequency frequency,
-                               Real bump=2e-4)
-        {
-            return boost::dynamic_pointer_cast<CallableBond>(*self)
-                ->effectiveDuration(oas,
-                                    engineTS,
-                                    dayCounter,
-                                    compounding,
-                                    frequency,
-                                    bump);
-        }
-
-        Real effectiveConvexity(Real oas,
-                                const Handle<YieldTermStructure>& engineTS,
-                                const DayCounter& dayCounter,
-                                Compounding compounding,
-                                Frequency frequency,
-                                Real bump=2e-4)
-        {
-            return boost::dynamic_pointer_cast<CallableBond>(*self)
-                ->effectiveConvexity(oas,
-                                     engineTS,
-                                     dayCounter,
-                                     compounding,
-                                     frequency,
-                                     bump);
-        }
-    }
+    Real effectiveConvexity(Real oas,
+                            const Handle<YieldTermStructure>& engineTS,
+                            const DayCounter& dayCounter,
+                            Compounding compounding,
+                            Frequency frequency,
+                            Real bump=2e-4);
 };
 
 %rename(TreeCallableFixedRateBondEngine) TreeCallableFixedRateBondEnginePtr;
@@ -649,43 +419,32 @@ class BlackCallableFixedRateBondEnginePtr
 
 %{
 using QuantLib::CPIBond;
-typedef boost::shared_ptr<Instrument> CPIBondPtr;
 %}
 
-%rename(CPIBond) CPIBondPtr;
-class CPIBondPtr : public BondPtr {
+%shared_ptr(CPIBond)
+class CPIBond : public Bond {
     #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
-    %feature("kwargs") CPIBondPtr;
+    %feature("kwargs") CPIBond;
     #endif
   public:
-    %extend {
-        CPIBondPtr(
-                Natural settlementDays,
-                Real faceAmount,
-                bool growthOnly,
-                Real baseCPI,
-                const Period& observationLag,
-                const boost::shared_ptr<ZeroInflationIndex>& cpiIndex,
-                CPI::InterpolationType observationInterpolation,
-                const Schedule& schedule,
-                const std::vector<Rate>& coupons,
-                const DayCounter& accrualDayCounter,
-                BusinessDayConvention paymentConvention = ModifiedFollowing,
-                const Date& issueDate = Date(),
-                const Calendar& paymentCalendar = Calendar(),
-                const Period& exCouponPeriod = Period(),
-                const Calendar& exCouponCalendar = Calendar(),
-                BusinessDayConvention exCouponConvention = Unadjusted,
-                bool exCouponEndOfMonth = false) {
-            return new CPIBondPtr(
-                new CPIBond(settlementDays, faceAmount, growthOnly, baseCPI,
-                            observationLag, cpiIndex, observationInterpolation,
-                            schedule, coupons, accrualDayCounter,
-                            paymentConvention, issueDate, paymentCalendar,
-                            exCouponPeriod, exCouponCalendar,
-                            exCouponConvention, exCouponEndOfMonth));
-        }
-    }
+    CPIBond(
+            Natural settlementDays,
+            Real faceAmount,
+            bool growthOnly,
+            Real baseCPI,
+            const Period& observationLag,
+            const boost::shared_ptr<ZeroInflationIndex>& cpiIndex,
+            CPI::InterpolationType observationInterpolation,
+            const Schedule& schedule,
+            const std::vector<Rate>& coupons,
+            const DayCounter& accrualDayCounter,
+            BusinessDayConvention paymentConvention = ModifiedFollowing,
+            const Date& issueDate = Date(),
+            const Calendar& paymentCalendar = Calendar(),
+            const Period& exCouponPeriod = Period(),
+            const Calendar& exCouponCalendar = Calendar(),
+            BusinessDayConvention exCouponConvention = Unadjusted,
+            bool exCouponEndOfMonth = false);
 };
 
 

--- a/SWIG/calibrationhelpers.i
+++ b/SWIG/calibrationhelpers.i
@@ -211,10 +211,11 @@ namespace std {
 // the base class for calibrated models
 %{
 using QuantLib::CalibratedModel;
+using QuantLib::TermStructureConsistentModel;
 %}
 
-%ignore CalibratedModel;
-class CalibratedModel {
+%shared_ptr(CalibratedModel)
+class CalibratedModel : public virtual Observable{
     #if defined(SWIGRUBY)
     %rename("calibrate!") calibrate;
     #elif defined(SWIGCSHARP)
@@ -222,18 +223,32 @@ class CalibratedModel {
     #endif
   public:
     Array params() const;
-    void calibrate(
+    virtual void calibrate(
         const std::vector<boost::shared_ptr<CalibrationHelperBase> >&,
         OptimizationMethod&, const EndCriteria &,
         const Constraint& constraint = Constraint(),
-        const std::vector<Real>& weights = std::vector<Real>());
+        const std::vector<Real>& weights = std::vector<Real>(),
+        const std::vector<bool>& fixParameters = std::vector<bool>());
+     
     void setParams(const Array& params);
     Real value(const Array& params,
                const std::vector<boost::shared_ptr<CalibrationHelperBase> >&);
+    const boost::shared_ptr<Constraint>& constraint() const;
+    EndCriteria::Type endCriteria() const;
+    const Array& problemValues() const;
+    Integer functionEvaluation() const;
+  private:
+    CalibratedModel();
 };
 
+%shared_ptr(TermStructureConsistentModel)
+class TermStructureConsistentModel : public virtual Observable{
+  public:
+    const Handle<YieldTermStructure>& termStructure() const;
+  private:
+    TermStructureConsistentModel();
+};
 
-%template(CalibratedModel) boost::shared_ptr<CalibratedModel>;
 IsObservable(boost::shared_ptr<CalibratedModel>);
 
 %template(CalibratedModelHandle) Handle<CalibratedModel>;

--- a/SWIG/calibrationhelpers.i
+++ b/SWIG/calibrationhelpers.i
@@ -5,6 +5,7 @@
  Copyright (C) 2007 Luis Cota
  Copyright (C) 2016 Gouthaman Balaraman
  Copyright (C) 2016 Peter Caspers
+ Copyright (C) 2018 Matthias Lungwitz
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -41,192 +42,139 @@ using QuantLib::BlackCalibrationHelper;
 using QuantLib::SwaptionHelper;
 using QuantLib::CapHelper;
 using QuantLib::HestonModelHelper;
-typedef boost::shared_ptr<CalibrationHelperBase> BlackCalibrationHelperPtr;
-typedef boost::shared_ptr<CalibrationHelperBase> SwaptionHelperPtr;
-typedef boost::shared_ptr<CalibrationHelperBase> CapHelperPtr;
-typedef boost::shared_ptr<CalibrationHelperBase> HestonModelHelperPtr;
 %}
 
 // calibration helpers
-
-%ignore CalibrationHelperBase;
+%shared_ptr(CalibrationHelperBase)
 class CalibrationHelperBase {
   public:
 	Real calibrationError();
-};
-
-%template(CalibrationHelperBase) boost::shared_ptr<CalibrationHelperBase>;
-
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-%rename(_BlackCalibrationHelper) BlackCalibrationHelper;
-#else
-%ignore BlackCalibrationHelper;
-#endif
-class BlackCalibrationHelper : public CalibrationHelperBase {
   private:
-    BlackCalibrationHelper();
-  public:
-    enum CalibrationErrorType { RelativePriceError, PriceError, ImpliedVolError };
+    CalibrationHelperBase();
 };
 
-%rename(BlackCalibrationHelper) BlackCalibrationHelperPtr;
-class BlackCalibrationHelperPtr : public boost::shared_ptr<CalibrationHelperBase> {
+%shared_ptr(BlackCalibrationHelper)
+class BlackCalibrationHelper : public CalibrationHelperBase {
     #if defined(SWIGRUBY)
     %rename("pricingEngine=")      setPricingEngine;
     #endif
-  private:
-    BlackCalibrationHelperPtr();
   public:
-    %extend {
-        static const BlackCalibrationHelper::CalibrationErrorType RelativePriceError =
-            BlackCalibrationHelper::RelativePriceError;
-        static const BlackCalibrationHelper::CalibrationErrorType PriceError =
-            BlackCalibrationHelper::PriceError;
-        static const BlackCalibrationHelper::CalibrationErrorType ImpliedVolError =
-            BlackCalibrationHelper::ImpliedVolError;
-        void setPricingEngine(const boost::shared_ptr<PricingEngine>& engine) {
-            boost::dynamic_pointer_cast<BlackCalibrationHelper>(*self)
-                ->setPricingEngine(engine);
-        }
-        Real marketValue() const {
-            return boost::dynamic_pointer_cast<BlackCalibrationHelper>(*self)
-                ->marketValue();
-        }
-        Real modelValue() const {
-            return boost::dynamic_pointer_cast<BlackCalibrationHelper>(*self)
-                ->modelValue();
-        }
-        Volatility impliedVolatility(Real targetValue,
-                                     Real accuracy, Size maxEvaluations,
-                                     Volatility minVol, Volatility maxVol) {
-            return boost::dynamic_pointer_cast<BlackCalibrationHelper>(*self)
-                ->impliedVolatility(targetValue, accuracy, maxEvaluations,
-                                    minVol, maxVol);
-        }
-        Real blackPrice(Volatility volatility) {
-            return boost::dynamic_pointer_cast<BlackCalibrationHelper>(*self)
-                ->blackPrice(volatility);
-        }
-        Handle<Quote> volatility() const {
-            return boost::dynamic_pointer_cast<BlackCalibrationHelper>(*self)
-                ->volatility();
-        }
-        VolatilityType volatilityType() const {
-            return boost::dynamic_pointer_cast<BlackCalibrationHelper>(*self)
-                ->volatilityType();
-        }
+    enum CalibrationErrorType { RelativePriceError, PriceError, ImpliedVolError };
+                       
+    void setPricingEngine(const boost::shared_ptr<PricingEngine>& engine);
+    Real marketValue() const;
+    virtual Real modelValue() const;
+    Volatility impliedVolatility(Real targetValue,
+                                 Real accuracy, Size maxEvaluations,
+                                 Volatility minVol, Volatility maxVol);
+    Real blackPrice(Volatility volatility);
+    Handle<Quote> volatility() const;
+    VolatilityType volatilityType() const;
+    Real calibrationError();
+  private:
+    BlackCalibrationHelper();
 
-        Date swaptionExpiryDate() {
-            boost::shared_ptr<SwaptionHelper> s =
-                boost::dynamic_pointer_cast<SwaptionHelper>(*self);
-            return s ? s->swaption()->exercise()->date(0) : Null<Date>();
-        }
-        Real swaptionStrike() {
-            boost::shared_ptr<SwaptionHelper> s =
-                boost::dynamic_pointer_cast<SwaptionHelper>(*self);
-            return s ? s->swaption()->underlyingSwap()->fixedRate() : Null<Real>();
-        }
-        Real swaptionNominal() {
-            boost::shared_ptr<SwaptionHelper> s =
-                boost::dynamic_pointer_cast<SwaptionHelper>(*self);
-            return s ? s->swaption()->underlyingSwap()->nominal() : Null<Real>();
-        }
-        Date swaptionMaturityDate() {
-            boost::shared_ptr<SwaptionHelper> s =
-                boost::dynamic_pointer_cast<SwaptionHelper>(*self);
-            return s ? s->swaption()->underlyingSwap()->fixedSchedule().dates().back() : Null<Date>();
-        }
-    }
 };
 
 deprecate_feature(CalibrationHelper,
                   BlackCalibrationHelper);
 
 %inline %{
-    BlackCalibrationHelperPtr as_black_helper(const boost::shared_ptr<CalibrationHelperBase>& h) {
+    boost::shared_ptr<BlackCalibrationHelper> as_black_helper(const boost::shared_ptr<CalibrationHelperBase>& h) {
         return boost::dynamic_pointer_cast<BlackCalibrationHelper>(h);
+    }
+    boost::shared_ptr<SwaptionHelper> as_swaption_helper(const boost::shared_ptr<BlackCalibrationHelper>& h) {
+        return boost::dynamic_pointer_cast<SwaptionHelper>(h);
     }
 %}
 
-%rename(SwaptionHelper) SwaptionHelperPtr;
-class SwaptionHelperPtr : public BlackCalibrationHelperPtr {
+%shared_ptr(SwaptionHelper)
+class SwaptionHelper : public BlackCalibrationHelper {
   public:
+    SwaptionHelper(const Period& maturity, const Period& length,
+                      const Handle<Quote>& volatility,
+                      const boost::shared_ptr<IborIndex>& index,
+                      const Period& fixedLegTenor,
+                      const DayCounter& fixedLegDayCounter,
+                      const DayCounter& floatingLegDayCounter,
+                      const Handle<YieldTermStructure>& termStructure,
+                      BlackCalibrationHelper::CalibrationErrorType errorType
+                                = BlackCalibrationHelper::RelativePriceError,
+                      const Real strike = Null<Real>(),
+                      const Real nominal = 1.0,
+                      const VolatilityType type = ShiftedLognormal,
+                      const Real shift = 0.0);
+    
+    SwaptionHelper(const Date& exerciseDate, const Period& length,
+                      const Handle<Quote>& volatility,
+                      const boost::shared_ptr<IborIndex>& index,
+                      const Period& fixedLegTenor,
+                      const DayCounter& fixedLegDayCounter,
+                      const DayCounter& floatingLegDayCounter,
+                      const Handle<YieldTermStructure>& termStructure,
+                      BlackCalibrationHelper::CalibrationErrorType errorType
+                                = BlackCalibrationHelper::RelativePriceError,
+                      const Real strike = Null<Real>(),
+                      const Real nominal = 1.0,
+                      const VolatilityType type = ShiftedLognormal,
+                      const Real shift = 0.0);
+    
+    SwaptionHelper(const Date& exerciseDate, const Date& endDate,
+                      const Handle<Quote>& volatility,
+                      const boost::shared_ptr<IborIndex>& index,
+                      const Period& fixedLegTenor,
+                      const DayCounter& fixedLegDayCounter,
+                      const DayCounter& floatingLegDayCounter,
+                      const Handle<YieldTermStructure>& termStructure,
+                      BlackCalibrationHelper::CalibrationErrorType errorType
+                                = BlackCalibrationHelper::RelativePriceError,
+                      const Real strike = Null<Real>(),
+                      const Real nominal = 1.0,
+                      const VolatilityType type = ShiftedLognormal,
+                      const Real shift = 0.0);
+
+    boost::shared_ptr<VanillaSwap> underlyingSwap() const;
+    boost::shared_ptr<Swaption> swaption() const;
+                      
     %extend {
-        SwaptionHelperPtr(const Period& maturity, const Period& length,
-                          const Handle<Quote>& volatility,
-                          const boost::shared_ptr<IborIndex>& index,
-                          const Period& fixedLegTenor,
-                          const DayCounter& fixedLegDayCounter,
-                          const DayCounter& floatingLegDayCounter,
-                          const Handle<YieldTermStructure>& termStructure,
-                          BlackCalibrationHelper::CalibrationErrorType errorType
-                                    = BlackCalibrationHelper::RelativePriceError,
-                          const Real strike = Null<Real>(),
-                          const Real nominal = 1.0,
-                          const VolatilityType type = ShiftedLognormal,
-                          const Real shift = 0.0) {
-            return new SwaptionHelperPtr(
-                new SwaptionHelper(maturity,length,volatility,
-                                   index,fixedLegTenor,
-                                   fixedLegDayCounter,
-                                   floatingLegDayCounter,
-                                   termStructure,
-                                   errorType,
-                                   strike, nominal, 
-                                   type, shift));
-        }
-        
-        SwaptionHelperPtr(const Date& exerciseDate, const Period& length,
-                          const Handle<Quote>& volatility,
-                          const boost::shared_ptr<IborIndex>& index,
-                          const Period& fixedLegTenor,
-                          const DayCounter& fixedLegDayCounter,
-                          const DayCounter& floatingLegDayCounter,
-                          const Handle<YieldTermStructure>& termStructure,
-                          BlackCalibrationHelper::CalibrationErrorType errorType
-                                    = BlackCalibrationHelper::RelativePriceError,
-                          const Real strike = Null<Real>(),
-                          const Real nominal = 1.0,
-                          const VolatilityType type = ShiftedLognormal,
-                          const Real shift = 0.0) {
-            return new SwaptionHelperPtr(
-                new SwaptionHelper(exerciseDate,length,volatility,
-                                   index,fixedLegTenor,
-                                   fixedLegDayCounter,
-                                   floatingLegDayCounter,
-                                   termStructure,
-                                   errorType,
-                                   strike, nominal, 
-                                   type, shift));
-        }
-        
-        SwaptionHelperPtr(const Date& exerciseDate, const Date& endDate,
-                          const Handle<Quote>& volatility,
-                          const boost::shared_ptr<IborIndex>& index,
-                          const Period& fixedLegTenor,
-                          const DayCounter& fixedLegDayCounter,
-                          const DayCounter& floatingLegDayCounter,
-                          const Handle<YieldTermStructure>& termStructure,
-                          BlackCalibrationHelper::CalibrationErrorType errorType
-                                    = BlackCalibrationHelper::RelativePriceError,
-                          const Real strike = Null<Real>(),
-                          const Real nominal = 1.0,
-                          const VolatilityType type = ShiftedLognormal,
-                          const Real shift = 0.0) {
-            return new SwaptionHelperPtr(
-                new SwaptionHelper(exerciseDate,endDate,volatility,
-                                   index,fixedLegTenor,
-                                   fixedLegDayCounter,
-                                   floatingLegDayCounter,
-                                   termStructure,
-                                   errorType,
-                                   strike, nominal, 
-                                   type, shift));
-        }
-        
         std::vector<Time> times() {
             std::list<Time> l;
-            boost::dynamic_pointer_cast<BlackCalibrationHelper>(*self)->addTimesTo(l);
+            self->addTimesTo(l);
+            std::vector<Time> v;
+            std::copy(l.begin(),l.end(),std::back_inserter(v));
+            return v;
+        }
+        Date swaptionExpiryDate() {
+            return self->swaption()->exercise()->date(0);
+        }
+        Real swaptionStrike() {
+            return self->swaption()->underlyingSwap()->fixedRate();
+        }
+        Real swaptionNominal() {
+            return self->swaption()->underlyingSwap()->nominal();
+        }
+        Date swaptionMaturityDate() {
+            return self->swaption()->underlyingSwap()->fixedSchedule().dates().back();
+        }
+    }
+};
+
+%shared_ptr(CapHelper)
+class CapHelper : public BlackCalibrationHelper {
+  public:
+    CapHelper(const Period& length,
+                 const Handle<Quote>& volatility,
+                 const boost::shared_ptr<IborIndex>& index,
+                 Frequency fixedLegFrequency,
+                 const DayCounter& fixedLegDayCounter,
+                 bool includeFirstSwaplet,
+                 const Handle<YieldTermStructure>& termStructure,
+                 BlackCalibrationHelper::CalibrationErrorType errorType
+                                = BlackCalibrationHelper::RelativePriceError);
+    %extend {        
+        std::vector<Time> times() {
+            std::list<Time> l;
+            self->addTimesTo(l);
             std::vector<Time> v;
             std::copy(l.begin(),l.end(),std::back_inserter(v));
             return v;
@@ -234,62 +182,30 @@ class SwaptionHelperPtr : public BlackCalibrationHelperPtr {
     }
 };
 
-%rename(CapHelper) CapHelperPtr;
-class CapHelperPtr : public BlackCalibrationHelperPtr {
+%shared_ptr(HestonModelHelper)
+class HestonModelHelper : public BlackCalibrationHelper {
   public:
-    %extend {
-        CapHelperPtr(const Period& length,
-                     const Handle<Quote>& volatility,
-                     const boost::shared_ptr<IborIndex>& index,
-                     Frequency fixedLegFrequency,
-                     const DayCounter& fixedLegDayCounter,
-                     bool includeFirstSwaplet,
-                     const Handle<YieldTermStructure>& termStructure,
-                     BlackCalibrationHelper::CalibrationErrorType errorType
-                                    = BlackCalibrationHelper::RelativePriceError) {
-            return new CapHelperPtr(
-                new CapHelper(length,volatility,index,fixedLegFrequency,
-                              fixedLegDayCounter,includeFirstSwaplet,
-                              termStructure));
-        }
-        std::vector<Time> times() {
-            std::list<Time> l;
-            boost::dynamic_pointer_cast<BlackCalibrationHelper>(*self)->addTimesTo(l);
-            std::vector<Time> v;
-            std::copy(l.begin(),l.end(),std::back_inserter(v));
-            return v;
-        }
-    }
-};
-
-%rename(HestonModelHelper) HestonModelHelperPtr;
-class HestonModelHelperPtr : public BlackCalibrationHelperPtr {
-  public:
-	%extend {
-		HestonModelHelperPtr(const Period& maturity,
-                             const Calendar& calendar,
-                             const Real s0,
-                             const Real strikePrice,
-                             const Handle<Quote>& volatility,
-                             const Handle<YieldTermStructure>& riskFreeRate,
-                             const Handle<YieldTermStructure>& dividendYield,
-                             BlackCalibrationHelper::CalibrationErrorType errorType
-								 = BlackCalibrationHelper::RelativePriceError) {
-			return new HestonModelHelperPtr(
-				new HestonModelHelper(maturity, calendar, s0, strikePrice,
-									  volatility, riskFreeRate, dividendYield,
-									  errorType)); 
-		}
-	}
+    HestonModelHelper(const Period& maturity,
+                      const Calendar& calendar,
+                      const Real s0,
+                      const Real strikePrice,
+                      const Handle<Quote>& volatility,
+                      const Handle<YieldTermStructure>& riskFreeRate,
+                      const Handle<YieldTermStructure>& dividendYield,
+                      BlackCalibrationHelper::CalibrationErrorType errorType
+                          = BlackCalibrationHelper::RelativePriceError);
 };
 
 // allow use of vectors of helpers
 #if defined(SWIGCSHARP)
 SWIG_STD_VECTOR_ENHANCED( boost::shared_ptr<CalibrationHelperBase> )
+SWIG_STD_VECTOR_ENHANCED( boost::shared_ptr<BlackCalibrationHelper> )
 #endif
 namespace std {
     %template(CalibrationHelperVector)
         vector<boost::shared_ptr<CalibrationHelperBase> >;
+    %template(BlackCalibrationHelperVector)
+        vector<boost::shared_ptr<BlackCalibrationHelper> >;        
 }
 
 // the base class for calibrated models

--- a/SWIG/capfloor.i
+++ b/SWIG/capfloor.i
@@ -51,7 +51,7 @@ class CapFloor : public Instrument {
     Date startDate() const;
     Date maturityDate() const;
 
-    Rate atmRate(const boost::shared_ptr<YieldTermStructure>& discountCurve);
+    Rate atmRate(const YieldTermStructure& discountCurve) const;
 };
 
 

--- a/SWIG/capfloor.i
+++ b/SWIG/capfloor.i
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
+ Copyright (C) 2018 Matthias Lungwitz
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -29,88 +30,51 @@ using QuantLib::CapFloor;
 using QuantLib::Cap;
 using QuantLib::Floor;
 using QuantLib::Collar;
-
-typedef boost::shared_ptr<Instrument> CapFloorPtr;
-typedef boost::shared_ptr<Instrument> CapPtr;
-typedef boost::shared_ptr<Instrument> FloorPtr;
-typedef boost::shared_ptr<Instrument> CollarPtr;
 %}
 
-%rename(CapFloor) CapFloorPtr;
-class CapFloorPtr : public boost::shared_ptr<Instrument> {
+%shared_ptr(CapFloor)
+class CapFloor : public Instrument {
   public:
-     %extend {
-        Volatility impliedVolatility(Real price,
-                                     const Handle<YieldTermStructure>& disc,
-                                     Volatility guess,
-                                     Real accuracy = 1.0e-4,
-                                     Natural maxEvaluations = 100,
-                                     Volatility minVol = 1.0e-7,
-                                     Volatility maxVol = 4.0,
-                                     VolatilityType type = ShiftedLognormal,
-                                     Real displacement = 0.0) const {
-            return boost::dynamic_pointer_cast<CapFloor>(*self)->
-                impliedVolatility(price, disc, guess, accuracy,
-                                  maxEvaluations, minVol, maxVol,
-                                  type, displacement);
-        }
-        const Leg& floatingLeg() const {
-            return boost::dynamic_pointer_cast<CapFloor>(*self)->floatingLeg();
-        }
+    Volatility impliedVolatility(Real price,
+                                 const Handle<YieldTermStructure>& disc,
+                                 Volatility guess,
+                                 Real accuracy = 1.0e-4,
+                                 Natural maxEvaluations = 100,
+                                 Volatility minVol = 1.0e-7,
+                                 Volatility maxVol = 4.0,
+                                 VolatilityType type = ShiftedLognormal,
+                                 Real displacement = 0.0) const;
+    const Leg& floatingLeg() const;
 
-        const std::vector<Rate>& capRates() const {
-            return boost::dynamic_pointer_cast<CapFloor>(*self)->capRates();
-        }
-        const std::vector<Rate>& floorRates() const {
-            return boost::dynamic_pointer_cast<CapFloor>(*self)->floorRates();
-        }
-        Date startDate() const {
-            return boost::dynamic_pointer_cast<CapFloor>(*self)->startDate();
-        }
-        Date maturityDate() const {
-            return boost::dynamic_pointer_cast<CapFloor>(*self)->maturityDate();
-        }
+    const std::vector<Rate>& capRates();
+    const std::vector<Rate>& floorRates();
+    Date startDate() const;
+    Date maturityDate() const;
 
-        Rate atmRate(const boost::shared_ptr<YieldTermStructure>& discountCurve) const {
-            return boost::dynamic_pointer_cast<CapFloor>(*self)->atmRate(*discountCurve);
-        }
-    }
+    Rate atmRate(const boost::shared_ptr<YieldTermStructure>& discountCurve);
 };
 
 
-
-%rename(Cap) CapPtr;
-class CapPtr : public CapFloorPtr {
+%shared_ptr(Cap)
+class Cap : public CapFloor {
   public:
-    %extend {
-        CapPtr(const std::vector<boost::shared_ptr<CashFlow> >& leg,
-               const std::vector<Rate>& capRates) {
-            return new CapPtr(new Cap(leg,capRates));
-        }
-    }
+    Cap(const std::vector<boost::shared_ptr<CashFlow> >& leg,
+           const std::vector<Rate>& capRates);
 };
 
-%rename(Floor) FloorPtr;
-class FloorPtr : public CapFloorPtr {
+%shared_ptr(Floor)
+class Floor : public CapFloor {
   public:
-    %extend {
-        FloorPtr(const std::vector<boost::shared_ptr<CashFlow> >& leg,
-                 const std::vector<Rate>& floorRates) {
-            return new FloorPtr(new Floor(leg,floorRates));
-        }
-    }
+    Floor(const std::vector<boost::shared_ptr<CashFlow> >& leg,
+             const std::vector<Rate>& floorRates);
 };
 
-%rename(Collar) CollarPtr;
-class CollarPtr : public CapFloorPtr {
+%shared_ptr(Collar)
+class Collar : public CapFloor {
   public:
-    %extend {
-        CollarPtr(const std::vector<boost::shared_ptr<CashFlow> >& leg,
-                  const std::vector<Rate>& capRates,
-                  const std::vector<Rate>& floorRates) {
-            return new CollarPtr(new Collar(leg,capRates,floorRates));
-        }
-    }
+    Collar(const std::vector<boost::shared_ptr<CashFlow> >& leg,
+              const std::vector<Rate>& capRates,
+              const std::vector<Rate>& floorRates);
 };
 
 %{

--- a/SWIG/convertiblebonds.i
+++ b/SWIG/convertiblebonds.i
@@ -1,6 +1,7 @@
 
 /*
  Copyright (C) 2006, 2007 StatPro Italia srl
+ Copyright (C) 2018 Matthias Lungwitz
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -127,40 +128,36 @@ class BinomialConvertibleEnginePtr : public boost::shared_ptr<PricingEngine> {
   public:
     %extend {
         BinomialConvertibleEnginePtr(
-                             const GeneralizedBlackScholesProcessPtr& process,
+                             const boost::shared_ptr<GeneralizedBlackScholesProcess>& process,
                              const std::string& type,
                              Size steps) {
-            boost::shared_ptr<GeneralizedBlackScholesProcess> bsProcess =
-                 boost::dynamic_pointer_cast<GeneralizedBlackScholesProcess>(
-                                                                     process);
-            QL_REQUIRE(bsProcess, "Black-Scholes process required");
             std::string s = boost::algorithm::to_lower_copy(type);
             if (s == "crr" || s == "coxrossrubinstein")
                 return new BinomialConvertibleEnginePtr(
                     new BinomialConvertibleEngine<CoxRossRubinstein>(
-                                                            bsProcess,steps));
+                                                            process,steps));
             else if (s == "jr" || s == "jarrowrudd")
                 return new BinomialConvertibleEnginePtr(
                     new BinomialConvertibleEngine<JarrowRudd>(
-                                                            bsProcess,steps));
+                                                            process,steps));
             else if (s == "eqp")
                 return new BinomialConvertibleEnginePtr(
                     new BinomialConvertibleEngine<AdditiveEQPBinomialTree>(
-                                                            bsProcess,steps));
+                                                            process,steps));
             else if (s == "trigeorgis")
                 return new BinomialConvertibleEnginePtr(
                     new BinomialConvertibleEngine<Trigeorgis>(
-                                                            bsProcess,steps));
+                                                            process,steps));
             else if (s == "tian")
                 return new BinomialConvertibleEnginePtr(
-                    new BinomialConvertibleEngine<Tian>(bsProcess,steps));
+                    new BinomialConvertibleEngine<Tian>(process,steps));
             else if (s == "lr" || s == "leisenreimer")
                 return new BinomialConvertibleEnginePtr(
                     new BinomialConvertibleEngine<LeisenReimer>(
-                                                            bsProcess,steps));
+                                                            process,steps));
             else if (s == "j4" || s == "joshi4")
                 return new BinomialConvertibleEnginePtr(
-                    new BinomialConvertibleEngine<Joshi4>(bsProcess,steps));
+                    new BinomialConvertibleEngine<Joshi4>(process,steps));
             else
                 QL_FAIL("unknown binomial engine type: "+s);
         }

--- a/SWIG/convertiblebonds.i
+++ b/SWIG/convertiblebonds.i
@@ -30,95 +30,61 @@ using QuantLib::ConvertibleZeroCouponBond;
 using QuantLib::ConvertibleFixedCouponBond;
 using QuantLib::ConvertibleFloatingRateBond;
 using QuantLib::BinomialConvertibleEngine;
-typedef boost::shared_ptr<Instrument> ConvertibleZeroCouponBondPtr;
-typedef boost::shared_ptr<Instrument> ConvertibleFixedCouponBondPtr;
-typedef boost::shared_ptr<Instrument> ConvertibleFloatingRateBondPtr;
 typedef boost::shared_ptr<PricingEngine> BinomialConvertibleEnginePtr;
 %}
 
-%rename(ConvertibleZeroCouponBond) ConvertibleZeroCouponBondPtr;
-class ConvertibleZeroCouponBondPtr : public BondPtr {
+%shared_ptr(ConvertibleZeroCouponBond)
+class ConvertibleZeroCouponBond : public Bond {
   public:
-    %extend {
-        ConvertibleZeroCouponBondPtr(
-              const boost::shared_ptr<Exercise>& exercise,
-              Real conversionRatio,
-              const std::vector<boost::shared_ptr<Dividend> >& dividends,
-              const std::vector<boost::shared_ptr<Callability> >& callability,
-              const Handle<Quote>& creditSpread,
-              const Date& issueDate,
-              Integer settlementDays,
-              const DayCounter& dayCounter,
-              const Schedule& schedule,
-              Real redemption = 100.0) {
-            return new ConvertibleZeroCouponBondPtr(
-                     new ConvertibleZeroCouponBond(exercise, conversionRatio,
-                                                   dividends, callability,
-                                                   creditSpread,
-                                                   issueDate, settlementDays,
-                                                   dayCounter, schedule,
-                                                   redemption));
-        }
-    }
+    ConvertibleZeroCouponBond(
+          const boost::shared_ptr<Exercise>& exercise,
+          Real conversionRatio,
+          const std::vector<boost::shared_ptr<Dividend> >& dividends,
+          const std::vector<boost::shared_ptr<Callability> >& callability,
+          const Handle<Quote>& creditSpread,
+          const Date& issueDate,
+          Integer settlementDays,
+          const DayCounter& dayCounter,
+          const Schedule& schedule,
+          Real redemption = 100.0);
 };
 
 
-%rename(ConvertibleFixedCouponBond) ConvertibleFixedCouponBondPtr;
-class ConvertibleFixedCouponBondPtr : public BondPtr {
+%shared_ptr(ConvertibleFixedCouponBond)
+class ConvertibleFixedCouponBond : public Bond {
   public:
-    %extend {
-        ConvertibleFixedCouponBondPtr(
-              const boost::shared_ptr<Exercise>& exercise,
-              Real conversionRatio,
-              const std::vector<boost::shared_ptr<Dividend> >& dividends,
-              const std::vector<boost::shared_ptr<Callability> >& callability,
-              const Handle<Quote>& creditSpread,
-              const Date& issueDate,
-              Integer settlementDays,
-              const std::vector<Rate>& coupons,
-              const DayCounter& dayCounter,
-              const Schedule& schedule,
-              Real redemption = 100.0) {
-            return new ConvertibleFixedCouponBondPtr(
-                    new ConvertibleFixedCouponBond(exercise, conversionRatio,
-                                                   dividends, callability,
-                                                   creditSpread,
-                                                   issueDate, settlementDays,
-                                                   coupons, dayCounter,
-                                                   schedule, redemption));
-        }
-    }
+    ConvertibleFixedCouponBond(
+          const boost::shared_ptr<Exercise>& exercise,
+          Real conversionRatio,
+          const std::vector<boost::shared_ptr<Dividend> >& dividends,
+          const std::vector<boost::shared_ptr<Callability> >& callability,
+          const Handle<Quote>& creditSpread,
+          const Date& issueDate,
+          Integer settlementDays,
+          const std::vector<Rate>& coupons,
+          const DayCounter& dayCounter,
+          const Schedule& schedule,
+          Real redemption = 100.0);
 };
 
 
-%rename(ConvertibleFloatingRateBond) ConvertibleFloatingRateBondPtr;
-class ConvertibleFloatingRateBondPtr : public BondPtr {
+%shared_ptr(ConvertibleFloatingRateBond)
+class ConvertibleFloatingRateBond : public Bond {
   public:
-    %extend {
-        ConvertibleFloatingRateBondPtr(
-              const boost::shared_ptr<Exercise>& exercise,
-              Real conversionRatio,
-              const std::vector<boost::shared_ptr<Dividend> >& dividends,
-              const std::vector<boost::shared_ptr<Callability> >& callability,
-              const Handle<Quote>& creditSpread,
-              const Date& issueDate,
-              Integer settlementDays,
-              const boost::shared_ptr<IborIndex>& index,
-              Integer fixingDays,
-              const std::vector<Spread>& spreads,
-              const DayCounter& dayCounter,
-              const Schedule& schedule,
-              Real redemption = 100.0) {
-            return new ConvertibleFloatingRateBondPtr(
-                   new ConvertibleFloatingRateBond(exercise, conversionRatio,
-                                                   dividends, callability,
-                                                   creditSpread,
-                                                   issueDate, settlementDays,
-                                                   index, fixingDays, spreads,
-                                                   dayCounter, schedule,
-                                                   redemption));
-        }
-    }
+    ConvertibleFloatingRateBond(
+          const boost::shared_ptr<Exercise>& exercise,
+          Real conversionRatio,
+          const std::vector<boost::shared_ptr<Dividend> >& dividends,
+          const std::vector<boost::shared_ptr<Callability> >& callability,
+          const Handle<Quote>& creditSpread,
+          const Date& issueDate,
+          Integer settlementDays,
+          const boost::shared_ptr<IborIndex>& index,
+          Integer fixingDays,
+          const std::vector<Spread>& spreads,
+          const DayCounter& dayCounter,
+          const Schedule& schedule,
+          Real redemption = 100.0);
 };
 
 

--- a/SWIG/creditdefaultswap.i
+++ b/SWIG/creditdefaultswap.i
@@ -78,9 +78,7 @@ class FaceValueClaimPtr : public boost::shared_ptr<Claim> {
 class FaceValueAccrualClaimPtr : public boost::shared_ptr<Claim> {
   public:
     %extend {
-        FaceValueAccrualClaimPtr(const BondPtr& referenceSecurity) {
-            boost::shared_ptr<Bond> bond =
-                boost::dynamic_pointer_cast<Bond>(referenceSecurity);
+        FaceValueAccrualClaimPtr(const boost::shared_ptr<Bond>& bond) {
             return new FaceValueAccrualClaimPtr(new FaceValueAccrualClaim(bond));
         }
     }

--- a/SWIG/creditdefaultswap.i
+++ b/SWIG/creditdefaultswap.i
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2008, 2009 StatPro Italia srl
+ Copyright (C) 2018 Matthias Lungwitz
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -33,27 +34,12 @@ using QuantLib::Claim;
 using QuantLib::FaceValueClaim;
 using QuantLib::FaceValueAccrualClaim;
 
-typedef boost::shared_ptr<Instrument> CreditDefaultSwapPtr;
 typedef boost::shared_ptr<PricingEngine> MidPointCdsEnginePtr;
 typedef boost::shared_ptr<PricingEngine> IntegralCdsEnginePtr;
 typedef boost::shared_ptr<PricingEngine> IsdaCdsEnginePtr;
 typedef boost::shared_ptr<Claim> FaceValueClaimPtr;
 typedef boost::shared_ptr<Claim> FaceValueAccrualClaimPtr;
 %}
-
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-%rename(_CreditDefaultSwap) CreditDefaultSwap;
-#else
-%ignore CreditDefaultSwap;
-#endif
-class CreditDefaultSwap {
-  public:
-    enum PricingModel {Midpoint, ISDA};
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-  private:
-    CreditDefaultSwap();
-#endif
-};
 
 %ignore Claim;
 class Claim {
@@ -84,132 +70,70 @@ class FaceValueAccrualClaimPtr : public boost::shared_ptr<Claim> {
     }
 };
 
-
-%rename(CreditDefaultSwap) CreditDefaultSwapPtr;
-class CreditDefaultSwapPtr : public boost::shared_ptr<Instrument> {
+%shared_ptr(CreditDefaultSwap)
+class CreditDefaultSwap : public Instrument {
   public:
-    %extend {
-        static const CreditDefaultSwap::PricingModel Midpoint = CreditDefaultSwap::Midpoint;
-        static const CreditDefaultSwap::PricingModel ISDA = CreditDefaultSwap::ISDA;
+    enum PricingModel {
+        Midpoint,
+        ISDA
+    };
 
-        CreditDefaultSwapPtr(Protection::Side side,
-                             Real notional,
-                             Rate spread,
-                             const Schedule& schedule,
-                             BusinessDayConvention paymentConvention,
-                             const DayCounter& dayCounter,
-                             bool settlesAccrual = true,
-                             bool paysAtDefaultTime = true,
-                             const Date& protectionStart = Date()) {
-            return new CreditDefaultSwapPtr(
-                    new CreditDefaultSwap(side, notional, spread, schedule,
-                                          paymentConvention, dayCounter,
-                                          settlesAccrual, paysAtDefaultTime,
-                                          protectionStart));
-        }
-        CreditDefaultSwapPtr(Protection::Side side,
-                             Real notional,
-                             Rate upfront,
-                             Rate spread,
-                             const Schedule& schedule,
-                             BusinessDayConvention paymentConvention,
-                             const DayCounter& dayCounter,
-                             bool settlesAccrual = true,
-                             bool paysAtDefaultTime = true,
-                             const Date& protectionStart = Date(),
-                             const Date& upfrontDate = Date(),
-                             const boost::shared_ptr<Claim>& claim =
-                                                        boost::shared_ptr<Claim>(),
-                             const DayCounter& lastPeriodDayCounter = DayCounter(),
-                             const bool rebatesAccrual = true) {
-            return new CreditDefaultSwapPtr(
-                    new CreditDefaultSwap(side, notional, upfront, spread,
-                                          schedule, paymentConvention,
-                                          dayCounter, settlesAccrual,
-                                          paysAtDefaultTime,
-                                          protectionStart,
-                                          upfrontDate,claim,
-                                          lastPeriodDayCounter,rebatesAccrual));
-        }
-        Protection::Side side() const {
-            return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->side();
-        }
-        Real notional() const {
-            return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->notional();
-        }
-        Rate runningSpread() const {
-            return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->runningSpread();
-        }
-        doubleOrNull upfront() const {
+    CreditDefaultSwap(Protection::Side side,
+                         Real notional,
+                         Rate spread,
+                         const Schedule& schedule,
+                         BusinessDayConvention paymentConvention,
+                         const DayCounter& dayCounter,
+                         bool settlesAccrual = true,
+                         bool paysAtDefaultTime = true,
+                         const Date& protectionStart = Date());
+    CreditDefaultSwap(Protection::Side side,
+                         Real notional,
+                         Rate upfront,
+                         Rate spread,
+                         const Schedule& schedule,
+                         BusinessDayConvention paymentConvention,
+                         const DayCounter& dayCounter,
+                         bool settlesAccrual = true,
+                         bool paysAtDefaultTime = true,
+                         const Date& protectionStart = Date(),
+                         const Date& upfrontDate = Date(),
+                         const boost::shared_ptr<Claim>& claim =
+                                                    boost::shared_ptr<Claim>(),
+                         const DayCounter& lastPeriodDayCounter = DayCounter(),
+                         const bool rebatesAccrual = true);
+    Protection::Side side() const;
+    Real notional() const;
+    Rate runningSpread() const;
+    %extend {
+    doubleOrNull upfront() const {
             boost::optional<Rate> result =
-                boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->upfront();
+                self->upfront();
             if (result)
                 return *result;
             else
                 return Null<double>();
         }
-        bool settlesAccrual() const {
-            return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->settlesAccrual();
-        }
-        bool paysAtDefaultTime() const {
-            return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->paysAtDefaultTime();
-        }
-        Rate fairSpread() const {
-            return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->fairSpread();
-        }
-        Rate fairUpfront() const {
-            return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->fairUpfront();
-        }
-        Real couponLegBPS() const {
-            return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->couponLegBPS();
-        }
-        Real couponLegNPV() const {
-            return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->couponLegNPV();
-        }
-        Real defaultLegNPV() const {
-            return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->defaultLegNPV();
-        }
-        Real upfrontBPS() const {
-            return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->upfrontBPS();
-        }
-        Real upfrontNPV() const {
-            return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->upfrontNPV();
-        }
-        Rate impliedHazardRate(Real targetNPV,
-                               const Handle<YieldTermStructure>& discountCurve,
-                               const DayCounter& dayCounter,
-                               Real recoveryRate = 0.4,
-                               Real accuracy = 1.0e-6,
-			       CreditDefaultSwap::PricingModel model = CreditDefaultSwap::Midpoint) const {
-            return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->impliedHazardRate(targetNPV, discountCurve, dayCounter,
-                                    recoveryRate, accuracy, model);
-        }
-        Rate conventionalSpread(Real conventionalRecovery,
-                const Handle<YieldTermStructure>& discountCurve,
-                const DayCounter& dayCounter) const{
-            return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->conventionalSpread(conventionalRecovery,discountCurve,
-                dayCounter) ;
-        }
-        std::vector<boost::shared_ptr<CashFlow> > coupons() {
-            return boost::dynamic_pointer_cast<CreditDefaultSwap>(*self)
-                ->coupons();
-        }
     }
+    bool settlesAccrual() const;
+    bool paysAtDefaultTime() const;
+    Rate fairSpread() const;
+    Rate fairUpfront() const;
+    Real couponLegBPS() const;
+    Real couponLegNPV() const;
+    Real defaultLegNPV() const;
+    Real upfrontBPS() const;
+    Real upfrontNPV() const;
+    Rate impliedHazardRate(Real targetNPV,
+                           const Handle<YieldTermStructure>& discountCurve,
+                           const DayCounter& dayCounter,
+                           Real recoveryRate = 0.4,
+                           Real accuracy = 1.0e-6,
+               CreditDefaultSwap::PricingModel model = CreditDefaultSwap::Midpoint) const;
+    Rate conventionalSpread(Real conventionalRecovery,
+            const Handle<YieldTermStructure>& discountCurve,
+            const DayCounter& dayCounter) const;
+    std::vector<boost::shared_ptr<CashFlow> > coupons();
 };
 
 

--- a/SWIG/defaultprobability.i
+++ b/SWIG/defaultprobability.i
@@ -257,13 +257,25 @@ export_survival_probability_curve(SurvivalProbabilityCurve,Linear);
 %{
 using QuantLib::DefaultProbabilityHelper;
 using QuantLib::SpreadCdsHelper;
-typedef boost::shared_ptr<DefaultProbabilityHelper> SpreadCdsHelperPtr;
 using QuantLib::UpfrontCdsHelper;
-typedef boost::shared_ptr<DefaultProbabilityHelper> UpfrontCdsHelperPtr;
 %}
 
 // rate helpers for curve bootstrapping
-%template(DefaultProbabilityHelper) boost::shared_ptr<DefaultProbabilityHelper>;
+
+%shared_ptr(DefaultProbabilityHelper)
+class DefaultProbabilityHelper : public Observable {
+  public:
+    Handle<Quote> quote() const;
+    Date latestDate() const;
+	Date earliestDate() const;
+	Date maturityDate() const;
+	Date latestRelevantDate() const;
+	Date pillarDate() const;
+	Real impliedQuote() const;
+	Real quoteError() const;
+  private:
+    DefaultProbabilityHelper();
+};
 
 #if defined(SWIGCSHARP)
 SWIG_STD_VECTOR_ENHANCED( boost::shared_ptr<DefaultProbabilityHelper> )
@@ -274,101 +286,71 @@ namespace std {
 }
 
 
-%rename(SpreadCdsHelper) SpreadCdsHelperPtr;
-class SpreadCdsHelperPtr : public boost::shared_ptr<DefaultProbabilityHelper> {
+%shared_ptr(SpreadCdsHelper)
+class SpreadCdsHelper : public DefaultProbabilityHelper {
   public:
-    %extend {
-        SpreadCdsHelperPtr(
-                const Handle<Quote>& spread,
-                const Period& tenor,
-                Integer settlementDays,
-                const Calendar& calendar,
-                Frequency frequency,
-                BusinessDayConvention convention,
-                DateGeneration::Rule rule,
-                const DayCounter& dayCounter,
-                Real recoveryRate,
-                const Handle<YieldTermStructure>& discountCurve,
-                bool settlesAccrual = true,
-                bool paysAtDefaultTime = true) {
-            return new SpreadCdsHelperPtr(
-                new SpreadCdsHelper(spread,tenor,settlementDays,calendar,
-                                    frequency,convention,rule,dayCounter,
-                                    recoveryRate,discountCurve,
-                                    settlesAccrual,paysAtDefaultTime));
-        }
-        SpreadCdsHelperPtr(
-                Rate spread,
-                const Period& tenor,
-                Integer settlementDays,
-                const Calendar& calendar,
-                Frequency frequency,
-                BusinessDayConvention convention,
-                DateGeneration::Rule rule,
-                const DayCounter& dayCounter,
-                Real recoveryRate,
-                const Handle<YieldTermStructure>& discountCurve,
-                bool settlesAccrual = true,
-                bool paysAtDefaultTime = true) {
-            return new SpreadCdsHelperPtr(
-                new SpreadCdsHelper(spread,tenor,settlementDays,calendar,
-                                    frequency,convention,rule,dayCounter,
-                                    recoveryRate,discountCurve,
-                                    settlesAccrual,paysAtDefaultTime));
-        }
-    }
+    SpreadCdsHelper(
+            const Handle<Quote>& spread,
+            const Period& tenor,
+            Integer settlementDays,
+            const Calendar& calendar,
+            Frequency frequency,
+            BusinessDayConvention convention,
+            DateGeneration::Rule rule,
+            const DayCounter& dayCounter,
+            Real recoveryRate,
+            const Handle<YieldTermStructure>& discountCurve,
+            bool settlesAccrual = true,
+            bool paysAtDefaultTime = true);
+    SpreadCdsHelper(
+            Rate spread,
+            const Period& tenor,
+            Integer settlementDays,
+            const Calendar& calendar,
+            Frequency frequency,
+            BusinessDayConvention convention,
+            DateGeneration::Rule rule,
+            const DayCounter& dayCounter,
+            Real recoveryRate,
+            const Handle<YieldTermStructure>& discountCurve,
+            bool settlesAccrual = true,
+            bool paysAtDefaultTime = true);
 };
 
 
-%rename(UpfrontCdsHelper) UpfrontCdsHelperPtr;
-class UpfrontCdsHelperPtr : public boost::shared_ptr<DefaultProbabilityHelper> {
+%shared_ptr(UpfrontCdsHelper)
+class UpfrontCdsHelper : public DefaultProbabilityHelper {
   public:
-    %extend {
-        UpfrontCdsHelperPtr(
-                const Handle<Quote>& upfront,
-                Rate spread,
-                const Period& tenor,
-                Integer settlementDays,
-                const Calendar& calendar,
-                Frequency frequency,
-                BusinessDayConvention convention,
-                DateGeneration::Rule rule,
-                const DayCounter& dayCounter,
-                Real recoveryRate,
-                const Handle<YieldTermStructure>& discountCurve,
-                Natural upfrontSettlementDays=0,
-                bool settlesAccrual = true,
-                bool paysAtDefaultTime = true) {
-            return new UpfrontCdsHelperPtr(
-                new UpfrontCdsHelper(upfront,spread,tenor,
-                                     settlementDays,calendar,
-                                     frequency,convention,rule,dayCounter,
-                                     recoveryRate,discountCurve,upfrontSettlementDays,
-                                     settlesAccrual,paysAtDefaultTime));
-        }
-        UpfrontCdsHelperPtr(
-                Rate upfront,
-                Rate spread,
-                const Period& tenor,
-                Integer settlementDays,
-                const Calendar& calendar,
-                Frequency frequency,
-                BusinessDayConvention convention,
-                DateGeneration::Rule rule,
-                const DayCounter& dayCounter,
-                Real recoveryRate,
-                const Handle<YieldTermStructure>& discountCurve,
-                Natural upfrontSettlementDays=0,
-                bool settlesAccrual = true,
-                bool paysAtDefaultTime = true) {
-            return new UpfrontCdsHelperPtr(
-                new UpfrontCdsHelper(upfront,spread,tenor,
-                                     settlementDays,calendar,
-                                     frequency,convention,rule,dayCounter,
-                                     recoveryRate,discountCurve,upfrontSettlementDays,
-                                     settlesAccrual,paysAtDefaultTime));
-        }
-    }
+    UpfrontCdsHelper(
+            const Handle<Quote>& upfront,
+            Rate spread,
+            const Period& tenor,
+            Integer settlementDays,
+            const Calendar& calendar,
+            Frequency frequency,
+            BusinessDayConvention convention,
+            DateGeneration::Rule rule,
+            const DayCounter& dayCounter,
+            Real recoveryRate,
+            const Handle<YieldTermStructure>& discountCurve,
+            Natural upfrontSettlementDays=0,
+            bool settlesAccrual = true,
+            bool paysAtDefaultTime = true);
+    UpfrontCdsHelper(
+            Rate upfront,
+            Rate spread,
+            const Period& tenor,
+            Integer settlementDays,
+            const Calendar& calendar,
+            Frequency frequency,
+            BusinessDayConvention convention,
+            DateGeneration::Rule rule,
+            const DayCounter& dayCounter,
+            Real recoveryRate,
+            const Handle<YieldTermStructure>& discountCurve,
+            Natural upfrontSettlementDays=0,
+            bool settlesAccrual = true,
+            bool paysAtDefaultTime = true);
 };
 
 

--- a/SWIG/exercise.i
+++ b/SWIG/exercise.i
@@ -2,6 +2,7 @@
 /*
  Copyright (C) 2003 StatPro Italia srl
  Copyright (C) 2016 Peter Caspers
+ Copyright (C) 2018 Matthias Lungwitz
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -21,6 +22,7 @@
 #define quantlib_exercise_i
 
 %include common.i
+%include boost_shared_ptr.i
 
 // exercise conditions
 
@@ -28,34 +30,19 @@
 using QuantLib::Exercise;
 %}
 
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-%rename(_Exercise) Exercise;
-#else
-%ignore Exercise;
-#endif
+%shared_ptr(Exercise)
 class Exercise {
   public:
-    enum Type { American, Bermudan, European };
-    Exercise::Type type() const;
-    const std::vector<Date>& dates() const;
-    Date lastDate() const { return dates_.back(); }
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-  private:
-    Exercise();
-#endif
+    enum Type {
+        American, Bermudan, European
+    };
+    explicit Exercise(Type type);
+    Type type() const;
+    Date date(Size index);
+    Date dateAt(Size index);
+    const std::vector<Date>& dates();
+    Date lastDate() const;
 };
-
-%template(Exercise) boost::shared_ptr<Exercise>;
-%extend boost::shared_ptr<Exercise> {
-    static const Exercise::Type American = Exercise::American;
-    static const Exercise::Type Bermudan = Exercise::Bermudan;
-    static const Exercise::Type European = Exercise::European;
-
-	Exercise::Type exerciseType() { 
-		return boost::dynamic_pointer_cast<Exercise>(*self)->type(); 
-	}
-}
-
 
 %{
 using QuantLib::EuropeanExercise;
@@ -63,50 +50,27 @@ using QuantLib::AmericanExercise;
 using QuantLib::BermudanExercise;
 using QuantLib::RebatedExercise;
 using QuantLib::SwingExercise;
-typedef boost::shared_ptr<Exercise> EuropeanExercisePtr;
-typedef boost::shared_ptr<Exercise> AmericanExercisePtr;
-typedef boost::shared_ptr<Exercise> BermudanExercisePtr;
-typedef boost::shared_ptr<Exercise> RebatedExercisePtr;
-typedef boost::shared_ptr<Exercise> SwingExercisePtr;
 %}
 
-%rename(EuropeanExercise) EuropeanExercisePtr;
-class EuropeanExercisePtr : public boost::shared_ptr<Exercise> {
+%shared_ptr(EuropeanExercise)
+class EuropeanExercise : public Exercise {
   public:
-    %extend {
-        EuropeanExercisePtr(const Date& date) {
-            return new EuropeanExercisePtr(new EuropeanExercise(date));
-        }
-	}
+    EuropeanExercise(const Date& date);
 };
 
-%rename(AmericanExercise) AmericanExercisePtr;
-class AmericanExercisePtr : public boost::shared_ptr<Exercise> {
+%shared_ptr(AmericanExercise)
+class AmericanExercise : public Exercise {
   public:
-    %extend {
-        AmericanExercisePtr(const Date& earliestDate,
-                            const Date& latestDate,
-                            bool payoffAtExpiry = false) {
-            return new AmericanExercisePtr(
-                                        new AmericanExercise(earliestDate,
-                                                             latestDate,
-                                                             payoffAtExpiry));
-
-        }
-    }
+    AmericanExercise(const Date& earliestDate,
+                        const Date& latestDate,
+                        bool payoffAtExpiry = false);
 };
 
-%rename(BermudanExercise) BermudanExercisePtr;
-class BermudanExercisePtr : public boost::shared_ptr<Exercise> {
+%shared_ptr(BermudanExercise)
+class BermudanExercise : public Exercise {
   public:
-    %extend {
-        BermudanExercisePtr(const std::vector<Date>& dates,
-                            bool payoffAtExpiry = false) {
-            return new BermudanExercisePtr(
-                                        new BermudanExercise(dates,
-                                                             payoffAtExpiry));
-        }
-    }
+    BermudanExercise(const std::vector<Date>& dates,
+                        bool payoffAtExpiry = false);
 };
 
 %{
@@ -116,32 +80,21 @@ using QuantLib::Following;
 using QuantLib::NullCalendar;
 %}
 
-%rename(RebatedExercise) RebatedExercisePtr;
-class RebatedExercisePtr : public boost::shared_ptr<Exercise> {
+%shared_ptr(RebatedExercise)
+class RebatedExercise : public Exercise {
   public:
-    %extend {
-        RebatedExercisePtr(const boost::shared_ptr<Exercise> exercise,
-                           const std::vector<Real> rebates,
-                           Natural rebateSettlementDays = 0,
-                           const Calendar &rebatePaymentCalendar = NullCalendar(),
-                           const BusinessDayConvention rebatePaymentConvention = Following) {
-            return new RebatedExercisePtr(new RebatedExercise(*exercise, rebates,
-                                                              rebateSettlementDays,
-                                                              rebatePaymentCalendar,
-                                                              rebatePaymentConvention));
-        }
-    }
+    RebatedExercise(const Exercise &exercise,
+                       const std::vector<Real> rebates,
+                       Natural rebateSettlementDays = 0,
+                       const Calendar &rebatePaymentCalendar = NullCalendar(),
+                       const BusinessDayConvention rebatePaymentConvention = Following);
 };
 
 
-%rename(SwingExercise) SwingExercisePtr;
-class SwingExercisePtr : public boost::shared_ptr<Exercise> {
+%shared_ptr(SwingExercise)
+class SwingExercise : public Exercise {
   public:
-    %extend {
-        SwingExercisePtr(const std::vector<Date>& dates) {
-            return new SwingExercisePtr(new SwingExercise(dates));
-        }
-    }
+    SwingExercise(const std::vector<Date>& dates);
 };
 
 #endif

--- a/SWIG/forward.i
+++ b/SWIG/forward.i
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2015 Gouthaman Balaraman
+ Copyright (C) 2018 Matthias Lungwitz 
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -22,35 +23,36 @@
 %include instruments.i
 %include termstructures.i
 %include interestrate.i
-%include fra.i
 
 // Forward
 %{
 using QuantLib::Forward;
-typedef boost::shared_ptr<Instrument> ForwardPtr;
 %}
 
-%rename(Forward) ForwardPtr;
-class ForwardPtr : public boost::shared_ptr<Instrument>{
+%shared_ptr(Forward)
+class Forward : public Instrument{
     public:
-        %extend {
-            // calculations
-            Real forwardValue() {
-                return boost::dynamic_pointer_cast<Forward>(*self)
-                    -> forwardValue();
-            }
-            InterestRate impliedYield(
-                            Real underlyingSpotValue,
-                            Real forwardValue,
-                            Date settlementDate,
-                            Compounding compoundingConvention,
-                            DayCounter dayCounter) {
-                    return boost::dynamic_pointer_cast<Forward>(*self)
-                        -> impliedYield(underlyingSpotValue, forwardValue,
-                                        settlementDate, compoundingConvention, 
-                                        dayCounter);
-                }
-        }
+        Date settlementDate() const;
+        bool isExpired() const;
+        const Calendar& calendar() const;
+        BusinessDayConvention businessDayConvention() const;
+        const DayCounter& dayCounter() const;
+        Handle<YieldTermStructure> discountCurve() const;
+        Handle<YieldTermStructure> incomeDiscountCurve() const;
+        Real spotValue() const;
+        Real spotIncome(const Handle<YieldTermStructure>&
+                                               incomeDiscountCurve) const;
+        
+        // calculations
+        Real forwardValue();
+        InterestRate impliedYield(
+                        Real underlyingSpotValue,
+                        Real forwardValue,
+                        Date settlementDate,
+                        Compounding compoundingConvention,
+                        DayCounter dayCounter);
+    private:
+        Forward();
 };
 
 
@@ -60,55 +62,30 @@ using QuantLib::FixedRateBondForward;
 using QuantLib::FixedRateBond;
 using QuantLib::BusinessDayConvention;
 using QuantLib::Position;
-typedef boost::shared_ptr<Instrument> FixedRateBondForwardPtr;
 %}
 
-%rename(FixedRateBondForward) FixedRateBondForwardPtr;
-class FixedRateBondForwardPtr : public ForwardPtr {
+%shared_ptr(FixedRateBondForward)
+class FixedRateBondForward : public Forward {
     public:
-        %extend {
-            FixedRateBondForwardPtr(
-                    const Date& valueDate,
-                    const Date& maturityDate,
-                    Position::Type type,
-                    Real strike,
-                    Natural settlementDays,
-                    const DayCounter& dayCounter,
-                    const Calendar& calendar,
-                    BusinessDayConvention businessDayConvention,
-                    const boost::shared_ptr<FixedRateBond>& fixedBond,
-                    const Handle<YieldTermStructure>& discountCurve =
-                                                Handle<YieldTermStructure>(),
-                    const Handle<YieldTermStructure>& incomeDiscountCurve =
-                                                Handle<YieldTermStructure>()) {
-                return new FixedRateBondForwardPtr(
-                       new FixedRateBondForward(
-                            valueDate, maturityDate, type, strike,
-                            settlementDays, dayCounter, calendar,
-                            businessDayConvention, fixedBond,
-                            discountCurve,  incomeDiscountCurve));
-            }
-            
-            Real forwardPrice() {
-                return boost::dynamic_pointer_cast<FixedRateBondForward>(*self)
-                    -> forwardPrice();
-            }
+        FixedRateBondForward(
+                const Date& valueDate,
+                const Date& maturityDate,
+                Position::Type type,
+                Real strike,
+                Natural settlementDays,
+                const DayCounter& dayCounter,
+                const Calendar& calendar,
+                BusinessDayConvention businessDayConvention,
+                const boost::shared_ptr<FixedRateBond>& fixedBond,
+                const Handle<YieldTermStructure>& discountCurve =
+                                            Handle<YieldTermStructure>(),
+                const Handle<YieldTermStructure>& incomeDiscountCurve =
+                                            Handle<YieldTermStructure>());
+        
+        Real forwardPrice();
 
-            Real cleanForwardPrice() {
-                return boost::dynamic_pointer_cast<FixedRateBondForward>(*self)
-                    -> cleanForwardPrice();
-            }
+        Real cleanForwardPrice();
 
-            Real spotIncome(const Handle<YieldTermStructure>& incomeDiscountCurve) {
-                return boost::dynamic_pointer_cast<FixedRateBondForward>(*self)
-                    -> spotIncome(incomeDiscountCurve);
-            }
-
-            Real spotValue() {
-                return boost::dynamic_pointer_cast<FixedRateBondForward>(*self)
-                    -> spotValue();
-            }
-        }
 };
 
 #endif

--- a/SWIG/forward.i
+++ b/SWIG/forward.i
@@ -76,18 +76,16 @@ class FixedRateBondForwardPtr : public ForwardPtr {
                     const DayCounter& dayCounter,
                     const Calendar& calendar,
                     BusinessDayConvention businessDayConvention,
-                    const FixedRateBondPtr& fixedBond,
+                    const boost::shared_ptr<FixedRateBond>& fixedBond,
                     const Handle<YieldTermStructure>& discountCurve =
                                                 Handle<YieldTermStructure>(),
                     const Handle<YieldTermStructure>& incomeDiscountCurve =
                                                 Handle<YieldTermStructure>()) {
-                const boost::shared_ptr<FixedRateBond>& fixedCouponBond = 
-                    boost::dynamic_pointer_cast<FixedRateBond>(fixedBond);
                 return new FixedRateBondForwardPtr(
                        new FixedRateBondForward(
                             valueDate, maturityDate, type, strike,
                             settlementDays, dayCounter, calendar,
-                            businessDayConvention, fixedCouponBond,
+                            businessDayConvention, fixedBond,
                             discountCurve,  incomeDiscountCurve));
             }
             

--- a/SWIG/fra.i
+++ b/SWIG/fra.i
@@ -1,6 +1,7 @@
 /*
  Copyright (C) 2012 Tawanda Gwena
  Copyright (C) 2012 Francis Duffy
+ Copyright (C) 2018 Matthias Lungwitz
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -22,48 +23,34 @@
 %include instruments.i
 %include termstructures.i
 %include interestrate.i
+%include forward.i
 
 %{
 using QuantLib::Position;
 using QuantLib::ForwardRateAgreement;
-typedef boost::shared_ptr<Instrument> ForwardRateAgreementPtr;
 %}
  
 struct Position {
     enum Type { Long, Short };
 };
 
-%rename(ForwardRateAgreement) ForwardRateAgreementPtr;
-class ForwardRateAgreementPtr : public boost::shared_ptr<Instrument> {
+%shared_ptr(ForwardRateAgreement)
+class ForwardRateAgreement : public Forward {
   public:
-    %extend {
-        ForwardRateAgreementPtr(
-                        const Date& valueDate,
-                        const Date& maturityDate,
-                        Position::Type type,
-                        Rate strikeForwardRate,
-                        Real notionalAmount,
-                        const boost::shared_ptr<IborIndex>& index,
-                        const Handle<YieldTermStructure>& discountCurve =
-                                               Handle<YieldTermStructure>()) {
-            return new ForwardRateAgreementPtr(
-                   new ForwardRateAgreement(valueDate, maturityDate, type,
-                                            strikeForwardRate, notionalAmount,
-                                            index, discountCurve));
-        }
-        Real spotIncome(const Handle<YieldTermStructure>& discount) const {
-            return boost::dynamic_pointer_cast<ForwardRateAgreement>(*self)
-                ->spotIncome(discount);
-        }
-        Real spotValue() const {
-            return boost::dynamic_pointer_cast<ForwardRateAgreement>(*self)
-                ->spotValue();
-        }
-        InterestRate forwardRate() const {
-            return boost::dynamic_pointer_cast<ForwardRateAgreement>(*self)
-                ->forwardRate();
-        }
-    }
+    ForwardRateAgreement(
+                    const Date& valueDate,
+                    const Date& maturityDate,
+                    Position::Type type,
+                    Rate strikeForwardRate,
+                    Real notionalAmount,
+                    const boost::shared_ptr<IborIndex>& index,
+                    const Handle<YieldTermStructure>& discountCurve =
+                                           Handle<YieldTermStructure>());
+
+    Date fixingDate() const;
+    Real spotIncome(const Handle<YieldTermStructure>& discount) const;
+    Real spotValue() const;
+    InterestRate forwardRate() const;
 };
  
 

--- a/SWIG/gaussian1dmodel.i
+++ b/SWIG/gaussian1dmodel.i
@@ -34,7 +34,7 @@ using QuantLib::Gaussian1dModel;
 %ignore Gaussian1dModel;
 class Gaussian1dModel {
     public:
-        const StochasticProcess1DPtr stateProcess() const;
+        const boost::shared_ptr<StochasticProcess1D> stateProcess() const;
 
         const Real numeraire(const Time t, const Real y = 0.0,
                              const Handle<YieldTermStructure> &yts =

--- a/SWIG/inflation.i
+++ b/SWIG/inflation.i
@@ -21,6 +21,7 @@
 #define quantlib_inflation_i
 
 %include termstructures.i
+%include swap.i
 
 %{
   using QuantLib::Seasonality;
@@ -437,227 +438,88 @@ export_piecewise_yoy_inflation_curve(PiecewiseYoYInflation,Linear);
 using QuantLib::ZeroCouponInflationSwap;
 using QuantLib::YearOnYearInflationSwap;
 using QuantLib::CPISwap;
-typedef boost::shared_ptr<Instrument> ZeroCouponInflationSwapPtr;
-typedef boost::shared_ptr<Instrument> YearOnYearInflationSwapPtr;
-typedef boost::shared_ptr<Instrument> CPISwapPtr;
 %}
 
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-%rename(_ZeroCouponInflationSwap) ZeroCouponInflationSwap;
-#else
-%ignore ZeroCouponInflationSwap;
-#endif
-class ZeroCouponInflationSwap {
+%shared_ptr(ZeroCouponInflationSwap)
+class ZeroCouponInflationSwap : public Swap {
   public:
     enum Type { Receiver = -1, Payer = 1 };
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-  private:
-    ZeroCouponInflationSwap();
-#endif
-};
-
-%rename(ZeroCouponInflationSwap) ZeroCouponInflationSwapPtr;
-class ZeroCouponInflationSwapPtr : public boost::shared_ptr<Instrument> {
-  public:
-    %extend {
-        static const ZeroCouponInflationSwap::Type Receiver =
-            ZeroCouponInflationSwap::Receiver;
-        static const ZeroCouponInflationSwap::Type Payer =
-            ZeroCouponInflationSwap::Payer;
-        ZeroCouponInflationSwapPtr(
-                       ZeroCouponInflationSwap::Type type,
-                       Real nominal,
-                       const Date& start,
-                       const Date& maturity,
-                       const Calendar& calendar,
-                       BusinessDayConvention convention,
-                       const DayCounter& dayCounter,
-                       Rate fixedRate,
-                       const boost::shared_ptr<ZeroInflationIndex>& index,
-                       const Period& lag,
-                       bool adjustInfObsDates = false,
-                       Calendar infCalendar = Calendar(),
-                       BusinessDayConvention infConvention = Following) {
-            return new ZeroCouponInflationSwapPtr(
-                new ZeroCouponInflationSwap(type, nominal, start, maturity,
-                                            calendar, convention, dayCounter,
-                                            fixedRate, index, lag,
-                                            adjustInfObsDates,
-                                            infCalendar, infConvention));
-        }
-        Rate fairRate() {
-            return boost::dynamic_pointer_cast<ZeroCouponInflationSwap>(*self)
-                ->fairRate();
-        }
-        Real fixedLegNPV() {
-            return boost::dynamic_pointer_cast<ZeroCouponInflationSwap>(*self)
-                ->fixedLegNPV();
-        }
-        Real inflationLegNPV() {
-            return boost::dynamic_pointer_cast<ZeroCouponInflationSwap>(*self)
-                ->inflationLegNPV();
-        }
-        std::vector<boost::shared_ptr<CashFlow> > fixedLeg() {
-            return boost::dynamic_pointer_cast<ZeroCouponInflationSwap>(*self)
-                ->fixedLeg();
-        }
-        std::vector<boost::shared_ptr<CashFlow> > inflationLeg() {
-            return boost::dynamic_pointer_cast<ZeroCouponInflationSwap>(*self)
-                ->inflationLeg();
-        }
-        ZeroCouponInflationSwap::Type type() {
-            return boost::dynamic_pointer_cast<ZeroCouponInflationSwap>(*self)
-                ->type();
-        }
-    }
-};
-
-
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-%rename(_YearOnYearInflationSwap) YearOnYearInflationSwap;
-#else
-%ignore YearOnYearInflationSwap;
-#endif
-class YearOnYearInflationSwap {
-  public:
-    enum Type { Receiver = -1, Payer = 1 };
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-  private:
-    YearOnYearInflationSwap();
-#endif
-};
-
-%rename(YearOnYearInflationSwap) YearOnYearInflationSwapPtr;
-class YearOnYearInflationSwapPtr : public boost::shared_ptr<Instrument> {
-  public:
-    %extend {
-        static const YearOnYearInflationSwap::Type Receiver =
-            YearOnYearInflationSwap::Receiver;
-        static const YearOnYearInflationSwap::Type Payer =
-            YearOnYearInflationSwap::Payer;
-        YearOnYearInflationSwapPtr(
-                   YearOnYearInflationSwap::Type type,
+    ZeroCouponInflationSwap(
+                   ZeroCouponInflationSwap::Type type,
                    Real nominal,
-                   const Schedule& fixedSchedule,
+                   const Date& start,
+                   const Date& maturity,
+                   const Calendar& calendar,
+                   BusinessDayConvention convention,
+                   const DayCounter& dayCounter,
                    Rate fixedRate,
-                   const DayCounter& fixedDayCounter,
-                   const Schedule& yoySchedule,
-                   const boost::shared_ptr<YoYInflationIndex>& index,
+                   const boost::shared_ptr<ZeroInflationIndex>& index,
                    const Period& lag,
-                   Spread spread,
-                   const DayCounter& yoyDayCounter,
-                   const Calendar& paymentCalendar,
-                   BusinessDayConvention paymentConvention = Following) {
-            return new YearOnYearInflationSwapPtr(
-                new YearOnYearInflationSwap(type, nominal, fixedSchedule,
-                                            fixedRate, fixedDayCounter,
-                                            yoySchedule, index, lag, spread,
-                                            yoyDayCounter, paymentCalendar,
-                                            paymentConvention));
-        }
-        Rate fairRate() {
-            return boost::dynamic_pointer_cast<YearOnYearInflationSwap>(*self)
-                ->fairRate();
-        }
-        Real fixedLegNPV() {
-            return boost::dynamic_pointer_cast<YearOnYearInflationSwap>(*self)
-                ->fixedLegNPV();
-        }
-        Real yoyLegNPV() {
-            return boost::dynamic_pointer_cast<YearOnYearInflationSwap>(*self)
-                ->yoyLegNPV();
-        }
-		Spread fairSpread() {
-            return boost::dynamic_pointer_cast<YearOnYearInflationSwap>(*self)
-                ->fairSpread();
-        }
-		const Leg& fixedLeg() {
-            return boost::dynamic_pointer_cast<YearOnYearInflationSwap>(*self)
-                ->fixedLeg();
-        }
-		const Leg& yoyLeg() {
-            return boost::dynamic_pointer_cast<YearOnYearInflationSwap>(*self)
-                ->yoyLeg();
-        }
-    }
+                   bool adjustInfObsDates = false,
+                   Calendar infCalendar = Calendar(),
+                   BusinessDayConvention infConvention = Following);
+    Rate fairRate();
+    Real fixedLegNPV();
+    Real inflationLegNPV();
+    std::vector<boost::shared_ptr<CashFlow> > fixedLeg();
+    std::vector<boost::shared_ptr<CashFlow> > inflationLeg();
+    ZeroCouponInflationSwap::Type type();
 };
 
-
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-%rename(_CPISwap) CPISwap;
-#else
-%ignore CPISwap;
-#endif
-class CPISwap {
+%shared_ptr(YearOnYearInflationSwap)
+class YearOnYearInflationSwap : public Swap {
   public:
     enum Type { Receiver = -1, Payer = 1 };
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-  private:
-    CPISwap();
-#endif
+    YearOnYearInflationSwap(
+               YearOnYearInflationSwap::Type type,
+               Real nominal,
+               const Schedule& fixedSchedule,
+               Rate fixedRate,
+               const DayCounter& fixedDayCounter,
+               const Schedule& yoySchedule,
+               const boost::shared_ptr<YoYInflationIndex>& index,
+               const Period& lag,
+               Spread spread,
+               const DayCounter& yoyDayCounter,
+               const Calendar& paymentCalendar,
+               BusinessDayConvention paymentConvention = Following);
+    Rate fairRate();
+    Real fixedLegNPV();
+    Real yoyLegNPV();
+    Spread fairSpread();
+    const Leg& fixedLeg();
+    const Leg& yoyLeg();
 };
 
-%rename(CPISwap) CPISwapPtr;
-class CPISwapPtr : public boost::shared_ptr<Instrument> {
+%shared_ptr(CPISwap)
+class CPISwap : public Swap {
   public:
-    %extend {
-        static const CPISwap::Type Receiver =
-            CPISwap::Receiver;
-        static const CPISwap::Type Payer =
-            CPISwap::Payer;
-        CPISwapPtr(
-				CPISwap::Type type,
-				Real nominal,
-				bool subtractInflationNominal,
-				Spread spread,
-				const DayCounter& floatDayCount,
-				const Schedule& floatSchedule,
-				const BusinessDayConvention& floatRoll,
-				Natural fixingDays,
-				const boost::shared_ptr<IborIndex>& floatIndex,
-				Rate fixedRate,
-				Real baseCPI,
-				const DayCounter& fixedDayCount,
-				const Schedule& fixedSchedule,
-				const BusinessDayConvention& fixedRoll,
-				const Period& observationLag,
-				const boost::shared_ptr<ZeroInflationIndex>& fixedIndex,
-				CPI::InterpolationType observationInterpolation = CPI::AsIndex,
-				Real inflationNominal = Null<Real>() ) {
-		
-            return new CPISwapPtr(
-                new CPISwap(type, nominal, subtractInflationNominal,
-                                            spread, floatDayCount,
-                                            floatSchedule, floatRoll, fixingDays, floatIndex,
-                                            fixedRate, baseCPI, fixedDayCount, fixedSchedule, 
-											fixedRoll, observationLag, fixedIndex, observationInterpolation,
-                                            inflationNominal));
-        }
-        Rate fairRate() {
-            return boost::dynamic_pointer_cast<CPISwap>(*self)
-                ->fairRate();
-        }
-		Real floatLegNPV() {
-			return boost::dynamic_pointer_cast<CPISwap>(*self)
-                ->floatLegNPV();
-		}
-		Spread fairSpread() {
-			return boost::dynamic_pointer_cast<CPISwap>(*self)
-                ->fairSpread();
-		}
-		Real fixedLegNPV() {
-			return boost::dynamic_pointer_cast<CPISwap>(*self)
-                ->fixedLegNPV();
-		}
-		const Leg& cpiLeg() {
-			return boost::dynamic_pointer_cast<CPISwap>(*self)
-                ->cpiLeg();
-		}
-		const Leg& floatLeg() {
-			return boost::dynamic_pointer_cast<CPISwap>(*self)
-                ->floatLeg();
-		}
-    }
+    enum Type { Receiver = -1, Payer = 1 };
+    CPISwap(
+            CPISwap::Type type,
+            Real nominal,
+            bool subtractInflationNominal,
+            Spread spread,
+            const DayCounter& floatDayCount,
+            const Schedule& floatSchedule,
+            const BusinessDayConvention& floatRoll,
+            Natural fixingDays,
+            const boost::shared_ptr<IborIndex>& floatIndex,
+            Rate fixedRate,
+            Real baseCPI,
+            const DayCounter& fixedDayCount,
+            const Schedule& fixedSchedule,
+            const BusinessDayConvention& fixedRoll,
+            const Period& observationLag,
+            const boost::shared_ptr<ZeroInflationIndex>& fixedIndex,
+            CPI::InterpolationType observationInterpolation = CPI::AsIndex,
+            Real inflationNominal = Null<Real>() );
+    Rate fairRate();
+    Real floatLegNPV();
+    Spread fairSpread();
+    Real fixedLegNPV();
+    const Leg& cpiLeg();
+    const Leg& floatLeg();
 };
 
 
@@ -666,69 +528,46 @@ using QuantLib::YoYInflationCapFloor;
 using QuantLib::YoYInflationCap;
 using QuantLib::YoYInflationFloor;
 using QuantLib::YoYInflationCollar;
-
-typedef boost::shared_ptr<Instrument> YoYInflationCapFloorPtr;
-typedef boost::shared_ptr<Instrument> YoYInflationCapPtr;
-typedef boost::shared_ptr<Instrument> YoYInflationFloorPtr;
-typedef boost::shared_ptr<Instrument> YoYInflationCollarPtr;
 %}
 
-%rename(YoYInflationCapFloor) YoYInflationCapFloorPtr;
-class YoYInflationCapFloorPtr : public boost::shared_ptr<Instrument> {
+%shared_ptr(YoYInflationCapFloor)
+class YoYInflationCapFloor : public Instrument {
   public:
-     %extend {
-         Volatility impliedVolatility(
-                               Real price,
-                               const Handle<YoYInflationTermStructure>& curve,
-                               Volatility guess,
-                               Real accuracy = 1.0e-4,
-                               Size maxEvaluations = 100,
-                               Volatility minVol = 1.0e-7,
-                               Volatility maxVol = 4.0) const {
-             return boost::dynamic_pointer_cast<YoYInflationCapFloor>(*self)->
-                 impliedVolatility(price, curve, guess, accuracy,
-                                   maxEvaluations, minVol, maxVol);
-         }
-     }
+     Volatility impliedVolatility(
+                           Real price,
+                           const Handle<YoYInflationTermStructure>& curve,
+                           Volatility guess,
+                           Real accuracy = 1.0e-4,
+                           Size maxEvaluations = 100,
+                           Volatility minVol = 1.0e-7,
+                           Volatility maxVol = 4.0) const;
+  private:
+    YoYInflationCapFloor();
 };
 
-%rename(YoYInflationCap) YoYInflationCapPtr;
-class YoYInflationCapPtr : public YoYInflationCapFloorPtr {
+%shared_ptr(YoYInflationCap)
+class YoYInflationCap : public YoYInflationCapFloor {
   public:
-    %extend {
-        YoYInflationCapPtr(
-                const std::vector<boost::shared_ptr<CashFlow> >& leg,
-                const std::vector<Rate>& capRates) {
-            return new YoYInflationCapPtr(new YoYInflationCap(leg,capRates));
-        }
-    }
+    YoYInflationCap(
+            const std::vector<boost::shared_ptr<CashFlow> >& leg,
+            const std::vector<Rate>& capRates);
 };
 
-%rename(YoYInflationFloor) YoYInflationFloorPtr;
-class YoYInflationFloorPtr : public YoYInflationCapFloorPtr {
+%shared_ptr(YoYInflationFloor)
+class YoYInflationFloor : public YoYInflationCapFloor {
   public:
-    %extend {
-        YoYInflationFloorPtr(
-                const std::vector<boost::shared_ptr<CashFlow> >& leg,
-                const std::vector<Rate>& floorRates) {
-            return new YoYInflationFloorPtr(
-                                       new YoYInflationFloor(leg,floorRates));
-        }
-    }
+    YoYInflationFloor(
+            const std::vector<boost::shared_ptr<CashFlow> >& leg,
+            const std::vector<Rate>& floorRates);
 };
 
-%rename(YoYInflationCollar) YoYInflationCollarPtr;
-class YoYInflationCollarPtr : public YoYInflationCapFloorPtr {
+%shared_ptr(YoYInflationCollar)
+class YoYInflationCollar : public YoYInflationCapFloor {
   public:
-    %extend {
-        YoYInflationCollarPtr(
-                const std::vector<boost::shared_ptr<CashFlow> >& leg,
-                const std::vector<Rate>& capRates,
-                const std::vector<Rate>& floorRates) {
-            return new YoYInflationCollarPtr(
-                             new YoYInflationCollar(leg,capRates,floorRates));
-        }
-    }
+    YoYInflationCollar(
+            const std::vector<boost::shared_ptr<CashFlow> >& leg,
+            const std::vector<Rate>& capRates,
+            const std::vector<Rate>& floorRates);
 };
 
 #endif

--- a/SWIG/instruments.i
+++ b/SWIG/instruments.i
@@ -38,11 +38,10 @@ using QuantLib::PricingEngine;
 
 %{
 using QuantLib::Instrument;
-using QuantLib::LazyObject;
 %}
     
 %shared_ptr(Instrument)
-class Instrument {
+class Instrument : public Observable {
     #if defined(SWIGRUBY)
     %rename("isExpired?")     isExpired;
     %rename("pricingEngine=") setPricingEngine;
@@ -58,6 +57,8 @@ class Instrument {
     void recalculate();
     void freeze();
     void unfreeze();
+  private:
+    Instrument();
 };
 
 #if defined(SWIGR)
@@ -70,7 +71,7 @@ function(x) print(summary(x)))
 %}
 #endif
 
-%template(Instrument) boost::shared_ptr<Instrument>;
+IsObservable(boost::shared_ptr<Instrument>);
 
 #if defined(SWIGCSHARP)
 SWIG_STD_VECTOR_ENHANCED( boost::shared_ptr<Instrument> )

--- a/SWIG/instruments.i
+++ b/SWIG/instruments.i
@@ -1,6 +1,7 @@
 
 /*
  Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
+ Copyright (C) 2018 Matthias Lungwitz
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -37,9 +38,10 @@ using QuantLib::PricingEngine;
 
 %{
 using QuantLib::Instrument;
+using QuantLib::LazyObject;
 %}
-
-%ignore Instrument;
+    
+%shared_ptr(Instrument)
 class Instrument {
     #if defined(SWIGRUBY)
     %rename("isExpired?")     isExpired;
@@ -69,7 +71,6 @@ function(x) print(summary(x)))
 #endif
 
 %template(Instrument) boost::shared_ptr<Instrument>;
-IsObservable(boost::shared_ptr<Instrument>);
 
 #if defined(SWIGCSHARP)
 SWIG_STD_VECTOR_ENHANCED( boost::shared_ptr<Instrument> )
@@ -82,43 +83,27 @@ namespace std {
 
 %{
 using QuantLib::Stock;
-typedef boost::shared_ptr<Instrument> StockPtr;
 %}
 
-%rename(Stock) StockPtr;
-class StockPtr : public boost::shared_ptr<Instrument> {
+%shared_ptr(Stock)
+class Stock : public Instrument {
   public:
-    %extend {
-        StockPtr(const Handle<Quote>& quote) {
-            return new StockPtr(new Stock(quote));
-        }
-    }
+    Stock(const Handle<Quote>& quote);
 };
 
 
 %{
 using QuantLib::CompositeInstrument;
-typedef boost::shared_ptr<Instrument> CompositeInstrumentPtr;
 %}
 
-%rename(CompositeInstrument) CompositeInstrumentPtr;
-class CompositeInstrumentPtr : public boost::shared_ptr<Instrument> {
+%shared_ptr(CompositeInstrument)
+class CompositeInstrument : public Instrument {
   public:
-    %extend {
-        CompositeInstrumentPtr() {
-            return new CompositeInstrumentPtr(new CompositeInstrument);
-        }
-        void add(const boost::shared_ptr<Instrument>& instrument,
-                 Real multiplier = 1.0) {
-            boost::dynamic_pointer_cast<CompositeInstrument>(*self)
-                ->add(instrument, multiplier);
-        }
-        void subtract(const boost::shared_ptr<Instrument>& instrument,
-                      Real multiplier = 1.0) {
-            boost::dynamic_pointer_cast<CompositeInstrument>(*self)
-                ->subtract(instrument, multiplier);
-        }
-    }
+    CompositeInstrument();
+    void add(const boost::shared_ptr<Instrument>& instrument,
+             Real multiplier = 1.0);
+    void subtract(const boost::shared_ptr<Instrument>& instrument,
+                  Real multiplier = 1.0);
 };
 
 

--- a/SWIG/montecarlo.i
+++ b/SWIG/montecarlo.i
@@ -3,6 +3,7 @@
  Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
  Copyright (C) 2003, 2004, 2005 StatPro Italia srl
  Copyright (C) 2008 Tito Ingargiola
+ Copyright (C) 2018 Matthias Lungwitz
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -83,13 +84,11 @@ typedef QuantLib::PathGenerator<GaussianRandomSequenceGenerator>
 class GaussianPathGenerator {
   public:
     %extend {
-        GaussianPathGenerator(const StochasticProcess1DPtr& process,
+        GaussianPathGenerator(const boost::shared_ptr<StochasticProcess1D>& process,
                               Time length, Size steps,
                               const GaussianRandomSequenceGenerator& rsg,
                               bool brownianBridge) {
-            boost::shared_ptr<StochasticProcess1D> process1d =
-                boost::dynamic_pointer_cast<StochasticProcess1D>(process);
-            return new GaussianPathGenerator(process1d,length,steps,
+            return new GaussianPathGenerator(process,length,steps,
                                              rsg,brownianBridge);
         }
     }
@@ -105,13 +104,11 @@ class GaussianSobolPathGenerator {
   public:
     %extend {
         GaussianSobolPathGenerator(
-                           const StochasticProcess1DPtr& process,
+                           const boost::shared_ptr<StochasticProcess1D>& process,
                            Time length, Size steps,
                            const GaussianLowDiscrepancySequenceGenerator& rsg,
                            bool brownianBridge) {
-            boost::shared_ptr<StochasticProcess1D> process1d =
-                boost::dynamic_pointer_cast<StochasticProcess1D>(process);
-            return new GaussianSobolPathGenerator(process1d,length,steps,
+            return new GaussianSobolPathGenerator(process,length,steps,
                                                   rsg,brownianBridge);
         }
     }

--- a/SWIG/observer.i
+++ b/SWIG/observer.i
@@ -30,6 +30,7 @@ using QuantLib::Observable;
 %shared_ptr(Observable);
 class Observable {};
 
+
 %define IsObservable(Type)
 #if defined(SWIGRUBY)
 %rename("toObservable") Type::asObservable;

--- a/SWIG/optimizers.i
+++ b/SWIG/optimizers.i
@@ -3,6 +3,7 @@
  Copyright (C) 2003, 2004, 2005, 2006 StatPro Italia srl
  Copyright (C) 2005 Dominic Thuillier
  Copyright (C) 2015 Klaus Spanderen
+ Copyright (C) 2018 Matthias Lungwitz 
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -111,32 +112,38 @@ using QuantLib::CompositeConstraint;
 using QuantLib::NonhomogeneousBoundaryConstraint;
 %}
 
+%shared_ptr(Constraint)
 class Constraint {
     // prevent direct instantiation
   private:
     Constraint();
 };
 
+%shared_ptr(BoundaryConstraint)
 class BoundaryConstraint : public Constraint {
   public:
     BoundaryConstraint(Real lower, Real upper);
 };
 
+%shared_ptr(NoConstraint)
 class NoConstraint : public Constraint {
   public:
     NoConstraint();
 };
 
+%shared_ptr(PositiveConstraint)
 class PositiveConstraint : public Constraint {
   public:
     PositiveConstraint();
 };
 
+%shared_ptr(CompositeConstraint)
 class CompositeConstraint : public Constraint {
   public:
     CompositeConstraint(const Constraint& c1, const Constraint& c2);
 };
 
+%shared_ptr(NonhomogeneousBoundaryConstraint)
 class NonhomogeneousBoundaryConstraint : public Constraint {
   public:
     NonhomogeneousBoundaryConstraint(const Array& l, const Array& u);

--- a/SWIG/options.i
+++ b/SWIG/options.i
@@ -251,47 +251,29 @@ class AnalyticEuropeanEnginePtr : public boost::shared_ptr<PricingEngine> {
 
 %{
 using QuantLib::HestonModel;
-typedef boost::shared_ptr<CalibratedModel> HestonModelPtr;
 %}
 
-%rename(HestonModel) HestonModelPtr;
-class HestonModelPtr : public boost::shared_ptr<CalibratedModel> {
+%shared_ptr(HestonModel)
+class HestonModel : public CalibratedModel {
   public:
-    %extend {
-        HestonModelPtr(const boost::shared_ptr<HestonProcess>&  process) {
-
-            return new HestonModelPtr(new HestonModel(process));
-        }
-        Real theta() const {
-            return boost::dynamic_pointer_cast<HestonModel>(*self)->theta();
-        }
-        Real kappa() const {
-            return boost::dynamic_pointer_cast<HestonModel>(*self)->kappa();
-        }
-        Real sigma() const {
-            return boost::dynamic_pointer_cast<HestonModel>(*self)->sigma();
-        }
-        Real rho() const {
-            return boost::dynamic_pointer_cast<HestonModel>(*self)->rho();
-        }
-        Real v0() const {
-            return boost::dynamic_pointer_cast<HestonModel>(*self)->v0();
-        }
-    }
+    HestonModel(const boost::shared_ptr<HestonProcess>&  process);
+    Real theta() const;
+    Real kappa() const;
+    Real sigma() const;
+    Real rho() const;
+    Real v0() const;
 };
 
 
 
 %{
 using QuantLib::PiecewiseTimeDependentHestonModel;
-typedef boost::shared_ptr<CalibratedModel> PiecewiseTimeDependentHestonModelPtr;
 %}
 
-%rename(PiecewiseTimeDependentHestonModel) PiecewiseTimeDependentHestonModelPtr;
-class PiecewiseTimeDependentHestonModelPtr : public boost::shared_ptr<CalibratedModel> {
+%shared_ptr(PiecewiseTimeDependentHestonModel)
+class PiecewiseTimeDependentHestonModel : public CalibratedModel {
     public:
-      %extend {
-         PiecewiseTimeDependentHestonModelPtr(
+         PiecewiseTimeDependentHestonModel(
               const Handle<YieldTermStructure>& riskFreeRate,
               const Handle<YieldTermStructure>& dividendYield,
               const Handle<Quote>& s0,
@@ -300,42 +282,18 @@ class PiecewiseTimeDependentHestonModelPtr : public boost::shared_ptr<Calibrated
               const Parameter& kappa,
               const Parameter& sigma,
               const Parameter& rho,
-              const TimeGrid& timeGrid) {
-            return new PiecewiseTimeDependentHestonModelPtr (
-                new PiecewiseTimeDependentHestonModel(riskFreeRate,
-                    dividendYield, s0, v0, theta, kappa, 
-                    sigma, rho, timeGrid));
-        }
+              const TimeGrid& timeGrid);
     
-        Real theta(Time t) const { 
-            return boost::dynamic_pointer_cast<PiecewiseTimeDependentHestonModel>(*self)->theta(t);
-        }
-        Real kappa(Time t) const {
-            return boost::dynamic_pointer_cast<PiecewiseTimeDependentHestonModel>(*self)->kappa(t);
-        }
-        Real sigma(Time t) const {
-            return boost::dynamic_pointer_cast<PiecewiseTimeDependentHestonModel>(*self)->sigma(t);
-        }
-        Real rho(Time t)   const { 
-            return boost::dynamic_pointer_cast<PiecewiseTimeDependentHestonModel>(*self)->rho(t);
-        }
-        Real v0()          const { 
-            return boost::dynamic_pointer_cast<PiecewiseTimeDependentHestonModel>(*self)->v0();
-        }
-        Real s0()          const { 
-            return boost::dynamic_pointer_cast<PiecewiseTimeDependentHestonModel>(*self)->s0();
-        }
-        const TimeGrid& timeGrid() const {
-            return boost::dynamic_pointer_cast<PiecewiseTimeDependentHestonModel>(*self)->timeGrid();
-        }
-        const Handle<YieldTermStructure>& dividendYield() const {
-            return boost::dynamic_pointer_cast<PiecewiseTimeDependentHestonModel>(*self)->dividendYield();
-        }
-        const Handle<YieldTermStructure>& riskFreeRate() const {
-            return boost::dynamic_pointer_cast<PiecewiseTimeDependentHestonModel>(*self)->riskFreeRate();
-        }
-    
-    }
+        Real theta(Time t) const;
+        Real kappa(Time t) const;
+        Real sigma(Time t) const;
+        Real rho(Time t)   const;
+        Real v0()          const;
+        Real s0()          const;
+        const TimeGrid& timeGrid() const;
+        const Handle<YieldTermStructure>& dividendYield() const;
+        const Handle<YieldTermStructure>& riskFreeRate() const;
+
 };
 
 
@@ -349,25 +307,19 @@ typedef boost::shared_ptr<PricingEngine> AnalyticHestonEnginePtr;
 class AnalyticHestonEnginePtr : public boost::shared_ptr<PricingEngine> {
   public:
     %extend {
-        AnalyticHestonEnginePtr(const HestonModelPtr& model, 
+        AnalyticHestonEnginePtr(const boost::shared_ptr<HestonModel>& model, 
                                 Size integrationOrder = 144) {
-            boost::shared_ptr<HestonModel> hModel =
-                 boost::dynamic_pointer_cast<HestonModel>(model);
-            QL_REQUIRE(hModel, "Heston model required");
 
             return new AnalyticHestonEnginePtr(
-                new AnalyticHestonEngine(hModel, integrationOrder));
+                new AnalyticHestonEngine(model, integrationOrder));
         }
 
-        AnalyticHestonEnginePtr(const HestonModelPtr& model, 
+        AnalyticHestonEnginePtr(const boost::shared_ptr<HestonModel>& model, 
                                 Real relTolerance,
                                 Size maxEvaluations) {
-            boost::shared_ptr<HestonModel> hModel =
-                 boost::dynamic_pointer_cast<HestonModel>(model);
-            QL_REQUIRE(hModel, "Heston model required");
 
             return new AnalyticHestonEnginePtr(
-                new AnalyticHestonEngine(hModel, relTolerance,maxEvaluations));
+                new AnalyticHestonEngine(model, relTolerance,maxEvaluations));
         }
     }
 };
@@ -381,14 +333,11 @@ typedef boost::shared_ptr<PricingEngine> COSHestonEnginePtr;
 class COSHestonEnginePtr : public boost::shared_ptr<PricingEngine> {
   public:
     %extend {
-        COSHestonEnginePtr(const HestonModelPtr& model, 
+        COSHestonEnginePtr(const boost::shared_ptr<HestonModel>& model, 
                            Real L = 16, Size N=200) {
-            boost::shared_ptr<HestonModel> hModel =
-                boost::dynamic_pointer_cast<HestonModel>(model);
-            QL_REQUIRE(hModel, "Heston model required");
 
             return new COSHestonEnginePtr(
-                new COSHestonEngine(hModel, L, N));
+                new COSHestonEngine(model, L, N));
         }
     }
 };
@@ -404,24 +353,20 @@ class AnalyticPTDHestonEnginePtr : public boost::shared_ptr<PricingEngine> {
   public:
     %extend {
         AnalyticPTDHestonEnginePtr(
-            const PiecewiseTimeDependentHestonModelPtr & model,
+            const boost::shared_ptr<PiecewiseTimeDependentHestonModel>& model,
             Real relTolerance, Size maxEvaluations) {
-                const boost::shared_ptr<PiecewiseTimeDependentHestonModel> hmodel = 
-                    boost::dynamic_pointer_cast<PiecewiseTimeDependentHestonModel>(model);
                 return new AnalyticPTDHestonEnginePtr(
-                    new AnalyticPTDHestonEngine(hmodel, relTolerance, maxEvaluations)
+                    new AnalyticPTDHestonEngine(model, relTolerance, maxEvaluations)
             );
         }
 
         // Constructor using Laguerre integration
         // and Gatheral's version of complex log.
         AnalyticPTDHestonEnginePtr(
-            const PiecewiseTimeDependentHestonModelPtr & model,
+            const boost::shared_ptr<PiecewiseTimeDependentHestonModel>& model,
             Size integrationOrder = 144) {
-                const boost::shared_ptr<PiecewiseTimeDependentHestonModel> hmodel = 
-                    boost::dynamic_pointer_cast<PiecewiseTimeDependentHestonModel>(model);
                 return new AnalyticPTDHestonEnginePtr(
-                    new AnalyticPTDHestonEngine(hmodel, integrationOrder)
+                    new AnalyticPTDHestonEngine(model, integrationOrder)
             );
         }
     
@@ -435,26 +380,15 @@ class AnalyticPTDHestonEnginePtr : public boost::shared_ptr<PricingEngine> {
 
 %{
 using QuantLib::BatesModel;
-typedef boost::shared_ptr<CalibratedModel> BatesModelPtr;
 %}
 
-%rename(BatesModel) BatesModelPtr;
-class BatesModelPtr : public HestonModelPtr {
+%shared_ptr(BatesModel)
+class BatesModel : public HestonModel {
   public:
-    %extend {
-        BatesModelPtr(const boost::shared_ptr<BatesProcess>&  process) {
-            return new BatesModelPtr(new BatesModel(process));
-        }
-        Real nu() const {
-            return boost::dynamic_pointer_cast<BatesModel>(*self)->nu();
-        }
-        Real delta() const {
-            return boost::dynamic_pointer_cast<BatesModel>(*self)->delta();
-        }
-        Real lambda() const {
-            return boost::dynamic_pointer_cast<BatesModel>(*self)->lambda();
-        }
-    }
+    BatesModel(const boost::shared_ptr<BatesProcess>&  process);
+    Real nu() const;
+    Real delta() const;
+    Real lambda() const;
 };
 
 
@@ -467,25 +401,19 @@ typedef boost::shared_ptr<PricingEngine> BatesEnginePtr;
 class BatesEnginePtr : public boost::shared_ptr<PricingEngine> {
   public:
     %extend {
-        BatesEnginePtr(const BatesModelPtr& model, 
+        BatesEnginePtr(const boost::shared_ptr<BatesModel>& model,
                        Size integrationOrder = 144) {
-            boost::shared_ptr<BatesModel> bModel =
-                 boost::dynamic_pointer_cast<BatesModel>(model);
-            QL_REQUIRE(bModel, "Bates model required");
 
             return new BatesEnginePtr(
-                new BatesEngine(bModel, integrationOrder));
+                new BatesEngine(model, integrationOrder));
         }
 
-        BatesEnginePtr(const BatesModelPtr& model, 
+        BatesEnginePtr(const boost::shared_ptr<BatesModel>& model, 
                        Real relTolerance,
                        Size maxEvaluations) {
-            boost::shared_ptr<BatesModel> bModel =
-                 boost::dynamic_pointer_cast<BatesModel>(model);
-            QL_REQUIRE(bModel, "Bates model required");
 
             return new BatesEnginePtr(
-                new BatesEngine(bModel, relTolerance,maxEvaluations));
+                new BatesEngine(model, relTolerance,maxEvaluations));
         }
     }
 };
@@ -776,14 +704,11 @@ typedef boost::shared_ptr<PricingEngine> FdBatesVanillaEnginePtr;
 class FdBatesVanillaEnginePtr : public boost::shared_ptr<PricingEngine> {
   public:
     %extend {
-        FdBatesVanillaEnginePtr(const BatesModelPtr& model,
+        FdBatesVanillaEnginePtr(const boost::shared_ptr<BatesModel>& model,
                                 Size tGrid = 100, Size xGrid = 100,
                                 Size vGrid=50, Size dampingSteps = 0) {
-            boost::shared_ptr<BatesModel> bModel =
-                 boost::dynamic_pointer_cast<BatesModel>(model);
-            QL_REQUIRE(bModel, "Bates model required");
             return new FdBatesVanillaEnginePtr(
-                               new FdBatesVanillaEngine(bModel, tGrid, xGrid,
+                               new FdBatesVanillaEngine(model, tGrid, xGrid,
                                                         vGrid, dampingSteps));
         }
     }

--- a/SWIG/payoffs.i
+++ b/SWIG/payoffs.i
@@ -1,6 +1,7 @@
 
 /*
  Copyright (C) 2003 StatPro Italia srl
+ Copyright (C) 2018 Matthias Lungwitz 
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -31,109 +32,61 @@ using QuantLib::AssetOrNothingPayoff;
 using QuantLib::SuperSharePayoff;
 using QuantLib::GapPayoff;
 using QuantLib::VanillaForwardPayoff;
-typedef boost::shared_ptr<Payoff> PlainVanillaPayoffPtr;
-typedef boost::shared_ptr<Payoff> PercentageStrikePayoffPtr;
-typedef boost::shared_ptr<Payoff> CashOrNothingPayoffPtr;
-typedef boost::shared_ptr<Payoff> AssetOrNothingPayoffPtr;
-typedef boost::shared_ptr<Payoff> SuperSharePayoffPtr;
-typedef boost::shared_ptr<Payoff> GapPayoffPtr;
-typedef boost::shared_ptr<Payoff> VanillaForwardPayoffPtr;
 %}
 
-%rename(PlainVanillaPayoff) PlainVanillaPayoffPtr;
-class PlainVanillaPayoffPtr : public boost::shared_ptr<Payoff> {
+%shared_ptr(PlainVanillaPayoff)
+class PlainVanillaPayoff : public Payoff {
   public:
-    %extend {
-        PlainVanillaPayoffPtr(Option::Type type,
-                              Real strike) {
-            return new PlainVanillaPayoffPtr(
-                                        new PlainVanillaPayoff(type, strike));
-        }
+    PlainVanillaPayoff(Option::Type type,
+                          Real strike);
 
-		Option::Type optionType() {
-          	return boost::dynamic_pointer_cast<
-									PlainVanillaPayoff>(*self)->optionType();
-		}
+    Option::Type optionType();
 
-		Real strike() {
-          	return boost::dynamic_pointer_cast<
-									PlainVanillaPayoff>(*self)->strike();
-		}
-    }
+    Real strike();
 };
 
-%rename(PercentageStrikePayoff) PercentageStrikePayoffPtr;
-class PercentageStrikePayoffPtr : public boost::shared_ptr<Payoff> {
+%shared_ptr(PercentageStrikePayoff)
+class PercentageStrikePayoff : public Payoff {
   public:
-    %extend {
-        PercentageStrikePayoffPtr(Option::Type type,
-                                  Real moneyness) {
-            return new PercentageStrikePayoffPtr(
-                                 new PercentageStrikePayoff(type, moneyness));
-        }
-    }
+    PercentageStrikePayoff(Option::Type type,
+                              Real moneyness);
 };
 
-%rename(CashOrNothingPayoff) CashOrNothingPayoffPtr;
-class CashOrNothingPayoffPtr : public boost::shared_ptr<Payoff> {
+%shared_ptr(CashOrNothingPayoff)
+class CashOrNothingPayoff : public Payoff {
   public:
-    %extend {
-        CashOrNothingPayoffPtr(Option::Type type,
-                               Real strike,
-                               Real payoff) {
-            return new CashOrNothingPayoffPtr(
-                               new CashOrNothingPayoff(type, strike, payoff));
-        }
-    }
+    CashOrNothingPayoff(Option::Type type,
+                           Real strike,
+                           Real payoff);
 };
 
-%rename(AssetOrNothingPayoff) AssetOrNothingPayoffPtr;
-class AssetOrNothingPayoffPtr : public boost::shared_ptr<Payoff> {
+%shared_ptr(AssetOrNothingPayoff)
+class AssetOrNothingPayoff : public Payoff {
   public:
-    %extend {
-        AssetOrNothingPayoffPtr(Option::Type type,
-                                Real strike) {
-            return new AssetOrNothingPayoffPtr(
-                                      new AssetOrNothingPayoff(type, strike));
-        }
-    }
+    AssetOrNothingPayoff(Option::Type type,
+                            Real strike);
 };
 
-%rename(SuperSharePayoff) SuperSharePayoffPtr;
-class SuperSharePayoffPtr : public boost::shared_ptr<Payoff> {
+%shared_ptr(SuperSharePayoff)
+class SuperSharePayoff : public Payoff {
   public:
-    %extend {
-        SuperSharePayoffPtr(Option::Type type,
-                            Real strike,
-                            Real increment) {
-            return new SuperSharePayoffPtr(
-                               new SuperSharePayoff(type, strike, increment));
-        }
-    }
+    SuperSharePayoff(Option::Type type,
+                        Real strike,
+                        Real increment);
 };
 
-%rename(GapPayoff) GapPayoffPtr;
-class GapPayoffPtr : public boost::shared_ptr<Payoff> {
+%shared_ptr(GapPayoff)
+class GapPayoff : public Payoff {
   public:
-    %extend {
-        GapPayoffPtr(Option::Type type,
-                            Real strike,
-                            Real strikePayoff) {
-            return new GapPayoffPtr(
-                               new GapPayoff(type, strike, strikePayoff));
-        }
-    }
+    GapPayoff(Option::Type type,
+                        Real strike,
+                        Real strikePayoff);
 };
 
-%rename(VanillaForwardPayoff) VanillaForwardPayoffPtr;
-class VanillaForwardPayoffPtr : public boost::shared_ptr<Payoff> {
+%shared_ptr(VanillaForwardPayoff)
+class VanillaForwardPayoff : public Payoff {
   public:
-    %extend {
-        VanillaForwardPayoffPtr(Option::Type type, Real strike) {
-            return new VanillaForwardPayoffPtr(
-                new VanillaForwardPayoff(type, strike));
-        }
-    }
+    VanillaForwardPayoff(Option::Type type, Real strike);
 };
 
 

--- a/SWIG/payoffs.i
+++ b/SWIG/payoffs.i
@@ -25,6 +25,8 @@
 // payoffs
 
 %{
+using QuantLib::TypePayoff;
+using QuantLib::StrikedTypePayoff;
 using QuantLib::PlainVanillaPayoff;
 using QuantLib::PercentageStrikePayoff;
 using QuantLib::CashOrNothingPayoff;
@@ -34,26 +36,39 @@ using QuantLib::GapPayoff;
 using QuantLib::VanillaForwardPayoff;
 %}
 
+%shared_ptr(TypePayoff)
+class TypePayoff : public Payoff {
+  public:
+    Option::Type optionType();
+  private:
+    TypePayoff();
+};
+
+%shared_ptr(StrikedTypePayoff)
+class StrikedTypePayoff : public TypePayoff
+{
+  public:
+    Real strike();
+  private:
+    StrikedTypePayoff();
+};
+
 %shared_ptr(PlainVanillaPayoff)
-class PlainVanillaPayoff : public Payoff {
+class PlainVanillaPayoff : public StrikedTypePayoff {
   public:
     PlainVanillaPayoff(Option::Type type,
                           Real strike);
-
-    Option::Type optionType();
-
-    Real strike();
 };
 
 %shared_ptr(PercentageStrikePayoff)
-class PercentageStrikePayoff : public Payoff {
+class PercentageStrikePayoff : public StrikedTypePayoff {
   public:
     PercentageStrikePayoff(Option::Type type,
                               Real moneyness);
 };
 
 %shared_ptr(CashOrNothingPayoff)
-class CashOrNothingPayoff : public Payoff {
+class CashOrNothingPayoff : public StrikedTypePayoff {
   public:
     CashOrNothingPayoff(Option::Type type,
                            Real strike,
@@ -61,14 +76,14 @@ class CashOrNothingPayoff : public Payoff {
 };
 
 %shared_ptr(AssetOrNothingPayoff)
-class AssetOrNothingPayoff : public Payoff {
+class AssetOrNothingPayoff : public StrikedTypePayoff {
   public:
     AssetOrNothingPayoff(Option::Type type,
                             Real strike);
 };
 
 %shared_ptr(SuperSharePayoff)
-class SuperSharePayoff : public Payoff {
+class SuperSharePayoff : public StrikedTypePayoff {
   public:
     SuperSharePayoff(Option::Type type,
                         Real strike,
@@ -76,7 +91,7 @@ class SuperSharePayoff : public Payoff {
 };
 
 %shared_ptr(GapPayoff)
-class GapPayoff : public Payoff {
+class GapPayoff : public StrikedTypePayoff {
   public:
     GapPayoff(Option::Type type,
                         Real strike,
@@ -84,7 +99,7 @@ class GapPayoff : public Payoff {
 };
 
 %shared_ptr(VanillaForwardPayoff)
-class VanillaForwardPayoff : public Payoff {
+class VanillaForwardPayoff : public StrikedTypePayoff {
   public:
     VanillaForwardPayoff(Option::Type type, Real strike);
 };

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -52,7 +52,7 @@ struct Pillar {
 %shared_ptr(RateHelper)
 class RateHelper : public Observable {
   public:
-    Handle<Quote> quote() const;
+    const Handle<Quote>& quote() const;
     Date latestDate() const;
 	Date earliestDate() const;
 	Date maturityDate() const;

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -345,15 +345,14 @@ class BondHelperPtr : public boost::shared_ptr<RateHelper> {
   public:
     %extend {
         BondHelperPtr(const Handle<Quote>& cleanPrice,
-                      const BondPtr& bond,
+                      const boost::shared_ptr<Bond>& bond,
                       bool useCleanPrice = true) {
-            boost::shared_ptr<Bond> b = boost::dynamic_pointer_cast<Bond>(bond);
             return new BondHelperPtr(
-                new BondHelper(cleanPrice, b, useCleanPrice));
+                new BondHelper(cleanPrice, bond, useCleanPrice));
         }
 
-        BondPtr bond() {
-            return BondPtr(boost::dynamic_pointer_cast<BondHelper>(*self)->bond());
+        boost::shared_ptr<Bond> bond() {
+            return boost::dynamic_pointer_cast<BondHelper>(*self)->bond();
         }
     }
 };
@@ -388,8 +387,8 @@ class FixedRateBondHelperPtr : public BondHelperPtr {
                                         useCleanPrice));
         }
 
-        FixedRateBondPtr bond() {
-            return FixedRateBondPtr(boost::dynamic_pointer_cast<FixedRateBondHelper>(*self)->bond());
+        boost::shared_ptr<Bond> bond() {
+            return boost::dynamic_pointer_cast<FixedRateBondHelper>(*self)->bond();
         }
     }
 };

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -334,7 +334,7 @@ class SwapRateHelperPtr : public boost::shared_ptr<RateHelper> {
 		Spread spread() {
 			return boost::dynamic_pointer_cast<SwapRateHelper>(*self)->spread();
 		}
-        VanillaSwapPtr swap() {
+        boost::shared_ptr<VanillaSwap> swap() {
             return boost::dynamic_pointer_cast<SwapRateHelper>(*self)->swap();
         }
     }
@@ -423,7 +423,7 @@ class OISRateHelperPtr : public boost::shared_ptr<RateHelper> {
 		Real impliedQuote() {
 			return boost::dynamic_pointer_cast<OISRateHelper>(*self)->impliedQuote();
 		}
-		OvernightIndexedSwapPtr swap() {
+		boost::shared_ptr<OvernightIndexedSwap> swap() {
             return boost::dynamic_pointer_cast<OISRateHelper>(*self)->swap();
         }
     }

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -43,23 +43,14 @@ using QuantLib::FixedRateBondHelper;
 using QuantLib::OISRateHelper;
 using QuantLib::DatedOISRateHelper;
 using QuantLib::FxSwapRateHelper;
-typedef boost::shared_ptr<RateHelper> DepositRateHelperPtr;
-typedef boost::shared_ptr<RateHelper> FraRateHelperPtr;
-typedef boost::shared_ptr<RateHelper> FuturesRateHelperPtr;
-typedef boost::shared_ptr<RateHelper> SwapRateHelperPtr;
-typedef boost::shared_ptr<RateHelper> BondHelperPtr;
-typedef boost::shared_ptr<RateHelper> FixedRateBondHelperPtr;
-typedef boost::shared_ptr<RateHelper> OISRateHelperPtr;
-typedef boost::shared_ptr<RateHelper> DatedOISRateHelperPtr;
-typedef boost::shared_ptr<RateHelper> FxSwapRateHelperPtr;
 %}
 
 struct Pillar {
     enum Choice { MaturityDate, LastRelevantDate, CustomDate};
 };
 
-%ignore RateHelper;
-class RateHelper {
+%shared_ptr(RateHelper)
+class RateHelper : public Observable {
   public:
     Handle<Quote> quote() const;
     Date latestDate() const;
@@ -69,408 +60,258 @@ class RateHelper {
 	Date pillarDate() const;
 	Real impliedQuote() const;
 	Real quoteError() const;
+  private:
+    RateHelper();
 };
 
-// rate helpers for curve bootstrapping
-%template(RateHelper) boost::shared_ptr<RateHelper>;
-
-%rename(DepositRateHelper) DepositRateHelperPtr;
-class DepositRateHelperPtr : public boost::shared_ptr<RateHelper> {
+%shared_ptr(DepositRateHelper)
+class DepositRateHelper : public RateHelper {
   public:
-    %extend {
-        DepositRateHelperPtr(
-                const Handle<Quote>& rate,
-                const Period& tenor,
-                Natural fixingDays,
-                const Calendar& calendar,
-                BusinessDayConvention convention,
-                bool endOfMonth,
-                const DayCounter& dayCounter) {
-            return new DepositRateHelperPtr(
-                new DepositRateHelper(rate,tenor,fixingDays,
-                                      calendar,convention,
-                                      endOfMonth, dayCounter));
-        }
-        DepositRateHelperPtr(
-                Rate rate,
-                const Period& tenor,
-                Natural fixingDays,
-                const Calendar& calendar,
-                BusinessDayConvention convention,
-                bool endOfMonth,
-                const DayCounter& dayCounter) {
-            return new DepositRateHelperPtr(
-                new DepositRateHelper(rate, tenor, fixingDays,
-                                      calendar, convention,
-                                      endOfMonth, dayCounter));
-        }
-        DepositRateHelperPtr(const Handle<Quote>& rate,
-                             const boost::shared_ptr<IborIndex>& index) {
-            return new DepositRateHelperPtr(
-                new DepositRateHelper(rate, index));
-        }
-        DepositRateHelperPtr(Rate rate,
-                             const boost::shared_ptr<IborIndex>& index) {
-            return new DepositRateHelperPtr(
-                new DepositRateHelper(rate, index));
-        }
-    }
+    DepositRateHelper(
+            const Handle<Quote>& rate,
+            const Period& tenor,
+            Natural fixingDays,
+            const Calendar& calendar,
+            BusinessDayConvention convention,
+            bool endOfMonth,
+            const DayCounter& dayCounter);
+    DepositRateHelper(
+            Rate rate,
+            const Period& tenor,
+            Natural fixingDays,
+            const Calendar& calendar,
+            BusinessDayConvention convention,
+            bool endOfMonth,
+            const DayCounter& dayCounter);
+    DepositRateHelper(const Handle<Quote>& rate,
+                         const boost::shared_ptr<IborIndex>& index);
+    DepositRateHelper(Rate rate,
+                         const boost::shared_ptr<IborIndex>& index);
 };
 
-%rename(FraRateHelper) FraRateHelperPtr;
-class FraRateHelperPtr : public boost::shared_ptr<RateHelper> {
+%shared_ptr(FraRateHelper)
+class FraRateHelper : public RateHelper {
   public:
-    %extend {
-        FraRateHelperPtr(
-                const Handle<Quote>& rate,
-                Natural monthsToStart,
-                Natural monthsToEnd,
-                Natural fixingDays,
-                const Calendar& calendar,
-                BusinessDayConvention convention,
-                bool endOfMonth,
-                const DayCounter& dayCounter,
-				Pillar::Choice pillar = Pillar::LastRelevantDate,
-                Date customPillarDate = Date()) {
-            return new FraRateHelperPtr(
-                new FraRateHelper(rate,monthsToStart,monthsToEnd,
-                                  fixingDays,calendar,convention,
-                                  endOfMonth,dayCounter, pillar, customPillarDate));
-        }
-        FraRateHelperPtr(
-                Rate rate,
-                Natural monthsToStart,
-                Natural monthsToEnd,
-                Natural fixingDays,
-                const Calendar& calendar,
-                BusinessDayConvention convention,
-                bool endOfMonth,
-                const DayCounter& dayCounter,
-				Pillar::Choice pillar = Pillar::LastRelevantDate,
-                Date customPillarDate = Date()) {
-            return new FraRateHelperPtr(
-                new FraRateHelper(rate,monthsToStart,monthsToEnd,
-                                  fixingDays,calendar,convention,
-                                  endOfMonth,dayCounter, pillar, customPillarDate));
-        }
-        FraRateHelperPtr(const Handle<Quote>& rate,
-                         Natural monthsToStart,
-                         const boost::shared_ptr<IborIndex>& index,
-						 Pillar::Choice pillar = Pillar::LastRelevantDate,
-						 Date customPillarDate = Date()) {
-            return new FraRateHelperPtr(
-                new FraRateHelper(rate, monthsToStart, index, pillar, customPillarDate));
-        }
-        FraRateHelperPtr(Rate rate,
-                         Natural monthsToStart,
-                         const boost::shared_ptr<IborIndex>& index,
-						 Pillar::Choice pillar = Pillar::LastRelevantDate,
-						 Date customPillarDate = Date()) {
-            return new FraRateHelperPtr(
-                new FraRateHelper(rate, monthsToStart, index, pillar, customPillarDate));
-        }
-    }
+    FraRateHelper(
+            const Handle<Quote>& rate,
+            Natural monthsToStart,
+            Natural monthsToEnd,
+            Natural fixingDays,
+            const Calendar& calendar,
+            BusinessDayConvention convention,
+            bool endOfMonth,
+            const DayCounter& dayCounter,
+            Pillar::Choice pillar = Pillar::LastRelevantDate,
+            Date customPillarDate = Date());
+    FraRateHelper(
+            Rate rate,
+            Natural monthsToStart,
+            Natural monthsToEnd,
+            Natural fixingDays,
+            const Calendar& calendar,
+            BusinessDayConvention convention,
+            bool endOfMonth,
+            const DayCounter& dayCounter,
+            Pillar::Choice pillar = Pillar::LastRelevantDate,
+            Date customPillarDate = Date());
+    FraRateHelper(const Handle<Quote>& rate,
+                     Natural monthsToStart,
+                     const boost::shared_ptr<IborIndex>& index,
+                     Pillar::Choice pillar = Pillar::LastRelevantDate,
+                     Date customPillarDate = Date());
+    FraRateHelper(Rate rate,
+                     Natural monthsToStart,
+                     const boost::shared_ptr<IborIndex>& index,
+                     Pillar::Choice pillar = Pillar::LastRelevantDate,
+                     Date customPillarDate = Date());
 };
 
-%rename(FuturesRateHelper) FuturesRateHelperPtr;
-class FuturesRateHelperPtr : public boost::shared_ptr<RateHelper> {
+%shared_ptr(FuturesRateHelper)
+class FuturesRateHelper : public RateHelper {
   public:
-    %extend {
-        FuturesRateHelperPtr(
-                const Handle<Quote>& price,
-                const Date& iborStartDate,
-                Natural nMonths,
-                const Calendar& calendar,
-                BusinessDayConvention convention,
-                bool endOfMonth,
-                const DayCounter& dayCounter,
-                const Handle<Quote>& convexityAdjustment,
-                Futures::Type type = Futures::IMM) {
-            return new FuturesRateHelperPtr(
-                new FuturesRateHelper(price,iborStartDate,nMonths,
-                                      calendar,convention,endOfMonth,
-                                      dayCounter,convexityAdjustment,type));
-        }
-        FuturesRateHelperPtr(
-                Real price,
-                const Date& iborStartDate,
-                Natural nMonths,
-                const Calendar& calendar,
-                BusinessDayConvention convention,
-                bool endOfMonth,
-                const DayCounter& dayCounter,
-                Rate convexityAdjustment = 0.0,
-                Futures::Type type = Futures::IMM) {
-            return new FuturesRateHelperPtr(
-                new FuturesRateHelper(price,iborStartDate,nMonths,
-                                      calendar,convention,endOfMonth,
-                                      dayCounter,convexityAdjustment,type));
-        }
-        FuturesRateHelperPtr(
-                const Handle<Quote>& price,
-                const Date& iborStartDate,
-                const Date& iborEndDate,
-                const DayCounter& dayCounter,
-                const Handle<Quote>& convexityAdjustment,
-                Futures::Type type = Futures::IMM) {
-            return new FuturesRateHelperPtr(
-                new FuturesRateHelper(price,iborStartDate,iborEndDate,
-                                      dayCounter,convexityAdjustment,type));
-        }
-        FuturesRateHelperPtr(
-                Real price,
-                const Date& iborStartDate,
-                const Date& iborEndDate,
-                const DayCounter& dayCounter,
-                Rate convexityAdjustment = 0.0,
-                Futures::Type type = Futures::IMM) {
-            return new FuturesRateHelperPtr(
-                new FuturesRateHelper(price,iborStartDate,iborEndDate,
-                                      dayCounter,convexityAdjustment,type));
-        }
-        FuturesRateHelperPtr(
-                const Handle<Quote>& price,
-                const Date& iborStartDate,
-                const boost::shared_ptr<IborIndex>& index,
-                const Handle<Quote>& convexityAdjustment,
-                Futures::Type type = Futures::IMM) {
-            return new FuturesRateHelperPtr(
-                new FuturesRateHelper(price,iborStartDate,index,
-                                      convexityAdjustment,type));
-        }
-        FuturesRateHelperPtr(
-                Real price,
-                const Date& iborStartDate,
-                const boost::shared_ptr<IborIndex>& index,
-                Real convexityAdjustment = 0.0,
-                Futures::Type type = Futures::IMM) {
-            return new FuturesRateHelperPtr(
-                new FuturesRateHelper(price,iborStartDate,index,
-                                      convexityAdjustment,type));
-        }
-    }
+    FuturesRateHelper(
+            const Handle<Quote>& price,
+            const Date& iborStartDate,
+            Natural nMonths,
+            const Calendar& calendar,
+            BusinessDayConvention convention,
+            bool endOfMonth,
+            const DayCounter& dayCounter,
+            const Handle<Quote>& convexityAdjustment = Handle<Quote>(),
+            Futures::Type type = Futures::IMM);
+    FuturesRateHelper(
+            Real price,
+            const Date& iborStartDate,
+            Natural nMonths,
+            const Calendar& calendar,
+            BusinessDayConvention convention,
+            bool endOfMonth,
+            const DayCounter& dayCounter,
+            Rate convexityAdjustment = 0.0,
+            Futures::Type type = Futures::IMM);
+    FuturesRateHelper(
+            const Handle<Quote>& price,
+            const Date& iborStartDate,
+            const Date& iborEndDate,
+            const DayCounter& dayCounter,
+            const Handle<Quote>& convexityAdjustment = Handle<Quote>(),
+            Futures::Type type = Futures::IMM);
+    FuturesRateHelper(
+            Real price,
+            const Date& iborStartDate,
+            const Date& iborEndDate,
+            const DayCounter& dayCounter,
+            Rate convexityAdjustment = 0.0,
+            Futures::Type type = Futures::IMM);
+    FuturesRateHelper(
+            const Handle<Quote>& price,
+            const Date& iborStartDate,
+            const boost::shared_ptr<IborIndex>& index,
+            const Handle<Quote>& convexityAdjustment = Handle<Quote>(),
+            Futures::Type type = Futures::IMM);
+    FuturesRateHelper(
+            Real price,
+            const Date& iborStartDate,
+            const boost::shared_ptr<IborIndex>& index,
+            Real convexityAdjustment = 0.0,
+            Futures::Type type = Futures::IMM);
 };
 
-%rename(SwapRateHelper) SwapRateHelperPtr;
-class SwapRateHelperPtr : public boost::shared_ptr<RateHelper> {
+%shared_ptr(SwapRateHelper)
+class SwapRateHelper : public RateHelper {
   public:
-    %extend {
-        SwapRateHelperPtr(
-                const Handle<Quote>& rate,
-                const Period& tenor,
-                const Calendar& calendar,
-                Frequency fixedFrequency,
-                BusinessDayConvention fixedConvention,
-                const DayCounter& fixedDayCount,
-                const boost::shared_ptr<IborIndex>& index,
-                const Handle<Quote>& spread = Handle<Quote>(),
-                const Period& fwdStart = 0*Days,
-                const Handle<YieldTermStructure>& discountingCurve
-                                            = Handle<YieldTermStructure>(),
-                Natural settlementDays = Null<Natural>(),
-                Pillar::Choice pillar = Pillar::LastRelevantDate,
-                Date customPillarDate = Date()) {
-            return new SwapRateHelperPtr(
-                new SwapRateHelper(rate, tenor, calendar,
-                                   fixedFrequency, fixedConvention,
-                                   fixedDayCount, index,
-                                   spread, fwdStart,
-                                   discountingCurve, settlementDays,
-                                   pillar, customPillarDate));
-        }
-        SwapRateHelperPtr(
-                Rate rate,
-                const Period& tenor,
-                const Calendar& calendar,
-                Frequency fixedFrequency,
-                BusinessDayConvention fixedConvention,
-                const DayCounter& fixedDayCount,
-                const boost::shared_ptr<IborIndex>& index,
-                const Handle<Quote>& spread = Handle<Quote>(),
-                const Period& fwdStart = 0*Days,
-                const Handle<YieldTermStructure>& discountingCurve
-                                            = Handle<YieldTermStructure>(),
-                Natural settlementDays = Null<Natural>(),
-                Pillar::Choice pillar = Pillar::LastRelevantDate,
-                Date customPillarDate = Date()) {
-            return new SwapRateHelperPtr(
-                new SwapRateHelper(rate, tenor, calendar,
-                                   fixedFrequency, fixedConvention,
-                                   fixedDayCount, index,
-                                   spread, fwdStart,
-                                   discountingCurve, settlementDays,
-                                   pillar, customPillarDate));
-        }
-        SwapRateHelperPtr(
-                const Handle<Quote>& rate,
-                const boost::shared_ptr<SwapIndex>& index,
-                const Handle<Quote>& spread = Handle<Quote>(),
-                const Period& fwdStart = 0*Days,
-                const Handle<YieldTermStructure>& discountingCurve
-                                            = Handle<YieldTermStructure>(),
-                Pillar::Choice pillar = Pillar::LastRelevantDate,
-                Date customPillarDate = Date()) {
-            return new SwapRateHelperPtr(
-                new SwapRateHelper(rate, index,
-                                   spread, fwdStart,
-                                   discountingCurve,
-                                   pillar, customPillarDate));
-        }
-        SwapRateHelperPtr(
-                Rate rate,
-                const boost::shared_ptr<SwapIndex>& index,
-                const Handle<Quote>& spread = Handle<Quote>(),
-                const Period& fwdStart = 0*Days,
-                const Handle<YieldTermStructure>& discountingCurve
-                                            = Handle<YieldTermStructure>(),
-                Pillar::Choice pillar = Pillar::LastRelevantDate,
-                Date customPillarDate = Date()) {
-            return new SwapRateHelperPtr(
-                new SwapRateHelper(rate, index,
-                                   spread, fwdStart,
-                                   discountingCurve,
-                                   pillar, customPillarDate));
-        }
-		Spread spread() {
-			return boost::dynamic_pointer_cast<SwapRateHelper>(*self)->spread();
-		}
-        boost::shared_ptr<VanillaSwap> swap() {
-            return boost::dynamic_pointer_cast<SwapRateHelper>(*self)->swap();
-        }
-    }
+    SwapRateHelper(
+            const Handle<Quote>& rate,
+            const Period& tenor,
+            const Calendar& calendar,
+            Frequency fixedFrequency,
+            BusinessDayConvention fixedConvention,
+            const DayCounter& fixedDayCount,
+            const boost::shared_ptr<IborIndex>& index,
+            const Handle<Quote>& spread = Handle<Quote>(),
+            const Period& fwdStart = 0*Days,
+            const Handle<YieldTermStructure>& discountingCurve
+                                        = Handle<YieldTermStructure>(),
+            Natural settlementDays = Null<Natural>(),
+            Pillar::Choice pillar = Pillar::LastRelevantDate,
+            Date customPillarDate = Date());
+    SwapRateHelper(
+            Rate rate,
+            const Period& tenor,
+            const Calendar& calendar,
+            Frequency fixedFrequency,
+            BusinessDayConvention fixedConvention,
+            const DayCounter& fixedDayCount,
+            const boost::shared_ptr<IborIndex>& index,
+            const Handle<Quote>& spread = Handle<Quote>(),
+            const Period& fwdStart = 0*Days,
+            const Handle<YieldTermStructure>& discountingCurve
+                                        = Handle<YieldTermStructure>(),
+            Natural settlementDays = Null<Natural>(),
+            Pillar::Choice pillar = Pillar::LastRelevantDate,
+            Date customPillarDate = Date());
+    SwapRateHelper(
+            const Handle<Quote>& rate,
+            const boost::shared_ptr<SwapIndex>& index,
+            const Handle<Quote>& spread = Handle<Quote>(),
+            const Period& fwdStart = 0*Days,
+            const Handle<YieldTermStructure>& discountingCurve
+                                        = Handle<YieldTermStructure>(),
+            Pillar::Choice pillar = Pillar::LastRelevantDate,
+            Date customPillarDate = Date());
+    SwapRateHelper(
+            Rate rate,
+            const boost::shared_ptr<SwapIndex>& index,
+            const Handle<Quote>& spread = Handle<Quote>(),
+            const Period& fwdStart = 0*Days,
+            const Handle<YieldTermStructure>& discountingCurve
+                                        = Handle<YieldTermStructure>(),
+            Pillar::Choice pillar = Pillar::LastRelevantDate,
+            Date customPillarDate = Date());
+    Spread spread();
+    boost::shared_ptr<VanillaSwap> swap();
 };
 
-%rename(BondHelper) BondHelperPtr;
-class BondHelperPtr : public boost::shared_ptr<RateHelper> {
+%shared_ptr(BondHelper)
+class BondHelper : public RateHelper {
   public:
-    %extend {
-        BondHelperPtr(const Handle<Quote>& cleanPrice,
-                      const boost::shared_ptr<Bond>& bond,
-                      bool useCleanPrice = true) {
-            return new BondHelperPtr(
-                new BondHelper(cleanPrice, bond, useCleanPrice));
-        }
+    BondHelper(const Handle<Quote>& cleanPrice,
+                  const boost::shared_ptr<Bond>& bond,
+                  bool useCleanPrice = true);
 
-        boost::shared_ptr<Bond> bond() {
-            return boost::dynamic_pointer_cast<BondHelper>(*self)->bond();
-        }
-    }
+    boost::shared_ptr<Bond> bond();
 };
 
-%rename(FixedRateBondHelper) FixedRateBondHelperPtr;
-class FixedRateBondHelperPtr : public BondHelperPtr {
+%shared_ptr(FixedRateBondHelper)
+class FixedRateBondHelper : public BondHelper {
   public:
-    %extend {
-        FixedRateBondHelperPtr(
-                      const Handle<Quote>& cleanPrice,
-                      Size settlementDays,
-                      Real faceAmount,
-                      const Schedule& schedule,
-                      const std::vector<Rate>& coupons,
-                      const DayCounter& paymentDayCounter,
-                      BusinessDayConvention paymentConvention = Following,
-                      Real redemption = 100.0,
-                      const Date& issueDate = Date(),
-                      const Calendar& paymentCalendar = Calendar(),
-                      const Period& exCouponPeriod = Period(),
-                      const Calendar& exCouponCalendar = Calendar(),
-                      BusinessDayConvention exCouponConvention = Unadjusted,
-                      bool exCouponEndOfMonth = false,
-                      bool useCleanPrice = true) {
-            return new FixedRateBondHelperPtr(
-                new FixedRateBondHelper(cleanPrice, settlementDays, faceAmount,
-                                        schedule, coupons, paymentDayCounter,
-                                        paymentConvention, redemption,
-                                        issueDate, paymentCalendar,
-                                        exCouponPeriod, exCouponCalendar,
-                                        exCouponConvention, exCouponEndOfMonth,
-                                        useCleanPrice));
-        }
+    FixedRateBondHelper(
+                  const Handle<Quote>& cleanPrice,
+                  Size settlementDays,
+                  Real faceAmount,
+                  const Schedule& schedule,
+                  const std::vector<Rate>& coupons,
+                  const DayCounter& paymentDayCounter,
+                  BusinessDayConvention paymentConvention = Following,
+                  Real redemption = 100.0,
+                  const Date& issueDate = Date(),
+                  const Calendar& paymentCalendar = Calendar(),
+                  const Period& exCouponPeriod = Period(),
+                  const Calendar& exCouponCalendar = Calendar(),
+                  BusinessDayConvention exCouponConvention = Unadjusted,
+                  bool exCouponEndOfMonth = false,
+                  bool useCleanPrice = true);
 
-        boost::shared_ptr<Bond> bond() {
-            return boost::dynamic_pointer_cast<FixedRateBondHelper>(*self)->bond();
-        }
-    }
+    boost::shared_ptr<FixedRateBond> fixedRateBond();
 };
 
 
-%rename(OISRateHelper) OISRateHelperPtr;
-class OISRateHelperPtr : public boost::shared_ptr<RateHelper> {
+%shared_ptr(OISRateHelper)
+class OISRateHelper : public RateHelper {
   public:
-    %extend {
-        OISRateHelperPtr(
-                Natural settlementDays,
-                const Period& tenor,
-                const Handle<Quote>& rate,
-                const boost::shared_ptr<OvernightIndex>& index,
-                const Handle<YieldTermStructure>& discountingCurve
-                                            = Handle<YieldTermStructure>(),
-                bool telescopicValueDates = false,
-                Natural paymentLag = 0,
-                BusinessDayConvention paymentConvention = Following,
-                Frequency paymentFrequency = Annual,
-                const Calendar& paymentCalendar = Calendar(),
-                const Period& forwardStart = 0 * Days, 
-                const Spread overnightSpread = 0.0) {
-            return new OISRateHelperPtr(
-                new OISRateHelper(settlementDays,tenor,rate,
-                                  index,discountingCurve,
-                                  telescopicValueDates, paymentLag,
-                                  paymentConvention, paymentFrequency,
-                                  paymentCalendar, forwardStart,
-                                  overnightSpread));
-        }
-		Real impliedQuote() {
-			return boost::dynamic_pointer_cast<OISRateHelper>(*self)->impliedQuote();
-		}
-		boost::shared_ptr<OvernightIndexedSwap> swap() {
-            return boost::dynamic_pointer_cast<OISRateHelper>(*self)->swap();
-        }
-    }
+    OISRateHelper(
+            Natural settlementDays,
+            const Period& tenor,
+            const Handle<Quote>& rate,
+            const boost::shared_ptr<OvernightIndex>& index,
+            const Handle<YieldTermStructure>& discountingCurve
+                                        = Handle<YieldTermStructure>(),
+            bool telescopicValueDates = false,
+            Natural paymentLag = 0,
+            BusinessDayConvention paymentConvention = Following,
+            Frequency paymentFrequency = Annual,
+            const Calendar& paymentCalendar = Calendar(),
+            const Period& forwardStart = 0 * Days, 
+            const Spread overnightSpread = 0.0);
+    boost::shared_ptr<OvernightIndexedSwap> swap();
 };
 
-%rename(DatedOISRateHelper) DatedOISRateHelperPtr;
-class DatedOISRateHelperPtr : public boost::shared_ptr<RateHelper> {
+%shared_ptr(DatedOISRateHelper)
+class DatedOISRateHelper : public RateHelper {
   public:
-    %extend {
-        DatedOISRateHelperPtr(
-                const Date& startDate,
-                const Date& endDate,
-                const Handle<Quote>& rate,
-                const boost::shared_ptr<OvernightIndex>& index,
-                const Handle<YieldTermStructure>& discountingCurve
-                                            = Handle<YieldTermStructure>()) {
-            return new DatedOISRateHelperPtr(
-                new DatedOISRateHelper(startDate,endDate,rate,
-                                       index,discountingCurve));
-        }
-    }
+    DatedOISRateHelper(
+            const Date& startDate,
+            const Date& endDate,
+            const Handle<Quote>& rate,
+            const boost::shared_ptr<OvernightIndex>& index,
+            const Handle<YieldTermStructure>& discountingCurve
+                                        = Handle<YieldTermStructure>());
 };
 
-%rename(FxSwapRateHelper) FxSwapRateHelperPtr;
-class FxSwapRateHelperPtr : public boost::shared_ptr<RateHelper> {
+%shared_ptr(FxSwapRateHelper)
+class FxSwapRateHelper : public RateHelper {
   public:
-    %extend {
-        FxSwapRateHelperPtr(
-                const Handle<Quote>& fwdPoint,
-                const Handle<Quote>& spotFx,
-                const Period& tenor,
-                Natural fixingDays,
-                const Calendar& calendar,
-                BusinessDayConvention convention,
-                bool endOfMonth,
-                bool isFxBaseCurrencyCollateralCurrency,
-                const Handle<YieldTermStructure>& coll
-                                = Handle<YieldTermStructure>(),
-                const Calendar& tradingCalendar = Calendar()) {
-            return new FxSwapRateHelperPtr(
-                new FxSwapRateHelper(fwdPoint, spotFx, tenor,
-                                     fixingDays, calendar, convention,
-                                     endOfMonth,
-                                     isFxBaseCurrencyCollateralCurrency,
-                                     coll, tradingCalendar));
-        } 
-   }
+    FxSwapRateHelper(
+            const Handle<Quote>& fwdPoint,
+            const Handle<Quote>& spotFx,
+            const Period& tenor,
+            Natural fixingDays,
+            const Calendar& calendar,
+            BusinessDayConvention convention,
+            bool endOfMonth,
+            bool isFxBaseCurrencyCollateralCurrency,
+            const Handle<YieldTermStructure>& collateralCurve,
+            const Calendar& tradingCalendar = Calendar());
 };
 
 
@@ -483,16 +324,16 @@ namespace std {
 }
 
 %inline %{
-    DepositRateHelperPtr as_depositratehelper(const boost::shared_ptr<RateHelper> helper) {
+    const boost::shared_ptr<DepositRateHelper> as_depositratehelper(const boost::shared_ptr<RateHelper> helper) {
         return boost::dynamic_pointer_cast<DepositRateHelper>(helper);
     }
-	FraRateHelperPtr as_fraratehelper(const boost::shared_ptr<RateHelper> helper) {
+	const boost::shared_ptr<FraRateHelper> as_fraratehelper(const boost::shared_ptr<RateHelper> helper) {
         return boost::dynamic_pointer_cast<FraRateHelper>(helper);
     }
-    SwapRateHelperPtr as_swapratehelper(const boost::shared_ptr<RateHelper> helper) {
+    const boost::shared_ptr<SwapRateHelper> as_swapratehelper(const boost::shared_ptr<RateHelper> helper) {
         return boost::dynamic_pointer_cast<SwapRateHelper>(helper);
     }
-    OISRateHelperPtr as_oisratehelper(const boost::shared_ptr<RateHelper> helper) {
+    const boost::shared_ptr<OISRateHelper> as_oisratehelper(const boost::shared_ptr<RateHelper> helper) {
         return boost::dynamic_pointer_cast<OISRateHelper>(helper);
     }
 %}

--- a/SWIG/stochasticprocess.i
+++ b/SWIG/stochasticprocess.i
@@ -3,6 +3,7 @@
  Copyright (C) 2004, 2005, 2007, 2008 StatPro Italia srl
  Copyright (C) 2010 Klaus Spanderen
  Copyright (C) 2015 Matthias Groncki
+ Copyright (C) 2018 Matthias Lungwitz
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -24,27 +25,17 @@
 %include marketelements.i
 %include termstructures.i
 %include volatilities.i
+%include observer.i
 
 %{
 using QuantLib::StochasticProcess;
 %}
 
-%ignore StochasticProcess;
-class StochasticProcess {
-  public:
-    virtual Size size() const = 0;
-    virtual Size factors() const;
-    virtual Array initialValues() const = 0;
-    virtual Array drift(Time t, const Array& x) const = 0;
-    virtual Matrix diffusion(Time t, const Array& x) const = 0;
-    virtual Array expectation(Time t0, const Array& x0, Time dt) const;
-    virtual Matrix stdDeviation(Time t0, const Array& x0, Time dt) const;
-    virtual Matrix covariance(Time t0, const Array& x0, Time dt) const;
-    virtual Array evolve(Time t0, const Array& x0,
-                         Time dt, const Array& dw) const;
+%shared_ptr(StochasticProcess)
+class StochasticProcess : public Observable {
+  private:
+    StochasticProcess();
 };
-%template(StochasticProcess) boost::shared_ptr<StochasticProcess>;
-IsObservable(boost::shared_ptr<StochasticProcess>);
 
 #if defined(SWIGCSHARP)
 SWIG_STD_VECTOR_ENHANCED( boost::shared_ptr<StochasticProcess> )
@@ -55,389 +46,228 @@ std::vector<boost::shared_ptr<StochasticProcess> >;
 
 %{
 using QuantLib::StochasticProcess1D;
-typedef boost::shared_ptr<StochasticProcess> StochasticProcess1DPtr;
 %}
 
-%rename(StochasticProcess1D) StochasticProcess1DPtr;
-class StochasticProcess1DPtr
-    : public boost::shared_ptr<StochasticProcess> {
+%shared_ptr(StochasticProcess1D)
+class StochasticProcess1D
+    : public StochasticProcess {
   public:
-    %extend {
-      Real x0() {
-          return boost::dynamic_pointer_cast<StochasticProcess1D>(*self)->x0();
-      }
-      Real drift(Time t, Real x) {
-          return boost::dynamic_pointer_cast<StochasticProcess1D>(*self)
-              ->drift(t, x);
-      }
-      Real diffusion(Time t, Real x) {
-          return boost::dynamic_pointer_cast<StochasticProcess1D>(*self)
-              ->diffusion(t, x);
-      }
-      Real expectation(Time t0, Real x0, Time dt) {
-          return boost::dynamic_pointer_cast<StochasticProcess1D>(*self)
-              ->expectation(t0, x0, dt);
-      }
-      Real stdDeviation(Time t0, Real x0, Time dt) {
-          return boost::dynamic_pointer_cast<StochasticProcess1D>(*self)
-              ->stdDeviation(t0, x0, dt);
-      }
-      Real variance(Time t0, Real x0, Time dt)  {
-          return boost::dynamic_pointer_cast<StochasticProcess1D>(*self)
-              ->variance(t0, x0, dt);
-      }
-      Real evolve(Time t0, Real x0, Time dt, Real dw) {
-          return boost::dynamic_pointer_cast<StochasticProcess1D>(*self)
-              ->evolve(t0, x0, dt, dw);
-      }
-      Real apply(Real x0, Real dx)  {
-          return boost::dynamic_pointer_cast<StochasticProcess1D>(*self)
-              ->apply(x0, dx);
-      }
-    }
-  private:
-    StochasticProcess1DPtr();
+      Real x0();
+      Real drift(Time t, Real x);
+      Real diffusion(Time t, Real x);
+      Real expectation(Time t0, Real x0, Time dt);
+      Real stdDeviation(Time t0, Real x0, Time dt);
+      Real variance(Time t0, Real x0, Time dt);
+      Real evolve(Time t0, Real x0, Time dt, Real dw);
+      Real apply(Real x0, Real dx);
 };
 
 
 %{
 using QuantLib::GeneralizedBlackScholesProcess;
-typedef boost::shared_ptr<StochasticProcess> GeneralizedBlackScholesProcessPtr;
 %}
 
-%rename(GeneralizedBlackScholesProcess) GeneralizedBlackScholesProcessPtr;
-class GeneralizedBlackScholesProcessPtr : public StochasticProcess1DPtr {
+%shared_ptr(GeneralizedBlackScholesProcess)
+class GeneralizedBlackScholesProcess : public StochasticProcess1D {
   public:
-    %extend {
-      GeneralizedBlackScholesProcessPtr(
+      GeneralizedBlackScholesProcess(
                              const Handle<Quote>& s0,
                              const Handle<YieldTermStructure>& dividendTS,
                              const Handle<YieldTermStructure>& riskFreeTS,
-                             const Handle<BlackVolTermStructure>& volTS) {
-          return new GeneralizedBlackScholesProcessPtr(
-                       new GeneralizedBlackScholesProcess(s0, dividendTS,
-                                                          riskFreeTS, volTS));
-      }
-      Handle<Quote> stateVariable() {
-          return boost::dynamic_pointer_cast<
-                      GeneralizedBlackScholesProcess>(*self)->stateVariable();
-      }
-      Handle<YieldTermStructure> dividendYield() {
-          return boost::dynamic_pointer_cast<
-                      GeneralizedBlackScholesProcess>(*self)->dividendYield();
-      }
-      Handle<YieldTermStructure> riskFreeRate() {
-          return boost::dynamic_pointer_cast<
-                      GeneralizedBlackScholesProcess>(*self)->riskFreeRate();
-      }
-      Handle<BlackVolTermStructure> blackVolatility() const {
-          return boost::dynamic_pointer_cast<
-                      GeneralizedBlackScholesProcess>(*self)->blackVolatility();
-      }
-    }
+                             const Handle<BlackVolTermStructure>& volTS);
+      Handle<Quote> stateVariable();
+      Handle<YieldTermStructure> dividendYield();
+      Handle<YieldTermStructure> riskFreeRate();
+      Handle<BlackVolTermStructure> blackVolatility();
 };
 
 %{
 using QuantLib::BlackScholesProcess;
-typedef boost::shared_ptr<StochasticProcess> BlackScholesProcessPtr;
 %}
 
-%rename(BlackScholesProcess) BlackScholesProcessPtr;
-class BlackScholesProcessPtr : public GeneralizedBlackScholesProcessPtr {
+%shared_ptr(BlackScholesProcess)
+class BlackScholesProcess : public GeneralizedBlackScholesProcess {
   public:
-    %extend {
-      BlackScholesProcessPtr(const Handle<Quote>& s0,
-                               const Handle<YieldTermStructure>& riskFreeTS,
-                               const Handle<BlackVolTermStructure>& volTS) {
-          return new BlackScholesProcessPtr(
-                            new BlackScholesProcess(s0, riskFreeTS, volTS));
-      }
-    }
+  BlackScholesProcess(const Handle<Quote>& s0,
+                           const Handle<YieldTermStructure>& riskFreeTS,
+                           const Handle<BlackVolTermStructure>& volTS);
 };
 
 %{
 using QuantLib::BlackScholesMertonProcess;
-typedef boost::shared_ptr<StochasticProcess> BlackScholesMertonProcessPtr;
 %}
 
-%rename(BlackScholesMertonProcess) BlackScholesMertonProcessPtr;
-class BlackScholesMertonProcessPtr : public GeneralizedBlackScholesProcessPtr {
+%shared_ptr(BlackScholesMertonProcess)
+class BlackScholesMertonProcess : public GeneralizedBlackScholesProcess {
   public:
-    %extend {
-      BlackScholesMertonProcessPtr(
+      BlackScholesMertonProcess(
                              const Handle<Quote>& s0,
                              const Handle<YieldTermStructure>& dividendTS,
                              const Handle<YieldTermStructure>& riskFreeTS,
-                             const Handle<BlackVolTermStructure>& volTS) {
-          return new BlackScholesMertonProcessPtr(
-                            new BlackScholesMertonProcess(s0, dividendTS,
-                                                          riskFreeTS, volTS));
-      }
-    }
+                             const Handle<BlackVolTermStructure>& volTS);
 };
 
 %{
 using QuantLib::BlackProcess;
-typedef boost::shared_ptr<StochasticProcess> BlackProcessPtr;
 %}
 
-%rename(BlackProcess) BlackProcessPtr;
-class BlackProcessPtr : public GeneralizedBlackScholesProcessPtr {
+%shared_ptr(BlackProcess)
+class BlackProcess : public GeneralizedBlackScholesProcess {
   public:
-    %extend {
-      BlackProcessPtr(const Handle<Quote>& s0,
+      BlackProcess(const Handle<Quote>& s0,
                       const Handle<YieldTermStructure>& riskFreeTS,
-                      const Handle<BlackVolTermStructure>& volTS) {
-          return new BlackProcessPtr(new BlackProcess(s0, riskFreeTS, volTS));
-      }
-    }
+                      const Handle<BlackVolTermStructure>& volTS);
 };
 
 %{
 using QuantLib::GarmanKohlagenProcess;
-typedef boost::shared_ptr<StochasticProcess> GarmanKohlagenProcessPtr;
 %}
 
-%rename(GarmanKohlagenProcess) GarmanKohlagenProcessPtr;
-class GarmanKohlagenProcessPtr : public GeneralizedBlackScholesProcessPtr {
+%shared_ptr(GarmanKohlagenProcess)
+class GarmanKohlagenProcess : public GeneralizedBlackScholesProcess {
   public:
-    %extend {
-      GarmanKohlagenProcessPtr(
+      GarmanKohlagenProcess(
                          const Handle<Quote>& s0,
                          const Handle<YieldTermStructure>& foreignRiskFreeTS,
                          const Handle<YieldTermStructure>& domesticRiskFreeTS,
-                         const Handle<BlackVolTermStructure>& volTS) {
-          return new GarmanKohlagenProcessPtr(
-                        new GarmanKohlagenProcess(s0, foreignRiskFreeTS,
-                                                  domesticRiskFreeTS, volTS));
-      }
-    }
+                         const Handle<BlackVolTermStructure>& volTS);
 };
 
 
 
 %{
 using QuantLib::Merton76Process;
-typedef boost::shared_ptr<StochasticProcess> Merton76ProcessPtr;
 %}
 
-%rename(Merton76Process) Merton76ProcessPtr;
-class Merton76ProcessPtr : public StochasticProcess1DPtr {
+%shared_ptr(Merton76Process)
+class Merton76Process : public StochasticProcess1D {
   public:
-    %extend {
-      Merton76ProcessPtr(const Handle<Quote>& stateVariable,
+      Merton76Process(const Handle<Quote>& stateVariable,
                          const Handle<YieldTermStructure>& dividendTS,
                          const Handle<YieldTermStructure>& riskFreeTS,
                          const Handle<BlackVolTermStructure>& volTS,
                          const Handle<Quote>& jumpIntensity,
                          const Handle<Quote>& meanLogJump,
-                         const Handle<Quote>& jumpVolatility) {
-            return new Merton76ProcessPtr(
-                              new Merton76Process(stateVariable, dividendTS,
-                                                  riskFreeTS, volTS,
-                                                  jumpIntensity, meanLogJump,
-                                                  jumpVolatility));
-      }
-    }
+                         const Handle<Quote>& jumpVolatility);
 };
 
 %{
 using QuantLib::StochasticProcessArray;
-typedef boost::shared_ptr<StochasticProcess> StochasticProcessArrayPtr;
 %}
 
-%rename(StochasticProcessArray) StochasticProcessArrayPtr;
-class StochasticProcessArrayPtr : public boost::shared_ptr<StochasticProcess> {
+%shared_ptr(StochasticProcessArray)
+class StochasticProcessArray : public StochasticProcess {
   public:
-    %extend {
-      StochasticProcessArrayPtr(
-               const std::vector<boost::shared_ptr<StochasticProcess> >&array,
-               const Matrix &correlation) {
-          std::vector<boost::shared_ptr<StochasticProcess1D> > in_array;
-          for (Size j=0; j < array.size(); j++)
-              in_array.push_back(
-                  boost::dynamic_pointer_cast<StochasticProcess1D>(array[j]));
-          return new StochasticProcessArrayPtr(
-                           new StochasticProcessArray(in_array, correlation));
-      }
-    }
+      StochasticProcessArray(
+               const std::vector<boost::shared_ptr<StochasticProcess1D> >&array,
+               const Matrix &correlation);
 };
 
 
 %{
 using QuantLib::GeometricBrownianMotionProcess;
-typedef boost::shared_ptr<StochasticProcess> GeometricBrownianMotionProcessPtr;
 %}
 
-%rename(GeometricBrownianMotionProcess) GeometricBrownianMotionProcessPtr;
-class GeometricBrownianMotionProcessPtr : public StochasticProcess1DPtr {
+%shared_ptr(GeometricBrownianMotionProcess)
+class GeometricBrownianMotionProcess : public StochasticProcess1D {
   public:
-    %extend {
-      GeometricBrownianMotionProcessPtr(Real initialValue,
+      GeometricBrownianMotionProcess(Real initialValue,
                                         Real mu,
-                                        Real sigma) {
-          return new GeometricBrownianMotionProcessPtr(
-                 new GeometricBrownianMotionProcess(initialValue, mu, sigma));
-      }
-    }
+                                        Real sigma);
 };
 
 %{
 using QuantLib::VarianceGammaProcess;
-typedef boost::shared_ptr<StochasticProcess> VarianceGammaProcessPtr;
 %}
 
-%rename(VarianceGammaProcess) VarianceGammaProcessPtr;
-class VarianceGammaProcessPtr : public StochasticProcess1DPtr {
+%shared_ptr(VarianceGammaProcess)
+class VarianceGammaProcess : public StochasticProcess1D {
   public:
-    %extend {
-      VarianceGammaProcessPtr(const Handle<Quote>& s0,
+      VarianceGammaProcess(const Handle<Quote>& s0,
             const Handle<YieldTermStructure>& dividendYield,
             const Handle<YieldTermStructure>& riskFreeRate,
-            Real sigma, Real nu, Real theta) {
-          return new VarianceGammaProcessPtr(
-                 new VarianceGammaProcess(s0,dividendYield,riskFreeRate,sigma,nu,theta));
-      }
-    }
+            Real sigma, Real nu, Real theta);
 };
 
 
 %{
 using QuantLib::HestonProcess;
-typedef boost::shared_ptr<StochasticProcess> HestonProcessPtr;
 %}
 
-%rename(HestonProcess) HestonProcessPtr;
-class HestonProcessPtr : public boost::shared_ptr<StochasticProcess> {
+%shared_ptr(HestonProcess)
+class HestonProcess : public StochasticProcess {
   public:
-    %extend {
-      HestonProcessPtr(const Handle<YieldTermStructure>& riskFreeTS,
+      HestonProcess(const Handle<YieldTermStructure>& riskFreeTS,
 					   const Handle<YieldTermStructure>& dividendTS,
 					   const Handle<Quote>& s0,
 					   Real v0, Real kappa,
-                       Real theta, Real sigma, Real rho) {
-		return new HestonProcessPtr(
-			new HestonProcess(riskFreeTS, dividendTS, s0, v0, 
-						      kappa, theta, sigma, rho));	
-      }
+                       Real theta, Real sigma, Real rho);
                        
-      Handle<Quote> s0() {
-          return boost::dynamic_pointer_cast<
-                      HestonProcess>(*self)->s0();
-      }
-      Handle<YieldTermStructure> dividendYield() {
-          return boost::dynamic_pointer_cast<
-                      HestonProcess>(*self)->dividendYield();
-      }
-      Handle<YieldTermStructure> riskFreeRate() {
-          return boost::dynamic_pointer_cast<
-                      HestonProcess>(*self)->riskFreeRate();
-      }
-    }
+      Handle<Quote> s0();
+      Handle<YieldTermStructure> dividendYield();
+      Handle<YieldTermStructure> riskFreeRate();
 };
 
 %{
 using QuantLib::BatesProcess;
-typedef boost::shared_ptr<StochasticProcess> BatesProcessPtr;
 %}
 
-%rename(BatesProcess) BatesProcessPtr;
-class BatesProcessPtr : public HestonProcessPtr {
+%shared_ptr(BatesProcess)
+class BatesProcess : public HestonProcess {
   public:
-    %extend {
-      BatesProcessPtr(const Handle<YieldTermStructure>& riskFreeRate,
+      BatesProcess(const Handle<YieldTermStructure>& riskFreeRate,
                       const Handle<YieldTermStructure>& dividendYield,
                       const Handle<Quote>& s0,
                       Real v0, Real kappa,
                       Real theta, Real sigma, Real rho,
-                      Real lambda, Real nu, Real delta) {
-		return new BatesProcessPtr(
-			new BatesProcess(riskFreeRate, dividendYield, s0, v0, 
-							 kappa, theta, sigma, rho, 
-							 lambda, nu, delta));
-	  }
-    }
+                      Real lambda, Real nu, Real delta);
 };
 
 %{
 using QuantLib::HullWhiteProcess;
-typedef boost::shared_ptr<StochasticProcess> HullWhiteProcessPtr;
 %}
 
-%rename(HullWhiteProcess) HullWhiteProcessPtr;
-class HullWhiteProcessPtr : public StochasticProcess1DPtr {
+%shared_ptr(HullWhiteProcess)
+class HullWhiteProcess : public StochasticProcess1D {
   public:
-    %extend {
-      HullWhiteProcessPtr(const Handle<YieldTermStructure>& riskFreeTS,
-                          Real a, Real sigma) {
-            return new HullWhiteProcessPtr(new HullWhiteProcess(riskFreeTS, a, sigma));	
-        }
-    }
+      HullWhiteProcess(const Handle<YieldTermStructure>& riskFreeTS,
+                          Real a, Real sigma);
 };
 
 %{
 using QuantLib::HullWhiteForwardProcess;
-typedef boost::shared_ptr<StochasticProcess> HullWhiteForwardProcessPtr;
 %}
 
-%rename(HullWhiteForwardProcess) HullWhiteForwardProcessPtr;
-class HullWhiteForwardProcessPtr : public StochasticProcess1DPtr {
+%shared_ptr(HullWhiteForwardProcess)
+class HullWhiteForwardProcess : public StochasticProcess1D {
   public:
-    %extend {
-        HullWhiteForwardProcessPtr(const Handle<YieldTermStructure>& riskFreeTS,
-                                 Real a,
-                                 Real sigma){
-            return new HullWhiteForwardProcessPtr(
-                new HullWhiteForwardProcess(riskFreeTS, a, sigma));
-        }
-        Real alpha(Time t) const{
-            return boost::dynamic_pointer_cast<HullWhiteForwardProcess>(*self)      ->alpha(t);
-        }
-        Real M_T(Real s, Real t, Real T) const{
-            return boost::dynamic_pointer_cast<HullWhiteForwardProcess>(*self)      ->M_T(s, t, T);
-        }
-        Real B(Time t, Time T) const{
-            return boost::dynamic_pointer_cast<HullWhiteForwardProcess>(*self)      ->B(t, T);
-        }
-        void setForwardMeasureTime(Time t) {
-            boost::dynamic_pointer_cast<HullWhiteForwardProcess>(*self)             ->setForwardMeasureTime(t);
-        }
-    }
+    HullWhiteForwardProcess(const Handle<YieldTermStructure>& riskFreeTS,
+                             Real a,
+                             Real sigma);
+    Real alpha(Time t) const;
+    Real M_T(Real s, Real t, Real T) const;
+    Real B(Time t, Time T) const;
+    void setForwardMeasureTime(Time t);
 };
 
 %{
 using QuantLib::GsrProcess;
-typedef boost::shared_ptr<StochasticProcess> GsrProcessPtr;
 %}
 
-%rename(GsrProcess) GsrProcessPtr;
-class GsrProcessPtr : public StochasticProcess1DPtr {
+%shared_ptr(GsrProcess)
+class GsrProcess : public StochasticProcess1D {
     public:
-    %extend {
-        GsrProcessPtr(const Array &times, const Array &vols,
-                   const Array &reversions, const Real T = 60.0) {
-            return new GsrProcessPtr(new GsrProcess(times, vols, reversions, T));
-        }
-        Real sigma(Time t) {
-            return boost::dynamic_pointer_cast<GsrProcess>(*self)->sigma(t);
-        }
-        Real reversion(Time t){
-            return boost::dynamic_pointer_cast<GsrProcess>(*self)->reversion(t);
-        }
-        Real y(Time t) {
-            return boost::dynamic_pointer_cast<GsrProcess>(*self)->y(t);
-        }
-        Real G(Time t, Time T, Real x){
-            return boost::dynamic_pointer_cast<GsrProcess>(*self)->G(t, T, x);
-        }
-        void setForwardMeasureTime(Time t) {
-            boost::dynamic_pointer_cast<GsrProcess>(*self)->setForwardMeasureTime(t);
-        }
-    }
+    GsrProcess(const Array &times, const Array &vols,
+               const Array &reversions, const Real T = 60.0);
+    Real sigma(Time t);
+    Real reversion(Time t);
+    Real y(Time t);
+    Real G(Time t, Time T, Real x);
+    void setForwardMeasureTime(Time t);
 };
 
 %inline %{
-    GsrProcessPtr as_gsr_process(
+    const boost::shared_ptr<GsrProcess> as_gsr_process(
                            const boost::shared_ptr<StochasticProcess>& proc) {
         return boost::dynamic_pointer_cast<GsrProcess>(proc);
     }
@@ -448,90 +278,69 @@ class GsrProcessPtr : public StochasticProcess1DPtr {
 using QuantLib::KlugeExtOUProcess;
 using QuantLib::ExtendedOrnsteinUhlenbeckProcess;
 using QuantLib::ExtOUWithJumpsProcess;
-typedef boost::shared_ptr<StochasticProcess> KlugeExtOUProcessPtr;
-typedef boost::shared_ptr<StochasticProcess> ExtendedOrnsteinUhlenbeckProcessPtr;
-typedef boost::shared_ptr<StochasticProcess> ExtOUWithJumpsProcessPtr;
 %}
 
-%rename(ExtendedOrnsteinUhlenbeckProcess) ExtendedOrnsteinUhlenbeckProcessPtr;
-class ExtendedOrnsteinUhlenbeckProcessPtr : public StochasticProcess1DPtr {
+%shared_ptr(ExtendedOrnsteinUhlenbeckProcess)
+class ExtendedOrnsteinUhlenbeckProcess : public StochasticProcess1D {
     public:
-    %extend {
+        enum Discretization { MidPoint, Trapezodial, GaussLobatto };
+
+        ExtendedOrnsteinUhlenbeckProcess(
+                                Real speed, Volatility sigma, Real x0,
+                                const boost::function<Real (Real)>& b,
+                                Discretization discretization = MidPoint,
+                                Real intEps = 1e-4);
+    %extend{                            
         #if defined(SWIGPYTHON)    
-        ExtendedOrnsteinUhlenbeckProcessPtr(
+        ExtendedOrnsteinUhlenbeckProcess(
             Real speed, Volatility sigma, Real x0, 
             PyObject* function, 
             Real intEps = 1e-4) {
             
             const UnaryFunction f(function);
-            return new ExtendedOrnsteinUhlenbeckProcessPtr(
-            	new ExtendedOrnsteinUhlenbeckProcess(
+            return new ExtendedOrnsteinUhlenbeckProcess(
             	    speed, sigma, x0, f, 
-            	    ExtendedOrnsteinUhlenbeckProcess::MidPoint, intEps));
+            	    ExtendedOrnsteinUhlenbeckProcess::MidPoint, intEps);
         }
         #elif defined(SWIGJAVA) || defined(SWIGCSHARP)
-        ExtendedOrnsteinUhlenbeckProcessPtr(
+        ExtendedOrnsteinUhlenbeckProcess(
             Real speed, Volatility sigma, Real x0, 
             UnaryFunctionDelegate* function,
             Real intEps = 1e-4) {
             
             const UnaryFunction f(function);
-            return new ExtendedOrnsteinUhlenbeckProcessPtr(
-            	new ExtendedOrnsteinUhlenbeckProcess(
+            return new ExtendedOrnsteinUhlenbeckProcess(
             	    speed, sigma, x0, f, 
-            	    ExtendedOrnsteinUhlenbeckProcess::MidPoint, intEps));
+            	    ExtendedOrnsteinUhlenbeckProcess::MidPoint, intEps);
         }
-		#endif        
+		#endif
     }
 };
 
-%rename(ExtOUWithJumpsProcess) ExtOUWithJumpsProcessPtr;
-class ExtOUWithJumpsProcessPtr : public StochasticProcess1DPtr {
+%shared_ptr(ExtOUWithJumpsProcess)
+class ExtOUWithJumpsProcess : public StochasticProcess {
     public:
-    %extend {
-        ExtOUWithJumpsProcessPtr(
-            const ExtendedOrnsteinUhlenbeckProcessPtr& process,
+        ExtOUWithJumpsProcess(
+            const boost::shared_ptr<ExtendedOrnsteinUhlenbeckProcess>& process,
             Real Y0, Real beta, Real jumpIntensity, Real eta) {
-            
-	        const boost::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> ouProcess =
-	            boost::dynamic_pointer_cast<ExtendedOrnsteinUhlenbeckProcess>(
-	                process);
-            
-            QL_REQUIRE(ouProcess, "Extended Ornstein-Uhlenbeck process required");
                         
-			return new ExtOUWithJumpsProcessPtr(
+			return new ExtOUWithJumpsProcess(
 				new ExtOUWithJumpsProcess(
-					ouProcess, Y0, beta, jumpIntensity, eta));
+					process, Y0, beta, jumpIntensity, eta));
         }
-    }
 };
 
-%rename(KlugeExtOUProcess) KlugeExtOUProcessPtr;
-class KlugeExtOUProcessPtr : public StochasticProcess1DPtr {
+%shared_ptr(KlugeExtOUProcess)
+class KlugeExtOUProcess : public StochasticProcess {
     public:
-    %extend {
-        KlugeExtOUProcessPtr(
+        KlugeExtOUProcess(
             Real rho,
-            const ExtOUWithJumpsProcessPtr& kluge,
-            const ExtendedOrnsteinUhlenbeckProcessPtr& extOU) {
-            
-	        const boost::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> ouProcess =
-	            boost::dynamic_pointer_cast<ExtendedOrnsteinUhlenbeckProcess>(
-	                extOU);
-            
-            QL_REQUIRE(ouProcess, "Extended Ornstein-Uhlenbeck process required");
-            
-            const boost::shared_ptr<ExtOUWithJumpsProcess> jProcess =
-	            boost::dynamic_pointer_cast<ExtOUWithJumpsProcess>(
-	                kluge);
-	                
-            QL_REQUIRE(jProcess, 
-            	"Extended Ornstein-Uhlenbeck with jumps process required");
+            const boost::shared_ptr<ExtOUWithJumpsProcess>& kluge,
+            const boost::shared_ptr<ExtendedOrnsteinUhlenbeckProcess>& extOU) {
 	                            	
-            return new KlugeExtOUProcessPtr(new KlugeExtOUProcess(
-            	rho, jProcess, ouProcess));
+            return new KlugeExtOUProcess(new KlugeExtOUProcess(
+            	rho, kluge, extOU));
         }
-    }
 };
 
 

--- a/SWIG/swap.i
+++ b/SWIG/swap.i
@@ -40,133 +40,48 @@ using QuantLib::DiscountingSwapEngine;
 using QuantLib::FloatFloatSwap;
 using QuantLib::OvernightIndexedSwap;
 
-typedef boost::shared_ptr<Instrument> SwapPtr;
-typedef boost::shared_ptr<Instrument> VanillaSwapPtr;
-typedef boost::shared_ptr<Instrument> NonstandardSwapPtr;
 typedef boost::shared_ptr<PricingEngine> DiscountingSwapEnginePtr;
-typedef boost::shared_ptr<Instrument> FloatFloatSwapPtr;
-typedef boost::shared_ptr<Instrument> OvernightIndexedSwapPtr;
 %}
 
-%rename(Swap) SwapPtr;
-class SwapPtr : public boost::shared_ptr<Instrument> {
+%shared_ptr(Swap)
+class Swap : public Instrument {
   public:
-    %extend {
-        SwapPtr(const std::vector<boost::shared_ptr<CashFlow> >& firstLeg,
-                const std::vector<boost::shared_ptr<CashFlow> >& secondLeg) {
-            return new SwapPtr(new Swap(firstLeg, secondLeg));
-        }
-        Date startDate() {
-            return boost::dynamic_pointer_cast<Swap>(*self)->startDate();
-        }
-        Date maturityDate() {
-            return boost::dynamic_pointer_cast<Swap>(*self)->maturityDate();
-        }
-        const Leg & leg(Size i){
-            return boost::dynamic_pointer_cast<Swap>(*self)->leg(i);
-        }
-        Real legNPV(Size j) const {
-            return boost::dynamic_pointer_cast<Swap>(*self)->legNPV(j);
-        }
-    }
+    Swap(const std::vector<boost::shared_ptr<CashFlow> >& firstLeg,
+         const std::vector<boost::shared_ptr<CashFlow> >& secondLeg);
+    Date startDate();
+    Date maturityDate();
+    const Leg & leg(Size i);
+    Real legNPV(Size j) const;
 };
 
-
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-%rename(_VanillaSwap) VanillaSwap;
-#else
-%ignore VanillaSwap;
-#endif
-class VanillaSwap {
+%shared_ptr(VanillaSwap)
+class VanillaSwap : public Swap {
   public:
     enum Type { Receiver = -1, Payer = 1 };
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-  private:
-    VanillaSwap();
-#endif
+    VanillaSwap(VanillaSwap::Type type, Real nominal,
+                   const Schedule& fixedSchedule, Rate fixedRate,
+                   const DayCounter& fixedDayCount,
+                   const Schedule& floatSchedule,
+                   const boost::shared_ptr<IborIndex>& index,
+                   Spread spread,
+                   const DayCounter& floatingDayCount);
+    Rate fairRate();
+    Spread fairSpread();
+    Real fixedLegBPS();
+    Real floatingLegBPS();
+    Real fixedLegNPV();
+    Real floatingLegNPV();
+    // Inspectors 
+    const Leg& fixedLeg();
+    const Leg& floatingLeg();
+    Real nominal();
+    const Schedule& fixedSchedule();
+    const Schedule& floatingSchedule();
+    Rate fixedRate();
+    Spread spread();
+    const DayCounter& floatingDayCount();
+    const DayCounter& fixedDayCount();
 };
-
-%rename(VanillaSwap) VanillaSwapPtr;
-class VanillaSwapPtr : public SwapPtr {
-  public:
-    %extend {
-        static const VanillaSwap::Type Receiver = VanillaSwap::Receiver;
-        static const VanillaSwap::Type Payer = VanillaSwap::Payer;
-        VanillaSwapPtr(VanillaSwap::Type type, Real nominal,
-                       const Schedule& fixedSchedule, Rate fixedRate,
-                       const DayCounter& fixedDayCount,
-                       const Schedule& floatSchedule,
-                       const boost::shared_ptr<IborIndex>& index,
-                       Spread spread,
-                       const DayCounter& floatingDayCount) {
-            return new VanillaSwapPtr(
-                    new VanillaSwap(type, nominal,fixedSchedule,fixedRate,
-                                    fixedDayCount,floatSchedule,index,
-                                    spread, floatingDayCount));
-        }
-        Rate fairRate() {
-            return boost::dynamic_pointer_cast<VanillaSwap>(*self)->fairRate();
-        }
-        Spread fairSpread() {
-            return boost::dynamic_pointer_cast<VanillaSwap>(*self)
-                 ->fairSpread();
-        }
-        Real fixedLegBPS() {
-            return boost::dynamic_pointer_cast<VanillaSwap>(*self)
-                 ->fixedLegBPS();
-        }
-        Real floatingLegBPS() {
-            return boost::dynamic_pointer_cast<VanillaSwap>(*self)
-                 ->floatingLegBPS();
-        }   
-        Real fixedLegNPV() {
-            return boost::dynamic_pointer_cast<VanillaSwap> (*self)
-                ->fixedLegNPV();
-        }
-        Real floatingLegNPV() {
-            return boost::dynamic_pointer_cast<VanillaSwap> (*self)
-                ->floatingLegNPV();
-        }
-        // Inspectors 
-        const Leg& fixedLeg() {
-            return boost::dynamic_pointer_cast<VanillaSwap> (*self)
-                ->fixedLeg();
-        }
-        const Leg& floatingLeg() {
-            return boost::dynamic_pointer_cast<VanillaSwap> (*self)
-                ->floatingLeg();
-        }
-        Real nominal() {
-            return boost::dynamic_pointer_cast<VanillaSwap> (*self)
-                ->nominal();
-        }
-        const Schedule& fixedSchedule() {
-            return boost::dynamic_pointer_cast<VanillaSwap> (*self)
-                ->fixedSchedule();
-        }
-        const Schedule& floatingSchedule() {
-            return boost::dynamic_pointer_cast<VanillaSwap> (*self)
-                ->floatingSchedule();
-        }
-        Rate fixedRate() {
-            return boost::dynamic_pointer_cast<VanillaSwap> (*self)
-                ->fixedRate();
-        }
-        Spread spread() {
-            return boost::dynamic_pointer_cast<VanillaSwap> (*self)
-                ->spread();
-        }
-        const DayCounter& floatingDayCount() {
-            return boost::dynamic_pointer_cast<VanillaSwap> (*self)
-                ->floatingDayCount();
-        }
-        const DayCounter& fixedDayCount() {
-            return boost::dynamic_pointer_cast<VanillaSwap> (*self)
-                ->fixedDayCount();
-        }
-    }
-};
-
 
 #if defined(SWIGPYTHON)
 %rename (_MakeVanillaSwap) MakeVanillaSwap;
@@ -209,19 +124,18 @@ class MakeVanillaSwap {
                               const Handle<YieldTermStructure>& discountCurve);
         MakeVanillaSwap& withPricingEngine(
                               const boost::shared_ptr<PricingEngine>& engine);
+
+        MakeVanillaSwap(const Period& swapTenor,
+                        const boost::shared_ptr<IborIndex>& index,
+                        Rate fixedRate,
+                        const Period& forwardStart);
+        
         %extend{
-            SwapPtr makeVanillaSwap(){
+            boost::shared_ptr<VanillaSwap> makeVanillaSwap(){
                 return (boost::shared_ptr<VanillaSwap>)(* $self);
             }
-            MakeVanillaSwap(const Period& swapTenor,
-                            const boost::shared_ptr<IborIndex>& index,
-                            Rate fixedRate,
-                            const Period& forwardStart){
-                return new MakeVanillaSwap(swapTenor, index, fixedRate, forwardStart);
-            };
         }
 };
-
 
 #if defined(SWIGPYTHON)
 %pythoncode{
@@ -297,90 +211,44 @@ def MakeVanillaSwap(swapTenor,iborIndex,fixedRate,forwardStart,
 }
 #endif
 
-
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-%rename(_NonstandardSwap) NonstandardSwap;
-#else
-%ignore NonstandardSwap;
-#endif
-class NonstandardSwap {
+%shared_ptr(NonstandardSwap)
+class NonstandardSwap : public Swap {
   public:
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-  private:
-    NonstandardSwap();
-#endif
-};
+    NonstandardSwap(VanillaSwap::Type type,
+                       const std::vector<Real> &fixedNominal,
+                       const std::vector<Real> &floatingNominal,
+                       const Schedule &fixedSchedule,
+                       const std::vector<Real> &fixedRate,
+                       const DayCounter &fixedDayCount,
+                       const Schedule &floatSchedule,
+                       const boost::shared_ptr<IborIndex> &index,
+                       const std::vector<Real> &gearing,
+                       const std::vector<Spread> &spread,
+                       const DayCounter &floatDayCount,
+                       const bool intermediateCapitalExchange = false,
+                       const bool finalCapitalExchange = false,
+                       BusinessDayConvention paymentConvention = Following);
+    // Inspectors
+    VanillaSwap::Type type() const;
+    const std::vector<Real> &fixedNominal() const;
+    const std::vector<Real> &floatingNominal() const;
 
-%rename(NonstandardSwap) NonstandardSwapPtr;
-class NonstandardSwapPtr : public SwapPtr {
-  public:
-    %extend {
-        NonstandardSwapPtr(VanillaSwap::Type type,
-                           const std::vector<Real> &fixedNominal,
-                           const std::vector<Real> &floatingNominal,
-                           const Schedule &fixedSchedule,
-                           const std::vector<Real> &fixedRate,
-                           const DayCounter &fixedDayCount,
-                           const Schedule &floatSchedule,
-                           const boost::shared_ptr<IborIndex> &index,
-                           const std::vector<Real> &gearing,
-                           const std::vector<Spread> &spread,
-                           const DayCounter &floatDayCount,
-                           const bool intermediateCapitalExchange = false,
-                           const bool finalCapitalExchange = false,
-                           BusinessDayConvention paymentConvention = Following) {
-            return new NonstandardSwapPtr(
-                new NonstandardSwap(type,fixedNominal,floatingNominal,fixedSchedule,fixedRate,
-                                    fixedDayCount,floatSchedule,index,gearing,
-                                    spread,floatDayCount,intermediateCapitalExchange,
-                                    finalCapitalExchange, paymentConvention));
-        }
-        // Inspectors
-        const Leg& fixedLeg() {
-            return boost::dynamic_pointer_cast<NonstandardSwap> (*self)
-                ->fixedLeg();
-        }
-        const Leg& floatingLeg() {
-            return boost::dynamic_pointer_cast<NonstandardSwap> (*self)
-                ->floatingLeg();
-        }
-        std::vector<Real> fixedNominals() {
-            return boost::dynamic_pointer_cast<NonstandardSwap> (*self)
-                ->fixedNominal();
-        }
-        std::vector<Real> floatingNominals() {
-            return boost::dynamic_pointer_cast<NonstandardSwap> (*self)
-                ->floatingNominal();
-        }
-        const Schedule& fixedSchedule() {
-            return boost::dynamic_pointer_cast<NonstandardSwap> (*self)
-                ->fixedSchedule();
-        }
-        const Schedule& floatingSchedule() {
-            return boost::dynamic_pointer_cast<NonstandardSwap> (*self)
-                ->floatingSchedule();
-        }
-        std::vector<Rate> fixedRate() {
-            return boost::dynamic_pointer_cast<NonstandardSwap> (*self)
-                ->fixedRate();
-        }
-        std::vector<Spread> spreads() {
-            return boost::dynamic_pointer_cast<NonstandardSwap> (*self)
-                ->spreads();
-        }
-        std::vector<Spread> gearings() {
-            return boost::dynamic_pointer_cast<NonstandardSwap> (*self)
-                ->gearings();
-        }
-        const DayCounter& floatingDayCount() {
-            return boost::dynamic_pointer_cast<NonstandardSwap> (*self)
-                ->floatingDayCount();
-        }
-        const DayCounter& fixedDayCount() {
-            return boost::dynamic_pointer_cast<NonstandardSwap> (*self)
-                ->fixedDayCount();
-        }
-    }
+    const Schedule &fixedSchedule() const;
+    const std::vector<Real> &fixedRate() const;
+    const DayCounter &fixedDayCount() const;
+
+    const Schedule &floatingSchedule() const;
+    const boost::shared_ptr<IborIndex> &iborIndex() const;
+    Spread spread() const;
+    Real gearing() const;
+    const std::vector<Spread>& spreads() const;
+    const std::vector<Real>& gearings() const;
+    const DayCounter &floatingDayCount() const;
+
+    BusinessDayConvention paymentConvention() const;
+
+    const Leg &fixedLeg() const;
+    const Leg &floatingLeg() const;
 };
 
 %rename(DiscountingSwapEngine) DiscountingSwapEnginePtr;
@@ -414,192 +282,97 @@ class DiscountingSwapEnginePtr : public boost::shared_ptr<PricingEngine> {
 
 %{
 using QuantLib::AssetSwap;
-typedef boost::shared_ptr<Instrument> AssetSwapPtr;
 %}
 
-%rename(AssetSwap) AssetSwapPtr;
-class AssetSwapPtr : public SwapPtr {
+%shared_ptr(AssetSwap)
+class AssetSwap : public Swap {
     #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
-    %feature("kwargs") AssetSwapPtr;
+    %feature("kwargs") AssetSwap;
     #endif
   public:
-    %extend {
-        AssetSwapPtr(bool payFixedRate,
-                     const boost::shared_ptr<Bond>& bond,
-                     Real bondCleanPrice,
-                     const boost::shared_ptr<IborIndex>& index,
-                     Spread spread,
-                     const Schedule& floatSchedule = Schedule(),
-                     const DayCounter& floatingDayCount = DayCounter(),
-                     bool parAssetSwap = true) {
-            return new AssetSwapPtr(
-                new AssetSwap(payFixedRate,bond,bondCleanPrice,index,spread,
-                              floatSchedule,floatingDayCount,parAssetSwap));
-        }
-        Real fairCleanPrice() {
-            return boost::dynamic_pointer_cast<AssetSwap>(*self)
-                ->fairCleanPrice();
-        }
-        Spread fairSpread() {
-            return boost::dynamic_pointer_cast<AssetSwap>(*self)
-                ->fairSpread();
-        }
-    }
+    AssetSwap(bool payFixedRate,
+                 const boost::shared_ptr<Bond>& bond,
+                 Real bondCleanPrice,
+                 const boost::shared_ptr<IborIndex>& index,
+                 Spread spread,
+                 const Schedule& floatSchedule = Schedule(),
+                 const DayCounter& floatingDayCount = DayCounter(),
+                 bool parAssetSwap = true);
+    Real fairCleanPrice();
+    Spread fairSpread();
 };
 
-%rename(FloatFloatSwap) FloatFloatSwapPtr;
-class FloatFloatSwapPtr : public SwapPtr {
-
+%shared_ptr(FloatFloatSwap)
+class FloatFloatSwap : public Swap {
   public:
-    %extend {
-        FloatFloatSwapPtr(VanillaSwap::Type type, const std::vector<Real> &nominal1,
-            const std::vector<Real> &nominal2, const Schedule &schedule1,
-            const boost::shared_ptr<InterestRateIndex> &index1,
-            const DayCounter &dayCount1, const Schedule &schedule2,
-            const boost::shared_ptr<InterestRateIndex> &index2,
-            const DayCounter &dayCount2,
-            const bool intermediateCapitalExchange = false,
-            const bool finalCapitalExchange = false,
-            const std::vector<Real> &gearing1 = std::vector<Real>(),
-            const std::vector<Real> &spread1 = std::vector<Real>(),
-            const std::vector<Real> &cappedRate1 = std::vector<Real>(),
-            const std::vector<Real> &flooredRate1 = std::vector<Real>(),
-            const std::vector<Real> &gearing2 = std::vector<Real>(),
-            const std::vector<Real> &spread2 = std::vector<Real>(),
-            const std::vector<Real> &cappedRate2 = std::vector<Real>(),
-            const std::vector<Real> &flooredRate2 = std::vector<Real>(),
-            BusinessDayConvention paymentConvention1 = Following,
-            BusinessDayConvention paymentConvention2 = Following) {
-            return new FloatFloatSwapPtr(
-                    new FloatFloatSwap(type, nominal1,nominal2,schedule1,
-                                    index1,dayCount1,schedule2,
-                                    index2, dayCount2,
-                                    intermediateCapitalExchange, finalCapitalExchange,
-                                    gearing1, spread1, cappedRate1,
-                                    flooredRate1, gearing2, spread2,
-                                    cappedRate2, flooredRate2,
-                                    paymentConvention1, paymentConvention2));
-        }
-
-    }
+    FloatFloatSwap(VanillaSwap::Type type, const std::vector<Real> &nominal1,
+        const std::vector<Real> &nominal2, const Schedule &schedule1,
+        const boost::shared_ptr<InterestRateIndex> &index1,
+        const DayCounter &dayCount1, const Schedule &schedule2,
+        const boost::shared_ptr<InterestRateIndex> &index2,
+        const DayCounter &dayCount2,
+        const bool intermediateCapitalExchange = false,
+        const bool finalCapitalExchange = false,
+        const std::vector<Real> &gearing1 = std::vector<Real>(),
+        const std::vector<Real> &spread1 = std::vector<Real>(),
+        const std::vector<Real> &cappedRate1 = std::vector<Real>(),
+        const std::vector<Real> &flooredRate1 = std::vector<Real>(),
+        const std::vector<Real> &gearing2 = std::vector<Real>(),
+        const std::vector<Real> &spread2 = std::vector<Real>(),
+        const std::vector<Real> &cappedRate2 = std::vector<Real>(),
+        const std::vector<Real> &flooredRate2 = std::vector<Real>(),
+        BusinessDayConvention paymentConvention1 = Following,
+        BusinessDayConvention paymentConvention2 = Following);
 };
 
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-%rename(_OvernightIndexedSwap) OvernightIndexedSwap;
-#else
-%ignore OvernightIndexedSwap;
-#endif
-class OvernightIndexedSwap {
+%shared_ptr(OvernightIndexedSwap)
+class OvernightIndexedSwap : public Swap {
   public:
     enum Type { Receiver = -1, Payer = 1 };
-#if defined(SWIGJAVA) || defined(SWIGCSHARP)
-  private:
-    OvernightIndexedSwap();
-#endif
-};
-
-%rename(OvernightIndexedSwap) OvernightIndexedSwapPtr;
-class OvernightIndexedSwapPtr : public SwapPtr {
-  public:
-    %extend {
-        static const OvernightIndexedSwap::Type Receiver = OvernightIndexedSwap::Receiver;
-        static const OvernightIndexedSwap::Type Payer = OvernightIndexedSwap::Payer;
-		
-		OvernightIndexedSwapPtr(
-				OvernightIndexedSwap::Type type,
-				Real nominal,
-				const Schedule& schedule,
-				Rate fixedRate,
-				const DayCounter& fixedDC,
-				const boost::shared_ptr<OvernightIndex>& index,
-				Spread spread = 0.0,
-				Natural paymentLag = 0,
-				BusinessDayConvention paymentAdjustment = Following,
-				Calendar paymentCalendar = Calendar(),
-				bool telescopicValueDates = false) {
-				return new OvernightIndexedSwapPtr(
-				 new OvernightIndexedSwap(type, nominal, schedule, fixedRate, fixedDC,
-				index, spread, paymentLag, paymentAdjustment, paymentCalendar, telescopicValueDates));
-		}
-		
-		OvernightIndexedSwapPtr(
-				OvernightIndexedSwap::Type type,
-				std::vector<Real> nominals,
-				const Schedule& schedule,
-				Rate fixedRate,
-				const DayCounter& fixedDC,
-				const boost::shared_ptr<OvernightIndex>& index,
-				Spread spread = 0.0,
-				Natural paymentLag = 0,
-				BusinessDayConvention paymentAdjustment = Following,
-				Calendar paymentCalendar = Calendar(),
-				bool telescopicValueDates = false) {
-				return new OvernightIndexedSwapPtr(
-				 new OvernightIndexedSwap(type, nominals, schedule, fixedRate, fixedDC,
-				index, spread, paymentLag, paymentAdjustment, paymentCalendar, telescopicValueDates));
-		}
+    
+    OvernightIndexedSwap(
+            OvernightIndexedSwap::Type type,
+            Real nominal,
+            const Schedule& schedule,
+            Rate fixedRate,
+            const DayCounter& fixedDC,
+            const boost::shared_ptr<OvernightIndex>& index,
+            Spread spread = 0.0,
+            Natural paymentLag = 0,
+            BusinessDayConvention paymentAdjustment = Following,
+            Calendar paymentCalendar = Calendar(),
+            bool telescopicValueDates = false);
+    
+    OvernightIndexedSwap(
+            OvernightIndexedSwap::Type type,
+            std::vector<Real> nominals,
+            const Schedule& schedule,
+            Rate fixedRate,
+            const DayCounter& fixedDC,
+            const boost::shared_ptr<OvernightIndex>& index,
+            Spread spread = 0.0,
+            Natural paymentLag = 0,
+            BusinessDayConvention paymentAdjustment = Following,
+            Calendar paymentCalendar = Calendar(),
+            bool telescopicValueDates = false);
 
 
-        Rate fixedLegBPS() {
-            return boost::dynamic_pointer_cast<OvernightIndexedSwap>(*self)->fixedLegBPS();
-        }
-        Real fixedLegNPV() {
-            return boost::dynamic_pointer_cast<OvernightIndexedSwap>(*self)
-                 ->fixedLegNPV();
-        }
-        Real fairRate() {
-            return boost::dynamic_pointer_cast<OvernightIndexedSwap>(*self)
-                 ->fairRate();
-        }
-        Real overnightLegBPS() {
-            return boost::dynamic_pointer_cast<OvernightIndexedSwap>(*self)
-                 ->overnightLegBPS();
-        }
-        Real overnightLegNPV() {
-            return boost::dynamic_pointer_cast<OvernightIndexedSwap> (*self)
-                ->overnightLegNPV();
-        }
-        Spread fairSpread() {
-            return boost::dynamic_pointer_cast<OvernightIndexedSwap> (*self)
-                ->fairSpread();
-        }
-        // Inspectors
-		OvernightIndexedSwap::Type type() {
-			return boost::dynamic_pointer_cast<OvernightIndexedSwap>(*self)->type();
-		}
-        Real nominal() {
-            return boost::dynamic_pointer_cast<OvernightIndexedSwap> (*self)
-                ->nominal();
-        }
-		std::vector<Real> nominals() {
-            return boost::dynamic_pointer_cast<OvernightIndexedSwap> (*self)
-                ->nominals();
-        }
-		Frequency paymentFrequency() {
-            return boost::dynamic_pointer_cast<OvernightIndexedSwap> (*self)
-                ->paymentFrequency();
-        }
-		Rate fixedRate() {
-            return boost::dynamic_pointer_cast<OvernightIndexedSwap> (*self)
-                ->fixedRate();
-        }
-		const DayCounter& fixedDayCount() {
-            return boost::dynamic_pointer_cast<OvernightIndexedSwap> (*self)
-                ->fixedDayCount();
-        }
-		Spread spread() {
-            return boost::dynamic_pointer_cast<OvernightIndexedSwap> (*self)
-                ->spread();
-        }
-        const Leg& fixedLeg() {
-            return boost::dynamic_pointer_cast<OvernightIndexedSwap> (*self)
-                ->fixedLeg();
-        }
-        const Leg& overnightLeg() {
-            return boost::dynamic_pointer_cast<OvernightIndexedSwap> (*self)
-                ->overnightLeg();
-        }
-    }
+    Rate fixedLegBPS();
+    Real fixedLegNPV();
+    Real fairRate();
+    Real overnightLegBPS();
+    Real overnightLegNPV();
+    Spread fairSpread();
+    // Inspectors
+    OvernightIndexedSwap::Type type();
+    Real nominal();
+    std::vector<Real> nominals();
+    Frequency paymentFrequency();
+    Rate fixedRate();
+    const DayCounter& fixedDayCount();
+    Spread spread();
+    const Leg& fixedLeg();
+    const Leg& overnightLeg();
 };
 
 #endif

--- a/SWIG/swap.i
+++ b/SWIG/swap.i
@@ -425,17 +425,15 @@ class AssetSwapPtr : public SwapPtr {
   public:
     %extend {
         AssetSwapPtr(bool payFixedRate,
-                     const BondPtr& bond,
+                     const boost::shared_ptr<Bond>& bond,
                      Real bondCleanPrice,
                      const boost::shared_ptr<IborIndex>& index,
                      Spread spread,
                      const Schedule& floatSchedule = Schedule(),
                      const DayCounter& floatingDayCount = DayCounter(),
                      bool parAssetSwap = true) {
-            const boost::shared_ptr<Bond> b =
-                boost::dynamic_pointer_cast<Bond>(bond);
             return new AssetSwapPtr(
-                new AssetSwap(payFixedRate,b,bondCleanPrice,index,spread,
+                new AssetSwap(payFixedRate,bond,bondCleanPrice,index,spread,
                               floatSchedule,floatingDayCount,parAssetSwap));
         }
         Real fairCleanPrice() {

--- a/SWIG/swaption.i
+++ b/SWIG/swaption.i
@@ -48,12 +48,9 @@ struct Settlement {
 class SwaptionPtr : public boost::shared_ptr<Instrument> {
   public:
     %extend {
-        SwaptionPtr(const VanillaSwapPtr& simpleSwap,
+        SwaptionPtr(const boost::shared_ptr<VanillaSwap>& swap,
                     const boost::shared_ptr<Exercise>& exercise,
                     Settlement::Type type = Settlement::Physical) {
-            boost::shared_ptr<VanillaSwap> swap =
-                 boost::dynamic_pointer_cast<VanillaSwap>(simpleSwap);
-            QL_REQUIRE(swap, "simple swap required");
             return new SwaptionPtr(new Swaption(swap,exercise,type));
         }
     }
@@ -67,12 +64,9 @@ using QuantLib::BasketGeneratingEngine;
 class NonstandardSwaptionPtr : public boost::shared_ptr<Instrument> {
   public:
     %extend {
-        NonstandardSwaptionPtr(const NonstandardSwapPtr& nonstandardSwap,
+        NonstandardSwaptionPtr(const boost::shared_ptr<NonstandardSwap>& swap,
                     const boost::shared_ptr<Exercise>& exercise,
                     Settlement::Type type = Settlement::Physical) {
-            boost::shared_ptr<NonstandardSwap> swap =
-                 boost::dynamic_pointer_cast<NonstandardSwap>(nonstandardSwap);
-            QL_REQUIRE(swap, "nonstandard swap required");
             return new NonstandardSwaptionPtr(new NonstandardSwaption(swap,exercise,type));
         }
 
@@ -99,7 +93,7 @@ class NonstandardSwaptionPtr : public boost::shared_ptr<Instrument> {
             return helpers;
         }
 
-		const NonstandardSwapPtr underlyingSwap() const {
+		const boost::shared_ptr<NonstandardSwap> &underlyingSwap() const {
 			return boost::dynamic_pointer_cast<NonstandardSwaption>(*self)->
                 underlyingSwap();
 		}
@@ -115,11 +109,8 @@ class NonstandardSwaptionPtr : public boost::shared_ptr<Instrument> {
 class FloatFloatSwaptionPtr : public boost::shared_ptr<Instrument> {
   public:
     %extend {
-        FloatFloatSwaptionPtr(const FloatFloatSwapPtr& simpleSwap,
+        FloatFloatSwaptionPtr(const boost::shared_ptr<FloatFloatSwap>& swap,
                     const boost::shared_ptr<Exercise>& exercise) {
-            boost::shared_ptr<FloatFloatSwap> swap =
-                 boost::dynamic_pointer_cast<FloatFloatSwap>(simpleSwap);
-            QL_REQUIRE(swap, "floatfloat swap required");
             return new FloatFloatSwaptionPtr(new FloatFloatSwaption(swap,exercise));
         }
 
@@ -151,7 +142,7 @@ class FloatFloatSwaptionPtr : public boost::shared_ptr<Instrument> {
                 ->result<Real>("underlyingValue");
         }
 
-		const FloatFloatSwapPtr underlyingSwap() const {
+		const boost::shared_ptr<FloatFloatSwap> &underlyingSwap() const {
 			return boost::dynamic_pointer_cast<FloatFloatSwaption>(*self)->
                 underlyingSwap();
 		}

--- a/SWIG/swaption.i
+++ b/SWIG/swaption.i
@@ -35,43 +35,61 @@ using QuantLib::Swaption;
 using QuantLib::NonstandardSwaption;
 using QuantLib::Settlement;
 using QuantLib::FloatFloatSwaption;
-typedef boost::shared_ptr<Instrument> SwaptionPtr;
-typedef boost::shared_ptr<Instrument> NonstandardSwaptionPtr;
-typedef boost::shared_ptr<Instrument> FloatFloatSwaptionPtr;
 %}
 
 struct Settlement {
    enum Type { Physical, Cash };
+   enum Method {
+        PhysicalOTC,
+        PhysicalCleared,
+        CollateralizedCashPrice,
+        ParYieldCurve
+   };
 };
-
-%rename(Swaption) SwaptionPtr;
-class SwaptionPtr : public boost::shared_ptr<Instrument> {
+    
+%shared_ptr(Swaption)
+class Swaption : public Instrument {
   public:
-    %extend {
-        SwaptionPtr(const boost::shared_ptr<VanillaSwap>& swap,
-                    const boost::shared_ptr<Exercise>& exercise,
-                    Settlement::Type type = Settlement::Physical) {
-            return new SwaptionPtr(new Swaption(swap,exercise,type));
-        }
-    }
+    Swaption(const boost::shared_ptr<VanillaSwap>& swap,
+                const boost::shared_ptr<Exercise>& exercise,
+                Settlement::Type type = Settlement::Physical,
+                Settlement::Method settlementMethod = Settlement::PhysicalOTC);
+    
+    Settlement::Type settlementType() const;       
+    Settlement::Method settlementMethod() const;
+    VanillaSwap::Type type() const;
+    const boost::shared_ptr<VanillaSwap>& underlyingSwap() const;
+    
+    //! implied volatility
+    Volatility impliedVolatility(
+                          Real price,
+                          const Handle<YieldTermStructure>& discountCurve,
+                          Volatility guess,
+                          Real accuracy = 1.0e-4,
+                          Natural maxEvaluations = 100,
+                          Volatility minVol = 1.0e-7,
+                          Volatility maxVol = 4.0,
+                          VolatilityType type = ShiftedLognormal,
+                          Real displacement = 0.0) const;
 };
 
 %{
 using QuantLib::BasketGeneratingEngine;
 %}
 
-%rename(NonstandardSwaption) NonstandardSwaptionPtr;
-class NonstandardSwaptionPtr : public boost::shared_ptr<Instrument> {
+%shared_ptr(NonstandardSwaption)
+class NonstandardSwaption : public Instrument {
   public:
-    %extend {
-        NonstandardSwaptionPtr(const boost::shared_ptr<NonstandardSwap>& swap,
-                    const boost::shared_ptr<Exercise>& exercise,
-                    Settlement::Type type = Settlement::Physical) {
-            return new NonstandardSwaptionPtr(new NonstandardSwaption(swap,exercise,type));
-        }
+    NonstandardSwaption(const boost::shared_ptr<NonstandardSwap>& swap,
+                const boost::shared_ptr<Exercise>& exercise,
+                Settlement::Type type = Settlement::Physical,
+                Settlement::Method settlementMethod = Settlement::PhysicalOTC);
+                
+    const boost::shared_ptr<NonstandardSwap> &underlyingSwap() const;
 
-        std::vector<boost::shared_ptr<CalibrationHelperBase> > calibrationBasket(
-            boost::shared_ptr<Index> standardSwapBase,
+    %extend {                
+        std::vector<boost::shared_ptr<BlackCalibrationHelper> > calibrationBasket(
+            boost::shared_ptr<SwapIndex> swapIndex,
             boost::shared_ptr<SwaptionVolatilityStructure> swaptionVolatility,
             std::string typeStr) {
 
@@ -82,74 +100,61 @@ class NonstandardSwaptionPtr : public boost::shared_ptr<Instrument> {
                 type = BasketGeneratingEngine::MaturityStrikeByDeltaGamma;
             else
                 QL_FAIL("type " << typeStr << "unknown.");
-            boost::shared_ptr<SwapIndex> swapIndex =
-                boost::dynamic_pointer_cast<SwapIndex>(standardSwapBase);
+
             std::vector<boost::shared_ptr<BlackCalibrationHelper> > hs =
-                boost::dynamic_pointer_cast<NonstandardSwaption>(*self)->
-                calibrationBasket(swapIndex, swaptionVolatility, type);
-            std::vector<boost::shared_ptr<CalibrationHelperBase> > helpers(hs.size());
+                self->calibrationBasket(swapIndex, swaptionVolatility, type);
+            std::vector<boost::shared_ptr<BlackCalibrationHelper> > helpers(hs.size());
             for (Size i=0; i<hs.size(); ++i)
                 helpers[i] = hs[i];
             return helpers;
         }
 
-		const boost::shared_ptr<NonstandardSwap> &underlyingSwap() const {
-			return boost::dynamic_pointer_cast<NonstandardSwaption>(*self)->
-                underlyingSwap();
-		}
 
-		std::vector<Real> probabilities() {
-            return boost::dynamic_pointer_cast<NonstandardSwaption>(*self)
-                ->result<std::vector<Real> >("probabilities");
+        std::vector<Real> probabilities() {
+            return self->result<std::vector<Real> >("probabilities");
         }
     }
 };
 
-%rename(FloatFloatSwaption) FloatFloatSwaptionPtr;
-class FloatFloatSwaptionPtr : public boost::shared_ptr<Instrument> {
-  public:
+%shared_ptr(FloatFloatSwaption)
+class FloatFloatSwaption : public Instrument {
+public:
+    FloatFloatSwaption(const boost::shared_ptr<FloatFloatSwap>& swap,
+                const boost::shared_ptr<Exercise>& exercise,
+                Settlement::Type delivery = Settlement::Physical,
+                Settlement::Method settlementMethod = Settlement::PhysicalOTC);
+
+    const boost::shared_ptr<FloatFloatSwap> &underlyingSwap();
+    
     %extend {
-        FloatFloatSwaptionPtr(const boost::shared_ptr<FloatFloatSwap>& swap,
-                    const boost::shared_ptr<Exercise>& exercise) {
-            return new FloatFloatSwaptionPtr(new FloatFloatSwaption(swap,exercise));
-        }
 
-        std::vector<boost::shared_ptr<CalibrationHelperBase> > calibrationBasket(
-            boost::shared_ptr<Index> standardSwapBase,
-            boost::shared_ptr<SwaptionVolatilityStructure> swaptionVolatility,
-            std::string typeStr) {
+        std::vector<boost::shared_ptr<BlackCalibrationHelper> > calibrationBasket(
+        boost::shared_ptr<SwapIndex> swapIndex,
+        boost::shared_ptr<SwaptionVolatilityStructure> swaptionVolatility,
+        std::string typeStr) {
 
-            BasketGeneratingEngine::CalibrationBasketType type;
-            if(typeStr == "Naive")
-                type = BasketGeneratingEngine::Naive;
-            else if(typeStr == "MaturityStrikeByDeltaGamma")
-                type = BasketGeneratingEngine::MaturityStrikeByDeltaGamma;
-            else
-                QL_FAIL("type " << typeStr << "unknown.");
-            boost::shared_ptr<SwapIndex> swapIndex =
-                boost::dynamic_pointer_cast<SwapIndex>(standardSwapBase);
-            std::vector<boost::shared_ptr<BlackCalibrationHelper> > hs =
-                boost::dynamic_pointer_cast<FloatFloatSwaption>(*self)->
-                calibrationBasket(swapIndex, swaptionVolatility, type);
-            std::vector<boost::shared_ptr<CalibrationHelperBase> > helpers(hs.size());
-            for (Size i=0; i<hs.size(); ++i)
-                helpers[i] = hs[i];
-            return helpers;
+        BasketGeneratingEngine::CalibrationBasketType type;
+        if(typeStr == "Naive")
+            type = BasketGeneratingEngine::Naive;
+        else if(typeStr == "MaturityStrikeByDeltaGamma")
+            type = BasketGeneratingEngine::MaturityStrikeByDeltaGamma;
+        else
+            QL_FAIL("type " << typeStr << "unknown.");
+
+        std::vector<boost::shared_ptr<BlackCalibrationHelper> > hs =
+            self->calibrationBasket(swapIndex, swaptionVolatility, type);
+        std::vector<boost::shared_ptr<BlackCalibrationHelper> > helpers(hs.size());
+        for (Size i=0; i<hs.size(); ++i)
+            helpers[i] = hs[i];
+        return helpers;
         }
 
         Real underlyingValue() {
-            return boost::dynamic_pointer_cast<FloatFloatSwaption>(*self)
-                ->result<Real>("underlyingValue");
+            return self->result<Real>("underlyingValue");
         }
 
-		const boost::shared_ptr<FloatFloatSwap> &underlyingSwap() const {
-			return boost::dynamic_pointer_cast<FloatFloatSwaption>(*self)->
-                underlyingSwap();
-		}
-
-		std::vector<Real> probabilities() {
-            return boost::dynamic_pointer_cast<FloatFloatSwaption>(*self)
-                ->result<std::vector<Real> >("probabilities");
+        std::vector<Real> probabilities() {
+            return self->result<std::vector<Real> >("probabilities");
         }
     }
 };


### PR DESCRIPTION
Some further steps on shared_ptr migration, mainly instruments.

One Observer-related unit test fails currently, this can be fixed later when asObservable() is no longer necessary due to direct inheritance.