### PR TITLE
Enable Travis CI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+
+language: cpp
+
+os: linux
+dist: trusty
+compiler: gcc
+services: docker
+
+env:
+  global:
+    - DOCKER_OPTS="--rm -ti -v ${TRAVIS_BUILD_DIR}:/build -w /build"
+  matrix:
+    # Python 2.7
+    - DOCKER_IMAGE=lballabio/quantlib-swig-devenv:python2
+      BUILD_SCRIPT="python2.build"
+    # Python 3
+    - DOCKER_IMAGE=lballabio/quantlib-swig-devenv:python3
+      BUILD_SCRIPT="python3.build"
+    # Java
+    - DOCKER_IMAGE=lballabio/quantlib-swig-devenv:java
+      BUILD_SCRIPT="java.build"
+    # C#
+    - DOCKER_IMAGE=lballabio/quantlib-swig-devenv:csharp
+      BUILD_SCRIPT="csharp.build"
+    # R
+    - DOCKER_IMAGE=lballabio/quantlib-swig-devenv:r
+      BUILD_SCRIPT="r.build"
+
+before_install:
+  - docker pull ${DOCKER_IMAGE}
+
+script:
+  - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ./.travis/${BUILD_SCRIPT}
+

--- a/.travis/csharp.build
+++ b/.travis/csharp.build
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+./autogen.sh \
+&& ./configure CXXFLAGS='-O2' \
+&& make -C CSharp \
+&& make -C CSharp check

--- a/.travis/java.build
+++ b/.travis/java.build
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+./autogen.sh \
+&& ./configure --with-jdk-include=/usr/lib/jvm/default-java/include \
+               --with-jdk-system-include=/usr/lib/jvm/default-java/include/linux CXXFLAGS='-O2' \
+&& make -C Java \
+&& make -C Java check

--- a/.travis/python2.build
+++ b/.travis/python2.build
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+./autogen.sh \
+&& ./configure PYTHON=/usr/bin/python2 CXXFLAGS='-O2' \
+&& make -C Python \
+&& make -C Python check \
+&& make -C Python install \
+&& for i in Python/examples/*.py ; do echo $i && /usr/bin/python2 $i || break -1 ; done
+

--- a/.travis/python3.build
+++ b/.travis/python3.build
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+./autogen.sh \
+&& ./configure PYTHON=/usr/bin/python3 CXXFLAGS='-O2' \
+&& make -C Python \
+&& make -C Python check \
+&& make -C Python install \
+&& for i in Python/examples/*.py ; do echo $i && /usr/bin/python3 $i || break -1 ; done
+

--- a/.travis/r.build
+++ b/.travis/r.build
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+./autogen.sh \
+&& ./configure CXXFLAGS='-O2' \
+&& make -C R \
+&& make -C R check

--- a/CSharp/Makefile.am
+++ b/CSharp/Makefile.am
@@ -21,8 +21,8 @@ NQuantLib.dll: $(BUILT_SOURCES)
 check-local: examples/BermudanSwaption.exe \
              examples/EquityOption.exe \
              examples/libNQuantLibc.so examples/NQuantLib.dll
-	./examples/BermudanSwaption.exe
-	./examples/EquityOption.exe
+	$(MONO) ./examples/BermudanSwaption.exe
+	$(MONO) ./examples/EquityOption.exe
 
 examples/%.exe: examples/%.cs
 	$(MCS) -nologo -target:exe -out:$@ -reference:NQuantLib.dll $<

--- a/SWIG/ql.i
+++ b/SWIG/ql.i
@@ -80,7 +80,7 @@
 %{
 #include <ql/quantlib.hpp>
 
-#if QL_HEX_VERSION < 0x011400f0
+#if QL_HEX_VERSION < 0x011500f0
     #error using an old version of QuantLib, please update
 #endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,8 @@ AC_ARG_ENABLE([ruby],
 AM_CONDITIONAL(BUILD_RUBY, test "$build_ruby" != "no")
 
 AC_PATH_PROGS([MCS], [gmcs mcs gmcs2])
-AM_CONDITIONAL(HAVE_MCS, test "x${MCS}" != "x")
+AC_PATH_PROGS([MONO], [mono])
+AM_CONDITIONAL(HAVE_MCS, test "x${MCS}" != "x" && test "x${MONO}" != "x")
 AC_ARG_ENABLE([csharp],
               AC_HELP_STRING([--disable-csharp],
                              [If disabled, the C# module


### PR DESCRIPTION
Enabled for Python 2 and 3, Java, C# and R.
Perl will be removed by #142.
The Ruby module is out of date.