### PR TITLE
Avoid 'from QuantLib import *' in Python code.

### DIFF
--- a/Python/examples/american-option.py
+++ b/Python/examples/american-option.py
@@ -13,22 +13,22 @@
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See the license for more details.
 
-from QuantLib import *
+import QuantLib as ql
 
 # global data
-todaysDate = Date(15, May, 1998)
-Settings.instance().evaluationDate = todaysDate
-settlementDate = Date(17, May, 1998)
-riskFreeRate = FlatForward(settlementDate, 0.06, Actual365Fixed())
+todaysDate = ql.Date(15, ql.May, 1998)
+ql.Settings.instance().evaluationDate = todaysDate
+settlementDate = ql.Date(17, ql.May, 1998)
+riskFreeRate = ql.FlatForward(settlementDate, 0.06, ql.Actual365Fixed())
 
 # option parameters
-exercise = AmericanExercise(settlementDate, Date(17, May, 1999))
-payoff = PlainVanillaPayoff(Option.Put, 40.0)
+exercise = ql.AmericanExercise(settlementDate, ql.Date(17, ql.May, 1999))
+payoff = ql.PlainVanillaPayoff(ql.Option.Put, 40.0)
 
 # market data
-underlying = SimpleQuote(36.0)
-volatility = BlackConstantVol(todaysDate, TARGET(), 0.20, Actual365Fixed())
-dividendYield = FlatForward(settlementDate, 0.00, Actual365Fixed())
+underlying = ql.SimpleQuote(36.0)
+volatility = ql.BlackConstantVol(todaysDate, ql.TARGET(), 0.20, ql.Actual365Fixed())
+dividendYield = ql.FlatForward(settlementDate, 0.00, ql.Actual365Fixed())
 
 # report
 header = "%19s" % "method" + " |" + " |".join(["%17s" % tag for tag in ["value", "estimated error", "actual error"]])
@@ -51,53 +51,53 @@ def report(method, x, dx=None):
 
 # good to go
 
-process = BlackScholesMertonProcess(
-    QuoteHandle(underlying),
-    YieldTermStructureHandle(dividendYield),
-    YieldTermStructureHandle(riskFreeRate),
-    BlackVolTermStructureHandle(volatility),
+process = ql.BlackScholesMertonProcess(
+    ql.QuoteHandle(underlying),
+    ql.YieldTermStructureHandle(dividendYield),
+    ql.YieldTermStructureHandle(riskFreeRate),
+    ql.BlackVolTermStructureHandle(volatility),
 )
 
-option = VanillaOption(payoff, exercise)
+option = ql.VanillaOption(payoff, exercise)
 
 refValue = 4.48667344
 report("reference value", refValue)
 
 # method: analytic
 
-option.setPricingEngine(BaroneAdesiWhaleyEngine(process))
+option.setPricingEngine(ql.BaroneAdesiWhaleyEngine(process))
 report("Barone-Adesi-Whaley", option.NPV())
 
-option.setPricingEngine(BjerksundStenslandEngine(process))
+option.setPricingEngine(ql.BjerksundStenslandEngine(process))
 report("Bjerksund-Stensland", option.NPV())
 
 # method: finite differences
 timeSteps = 801
 gridPoints = 800
 
-option.setPricingEngine(FDAmericanEngine(process, timeSteps, gridPoints))
+option.setPricingEngine(ql.FDAmericanEngine(process, timeSteps, gridPoints))
 report("finite differences", option.NPV())
 
 # method: binomial
 timeSteps = 801
 
-option.setPricingEngine(BinomialVanillaEngine(process, "JR", timeSteps))
+option.setPricingEngine(ql.BinomialVanillaEngine(process, "JR", timeSteps))
 report("binomial (JR)", option.NPV())
 
-option.setPricingEngine(BinomialVanillaEngine(process, "CRR", timeSteps))
+option.setPricingEngine(ql.BinomialVanillaEngine(process, "CRR", timeSteps))
 report("binomial (CRR)", option.NPV())
 
-option.setPricingEngine(BinomialVanillaEngine(process, "EQP", timeSteps))
+option.setPricingEngine(ql.BinomialVanillaEngine(process, "EQP", timeSteps))
 report("binomial (EQP)", option.NPV())
 
-option.setPricingEngine(BinomialVanillaEngine(process, "Trigeorgis", timeSteps))
+option.setPricingEngine(ql.BinomialVanillaEngine(process, "Trigeorgis", timeSteps))
 report("bin. (Trigeorgis)", option.NPV())
 
-option.setPricingEngine(BinomialVanillaEngine(process, "Tian", timeSteps))
+option.setPricingEngine(ql.BinomialVanillaEngine(process, "Tian", timeSteps))
 report("binomial (Tian)", option.NPV())
 
-option.setPricingEngine(BinomialVanillaEngine(process, "LR", timeSteps))
+option.setPricingEngine(ql.BinomialVanillaEngine(process, "LR", timeSteps))
 report("binomial (LR)", option.NPV())
 
-option.setPricingEngine(BinomialVanillaEngine(process, "Joshi4", timeSteps))
+option.setPricingEngine(ql.BinomialVanillaEngine(process, "Joshi4", timeSteps))
 report("binomial (Joshi)", option.NPV())

--- a/Python/examples/basket-option.py
+++ b/Python/examples/basket-option.py
@@ -13,75 +13,77 @@
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See the license for more details.
 
-from QuantLib import *
+import QuantLib as ql
 
 # global data
-todaysDate = Date(15,May,1998)
-Settings.instance().evaluationDate = todaysDate
-settlementDate = Date(17,May,1998)
-riskFreeRate = FlatForward(settlementDate, 0.05, Actual365Fixed())
+todaysDate = ql.Date(15, ql.May, 1998)
+ql.Settings.instance().evaluationDate = todaysDate
+settlementDate = ql.Date(17, ql.May, 1998)
+riskFreeRate = ql.FlatForward(settlementDate, 0.05, ql.Actual365Fixed())
 
 # option parameters
-exercise = EuropeanExercise(Date(17,May,1999))
-payoff = PlainVanillaPayoff(Option.Call, 8.0)
+exercise = ql.EuropeanExercise(ql.Date(17, ql.May, 1999))
+payoff = ql.PlainVanillaPayoff(ql.Option.Call, 8.0)
 
 # market data
-underlying1 = SimpleQuote(7.0)
-volatility1 = BlackConstantVol(todaysDate, TARGET(), 0.10, Actual365Fixed())
-dividendYield1 = FlatForward(settlementDate, 0.05, Actual365Fixed())
-underlying2 = SimpleQuote(7.0)
-volatility2 = BlackConstantVol(todaysDate, TARGET(), 0.10, Actual365Fixed())
-dividendYield2 = FlatForward(settlementDate, 0.05, Actual365Fixed())
+underlying1 = ql.SimpleQuote(7.0)
+volatility1 = ql.BlackConstantVol(todaysDate, ql.TARGET(), 0.10, ql.Actual365Fixed())
+dividendYield1 = ql.FlatForward(settlementDate, 0.05, ql.Actual365Fixed())
+underlying2 = ql.SimpleQuote(7.0)
+volatility2 = ql.BlackConstantVol(todaysDate, ql.TARGET(), 0.10, ql.Actual365Fixed())
+dividendYield2 = ql.FlatForward(settlementDate, 0.05, ql.Actual365Fixed())
 
 
-process1 = BlackScholesMertonProcess(QuoteHandle(underlying1),
-                                    YieldTermStructureHandle(dividendYield1),
-                                    YieldTermStructureHandle(riskFreeRate),
-                                    BlackVolTermStructureHandle(volatility1))
+process1 = ql.BlackScholesMertonProcess(
+    ql.QuoteHandle(underlying1),
+    ql.YieldTermStructureHandle(dividendYield1),
+    ql.YieldTermStructureHandle(riskFreeRate),
+    ql.BlackVolTermStructureHandle(volatility1),
+)
 
-process2 = BlackScholesMertonProcess(QuoteHandle(underlying2),
-                                    YieldTermStructureHandle(dividendYield2),
-                                    YieldTermStructureHandle(riskFreeRate),
-                                    BlackVolTermStructureHandle(volatility2))
+process2 = ql.BlackScholesMertonProcess(
+    ql.QuoteHandle(underlying2),
+    ql.YieldTermStructureHandle(dividendYield2),
+    ql.YieldTermStructureHandle(riskFreeRate),
+    ql.BlackVolTermStructureHandle(volatility2),
+)
 
-matrix = Matrix(2,2)
+matrix = ql.Matrix(2, 2)
 matrix[0][0] = 1.0
 matrix[1][1] = 1.0
 matrix[0][1] = 0.5
 matrix[1][0] = 0.5
 
-process = StochasticProcessArray([process1, process2], matrix)
-basketoption = BasketOption(MaxBasketPayoff(payoff), exercise)
-basketoption.setPricingEngine(MCEuropeanBasketEngine(process,
-                                                     "pseudorandom",
-                                                     timeStepsPerYear = 1,
-                                                     requiredTolerance = 0.02,
-                                                     seed = 42))
+process = ql.StochasticProcessArray([process1, process2], matrix)
+basketoption = ql.BasketOption(ql.MaxBasketPayoff(payoff), exercise)
+basketoption.setPricingEngine(
+    ql.MCEuropeanBasketEngine(process, "pseudorandom", timeStepsPerYear=1, requiredTolerance=0.02, seed=42)
+)
 print(basketoption.NPV())
 
-basketoption = BasketOption(MinBasketPayoff(payoff), exercise)
-basketoption.setPricingEngine(MCEuropeanBasketEngine(process,
-                                                     "pseudorandom",
-                                                     timeStepsPerYear = 1,
-                                                     requiredTolerance = 0.02,
-                                                     seed = 42))
+basketoption = ql.BasketOption(ql.MinBasketPayoff(payoff), exercise)
+basketoption.setPricingEngine(
+    ql.MCEuropeanBasketEngine(process, "pseudorandom", timeStepsPerYear=1, requiredTolerance=0.02, seed=42)
+)
 print(basketoption.NPV())
 
-basketoption = BasketOption(AverageBasketPayoff(payoff, 2), exercise)
-basketoption.setPricingEngine(MCEuropeanBasketEngine(process,
-                                                     "pseudorandom",
-                                                     timeStepsPerYear = 1,
-                                                     requiredTolerance = 0.02,
-                                                     seed = 42))
+basketoption = ql.BasketOption(ql.AverageBasketPayoff(payoff, 2), exercise)
+basketoption.setPricingEngine(
+    ql.MCEuropeanBasketEngine(process, "pseudorandom", timeStepsPerYear=1, requiredTolerance=0.02, seed=42)
+)
 print(basketoption.NPV())
 
-americanExercise = AmericanExercise(settlementDate, Date(17,May,1999))
-americanbasketoption = BasketOption(MaxBasketPayoff(payoff), americanExercise)
-americanbasketoption.setPricingEngine(MCAmericanBasketEngine(process,
-                                                             "pseudorandom",
-                                                             timeSteps = 10,
-                                                             requiredTolerance = 0.02,
-                                                             seed = 42,
-                                                             polynomOrder = 5,
-                                                             polynomType = LsmBasisSystem.Hermite))
+americanExercise = ql.AmericanExercise(settlementDate, ql.Date(17, ql.May, 1999))
+americanbasketoption = ql.BasketOption(ql.MaxBasketPayoff(payoff), americanExercise)
+americanbasketoption.setPricingEngine(
+    ql.MCAmericanBasketEngine(
+        process,
+        "pseudorandom",
+        timeSteps=10,
+        requiredTolerance=0.02,
+        seed=42,
+        polynomOrder=5,
+        polynomType=ql.LsmBasisSystem.Hermite,
+    )
+)
 print(americanbasketoption.NPV())

--- a/Python/examples/bermudan-swaption.py
+++ b/Python/examples/bermudan-swaption.py
@@ -1,4 +1,3 @@
-
 # Copyright (C) 2004, 2005, 2006, 2007 StatPro Italia srl
 #
 # This file is part of QuantLib, a free-software/open-source library
@@ -14,39 +13,44 @@
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See the license for more details.
 
-from QuantLib import *
+import QuantLib as ql
 
-swaptionVols = [ # maturity,          length,             volatility
-                 (Period(1, Years), Period(5, Years), 0.1148),
-                 (Period(2, Years), Period(4, Years), 0.1108),
-                 (Period(3, Years), Period(3, Years), 0.1070),
-                 (Period(4, Years), Period(2, Years), 0.1021),
-                 (Period(5, Years), Period(1, Years), 0.1000) ]
+swaptionVols = [
+    # maturity,          length,             volatility
+    (ql.Period(1, ql.Years), ql.Period(5, ql.Years), 0.1148),
+    (ql.Period(2, ql.Years), ql.Period(4, ql.Years), 0.1108),
+    (ql.Period(3, ql.Years), ql.Period(3, ql.Years), 0.1070),
+    (ql.Period(4, ql.Years), ql.Period(2, ql.Years), 0.1021),
+    (ql.Period(5, ql.Years), ql.Period(1, ql.Years), 0.1000),
+]
 
-def formatVol(v, digits = 2):
-    format = '%%.%df %%%%' % digits
+
+def formatVol(v, digits=2):
+    format = "%%.%df %%%%" % digits
     return format % (v * 100)
 
-def formatPrice(p, digits = 2):
-    format = '%%.%df' % digits
+
+def formatPrice(p, digits=2):
+    format = "%%.%df" % digits
     return format % p
+
 
 def calibrate(model, helpers, l, name):
 
-    format = '%12s |%12s |%12s |%12s |%12s'
-    header = format % ('maturity','length','volatility','implied','error')
-    rule = '-' * len(header)
-    dblrule = '=' * len(header)
+    format = "%12s |%12s |%12s |%12s |%12s"
+    header = format % ("maturity", "length", "volatility", "implied", "error")
+    rule = "-" * len(header)
+    dblrule = "=" * len(header)
 
-    print('')
+    print("")
     print(dblrule)
     print(name)
     print(rule)
 
-    method = Simplex(l);
-    model.calibrate(helpers, method, EndCriteria(1000, 250, 1e-7, 1e-7, 1e-7))
+    method = ql.Simplex(l)
+    model.calibrate(helpers, method, ql.EndCriteria(1000, 250, 1e-7, 1e-7, 1e-7))
 
-    print('Parameters: %s' % model.params())
+    print("Parameters: %s" % model.params())
     print(rule)
 
     print(header)
@@ -59,83 +63,113 @@ def calibrate(model, helpers, l, name):
         implied = helper.impliedVolatility(NPV, 1.0e-4, 1000, 0.05, 0.50)
         error = implied - vol
         totalError += abs(error)
-        print(format % (maturity, length,
-                        formatVol(vol,4), formatVol(implied,4),
-                        formatVol(error,4)))
-    averageError = totalError/len(helpers)
+        print(format % (maturity, length, formatVol(vol, 4), formatVol(implied, 4), formatVol(error, 4)))
+    averageError = totalError / len(helpers)
 
     print(rule)
-    format = '%%%ds' % len(header)
-    print(format % ('Average error: ' + formatVol(averageError,4)))
+    format = "%%%ds" % len(header)
+    print(format % ("Average error: " + formatVol(averageError, 4)))
     print(dblrule)
 
-todaysDate = Date(15,February,2002)
-Settings.instance().evaluationDate = todaysDate
-calendar = TARGET()
-settlementDate = Date(19,February,2002);
+
+todaysDate = ql.Date(15, ql.February, 2002)
+ql.Settings.instance().evaluationDate = todaysDate
+calendar = ql.TARGET()
+settlementDate = ql.Date(19, ql.February, 2002)
 
 # flat yield term structure impling 1x5 swap at 5%
-rate = QuoteHandle(SimpleQuote(0.04875825))
-termStructure = YieldTermStructureHandle(
-    FlatForward(settlementDate,rate,Actual365Fixed()))
+rate = ql.QuoteHandle(ql.SimpleQuote(0.04875825))
+termStructure = ql.YieldTermStructureHandle(ql.FlatForward(settlementDate, rate, ql.Actual365Fixed()))
 
 # define the ATM/OTM/ITM swaps
 
-swapEngine = DiscountingSwapEngine(termStructure)
+swapEngine = ql.DiscountingSwapEngine(termStructure)
 
-fixedLegFrequency = Annual
-fixedLegTenor = Period(1,Years)
-fixedLegConvention = Unadjusted
-floatingLegConvention = ModifiedFollowing
-fixedLegDayCounter = Thirty360(Thirty360.European);
-floatingLegFrequency = Semiannual
-floatingLegTenor = Period(6,Months)
+fixedLegFrequency = ql.Annual
+fixedLegTenor = ql.Period(1, ql.Years)
+fixedLegConvention = ql.Unadjusted
+floatingLegConvention = ql.ModifiedFollowing
+fixedLegDayCounter = ql.Thirty360(ql.Thirty360.European)
+floatingLegFrequency = ql.Semiannual
+floatingLegTenor = ql.Period(6, ql.Months)
 
-payFixed = VanillaSwap.Payer
+payFixed = ql.VanillaSwap.Payer
 fixingDays = 2
-index = Euribor6M(termStructure)
+index = ql.Euribor6M(termStructure)
 floatingLegDayCounter = index.dayCounter()
 
-swapStart = calendar.advance(settlementDate,1,Years,floatingLegConvention)
-swapEnd = calendar.advance(swapStart,5,Years,floatingLegConvention)
+swapStart = calendar.advance(settlementDate, 1, ql.Years, floatingLegConvention)
+swapEnd = calendar.advance(swapStart, 5, ql.Years, floatingLegConvention)
 
-fixedSchedule = Schedule(swapStart, swapEnd,
-                         fixedLegTenor, calendar,
-                         fixedLegConvention, fixedLegConvention,
-                         DateGeneration.Forward, False)
-floatingSchedule = Schedule(swapStart, swapEnd,
-                            floatingLegTenor, calendar,
-                            floatingLegConvention, floatingLegConvention,
-                            DateGeneration.Forward, False)
+fixedSchedule = ql.Schedule(
+    swapStart,
+    swapEnd,
+    fixedLegTenor,
+    calendar,
+    fixedLegConvention,
+    fixedLegConvention,
+    ql.DateGeneration.Forward,
+    False,
+)
+floatingSchedule = ql.Schedule(
+    swapStart,
+    swapEnd,
+    floatingLegTenor,
+    calendar,
+    floatingLegConvention,
+    floatingLegConvention,
+    ql.DateGeneration.Forward,
+    False,
+)
 
-dummy = VanillaSwap(payFixed, 100.0,
-                    fixedSchedule, 0.0, fixedLegDayCounter,
-                    floatingSchedule, index, 0.0,
-                    floatingLegDayCounter)
+dummy = ql.VanillaSwap(
+    payFixed, 100.0, fixedSchedule, 0.0, fixedLegDayCounter, floatingSchedule, index, 0.0, floatingLegDayCounter
+)
 dummy.setPricingEngine(swapEngine)
 atmRate = dummy.fairRate()
 
-atmSwap = VanillaSwap(payFixed, 1000.0,
-                      fixedSchedule, atmRate, fixedLegDayCounter,
-                      floatingSchedule, index, 0.0,
-                      floatingLegDayCounter)
-otmSwap = VanillaSwap(payFixed, 1000.0,
-                      fixedSchedule, atmRate*1.2, fixedLegDayCounter,
-                      floatingSchedule, index, 0.0,
-                      floatingLegDayCounter)
-itmSwap = VanillaSwap(payFixed, 1000.0,
-                      fixedSchedule, atmRate*0.8, fixedLegDayCounter,
-                      floatingSchedule, index, 0.0,
-                      floatingLegDayCounter)
+atmSwap = ql.VanillaSwap(
+    payFixed, 1000.0, fixedSchedule, atmRate, fixedLegDayCounter, floatingSchedule, index, 0.0, floatingLegDayCounter
+)
+otmSwap = ql.VanillaSwap(
+    payFixed,
+    1000.0,
+    fixedSchedule,
+    atmRate * 1.2,
+    fixedLegDayCounter,
+    floatingSchedule,
+    index,
+    0.0,
+    floatingLegDayCounter,
+)
+itmSwap = ql.VanillaSwap(
+    payFixed,
+    1000.0,
+    fixedSchedule,
+    atmRate * 0.8,
+    fixedLegDayCounter,
+    floatingSchedule,
+    index,
+    0.0,
+    floatingLegDayCounter,
+)
 atmSwap.setPricingEngine(swapEngine)
 otmSwap.setPricingEngine(swapEngine)
 itmSwap.setPricingEngine(swapEngine)
 
-helpers = [ SwaptionHelper(maturity, length,
-                           QuoteHandle(SimpleQuote(vol)),
-                           index, index.tenor(), index.dayCounter(),
-                           index.dayCounter(), termStructure)
-            for maturity, length, vol in swaptionVols ]
+helpers = [
+    ql.SwaptionHelper(
+        maturity,
+        length,
+        ql.QuoteHandle(ql.SimpleQuote(vol)),
+        index,
+        index.tenor(),
+        index.dayCounter(),
+        index.dayCounter(),
+        termStructure,
+    )
+    for maturity, length, vol in swaptionVols
+]
 
 times = {}
 for h in helpers:
@@ -143,80 +177,87 @@ for h in helpers:
         times[t] = 1
 times = sorted(times.keys())
 
-grid = TimeGrid(times, 30)
+grid = ql.TimeGrid(times, 30)
 
-G2model = G2(termStructure)
-HWmodel = HullWhite(termStructure)
-HWmodel2 = HullWhite(termStructure)
-BKmodel = BlackKarasinski(termStructure)
+G2model = ql.G2(termStructure)
+HWmodel = ql.HullWhite(termStructure)
+HWmodel2 = ql.HullWhite(termStructure)
+BKmodel = ql.BlackKarasinski(termStructure)
 
 print("Calibrating...")
 
 for h in helpers:
-    h.setPricingEngine(G2SwaptionEngine(G2model,6.0,16))
+    h.setPricingEngine(ql.G2SwaptionEngine(G2model, 6.0, 16))
 calibrate(G2model, helpers, 0.05, "G2 (analytic formulae)")
 
 for h in helpers:
-    h.setPricingEngine(JamshidianSwaptionEngine(HWmodel))
+    h.setPricingEngine(ql.JamshidianSwaptionEngine(HWmodel))
 calibrate(HWmodel, helpers, 0.05, "Hull-White (analytic formulae)")
 
 for h in helpers:
-    h.setPricingEngine(TreeSwaptionEngine(HWmodel2,grid))
+    h.setPricingEngine(ql.TreeSwaptionEngine(HWmodel2, grid))
 calibrate(HWmodel2, helpers, 0.05, "Hull-White (numerical calibration)")
 
 for h in helpers:
-    h.setPricingEngine(TreeSwaptionEngine(BKmodel,grid))
+    h.setPricingEngine(ql.TreeSwaptionEngine(BKmodel, grid))
 calibrate(BKmodel, helpers, 0.05, "Black-Karasinski (numerical calibration)")
 
 
 # price Bermudan swaptions on defined swaps
 
-bermudanDates = [ d for d in fixedSchedule ][:-1]
-exercise = BermudanExercise(bermudanDates)
+bermudanDates = [d for d in fixedSchedule][:-1]
+exercise = ql.BermudanExercise(bermudanDates)
 
-format = '%17s |%17s |%17s |%17s'
-header = format % ('model', 'in-the-money', 'at-the-money', 'out-of-the-money')
-rule = '-' * len(header)
-dblrule = '=' * len(header)
+format = "%17s |%17s |%17s |%17s"
+header = format % ("model", "in-the-money", "at-the-money", "out-of-the-money")
+rule = "-" * len(header)
+dblrule = "=" * len(header)
 
-print('')
+print("")
 print(dblrule)
-print('Pricing Bermudan swaptions...')
+print("Pricing Bermudan swaptions...")
 print(rule)
 print(header)
 print(rule)
 
-atmSwaption = Swaption(atmSwap, exercise)
-otmSwaption = Swaption(otmSwap, exercise)
-itmSwaption = Swaption(itmSwap, exercise)
+atmSwaption = ql.Swaption(atmSwap, exercise)
+otmSwaption = ql.Swaption(otmSwap, exercise)
+itmSwaption = ql.Swaption(itmSwap, exercise)
 
-atmSwaption.setPricingEngine(TreeSwaptionEngine(G2model, 50))
-otmSwaption.setPricingEngine(TreeSwaptionEngine(G2model, 50))
-itmSwaption.setPricingEngine(TreeSwaptionEngine(G2model, 50))
+atmSwaption.setPricingEngine(ql.TreeSwaptionEngine(G2model, 50))
+otmSwaption.setPricingEngine(ql.TreeSwaptionEngine(G2model, 50))
+itmSwaption.setPricingEngine(ql.TreeSwaptionEngine(G2model, 50))
 
-print(format % ('G2 analytic', formatPrice(itmSwaption.NPV()),
-                formatPrice(atmSwaption.NPV()), formatPrice(otmSwaption.NPV())))
+print(
+    format
+    % ("G2 analytic", formatPrice(itmSwaption.NPV()), formatPrice(atmSwaption.NPV()), formatPrice(otmSwaption.NPV()))
+)
 
-atmSwaption.setPricingEngine(TreeSwaptionEngine(HWmodel, 50))
-otmSwaption.setPricingEngine(TreeSwaptionEngine(HWmodel, 50))
-itmSwaption.setPricingEngine(TreeSwaptionEngine(HWmodel, 50))
+atmSwaption.setPricingEngine(ql.TreeSwaptionEngine(HWmodel, 50))
+otmSwaption.setPricingEngine(ql.TreeSwaptionEngine(HWmodel, 50))
+itmSwaption.setPricingEngine(ql.TreeSwaptionEngine(HWmodel, 50))
 
-print(format % ('HW analytic', formatPrice(itmSwaption.NPV()),
-                formatPrice(atmSwaption.NPV()), formatPrice(otmSwaption.NPV())))
+print(
+    format
+    % ("HW analytic", formatPrice(itmSwaption.NPV()), formatPrice(atmSwaption.NPV()), formatPrice(otmSwaption.NPV()))
+)
 
-atmSwaption.setPricingEngine(TreeSwaptionEngine(HWmodel2, 50))
-otmSwaption.setPricingEngine(TreeSwaptionEngine(HWmodel2, 50))
-itmSwaption.setPricingEngine(TreeSwaptionEngine(HWmodel2, 50))
+atmSwaption.setPricingEngine(ql.TreeSwaptionEngine(HWmodel2, 50))
+otmSwaption.setPricingEngine(ql.TreeSwaptionEngine(HWmodel2, 50))
+itmSwaption.setPricingEngine(ql.TreeSwaptionEngine(HWmodel2, 50))
 
-print(format % ('HW numerical', formatPrice(itmSwaption.NPV()),
-                formatPrice(atmSwaption.NPV()), formatPrice(otmSwaption.NPV())))
+print(
+    format
+    % ("HW numerical", formatPrice(itmSwaption.NPV()), formatPrice(atmSwaption.NPV()), formatPrice(otmSwaption.NPV()))
+)
 
-atmSwaption.setPricingEngine(TreeSwaptionEngine(BKmodel, 50))
-otmSwaption.setPricingEngine(TreeSwaptionEngine(BKmodel, 50))
-itmSwaption.setPricingEngine(TreeSwaptionEngine(BKmodel, 50))
+atmSwaption.setPricingEngine(ql.TreeSwaptionEngine(BKmodel, 50))
+otmSwaption.setPricingEngine(ql.TreeSwaptionEngine(BKmodel, 50))
+itmSwaption.setPricingEngine(ql.TreeSwaptionEngine(BKmodel, 50))
 
-print(format % ('BK numerical', formatPrice(itmSwaption.NPV()),
-                formatPrice(atmSwaption.NPV()), formatPrice(otmSwaption.NPV())))
+print(
+    format
+    % ("BK numerical", formatPrice(itmSwaption.NPV()), formatPrice(atmSwaption.NPV()), formatPrice(otmSwaption.NPV()))
+)
 
 print(dblrule)
-

--- a/Python/examples/bonds.py
+++ b/Python/examples/bonds.py
@@ -18,37 +18,36 @@
 #    some simple bonds. The last part is dedicated to peripherical
 #    computations such as "Yield to Price" or "Price to Yield"
 
-from QuantLib import *
+import QuantLib as ql
 
 # global data
-calendar = TARGET()
-settlementDate = Date(18,September,2008)
+calendar = ql.TARGET()
+settlementDate = ql.Date(18, ql.September, 2008)
 settlementDate = calendar.adjust(settlementDate)
 
 fixingDays = 3
 settlementDays = 3
 
-todaysDate = calendar.advance(settlementDate,-fixingDays, Days)
-Settings.instance().evaluationDate = todaysDate
+todaysDate = calendar.advance(settlementDate, -fixingDays, ql.Days)
+ql.Settings.instance().evaluationDate = todaysDate
 
-print('Today: '  + str(todaysDate))
-print('Settlement Date: ' + str(settlementDate))
+print("Today: " + str(todaysDate))
+print("Settlement Date: " + str(settlementDate))
 
 # market quotes
 
 # constructing bond yield curve
 
-zcQuotes = [(0.0096, Period(3,Months)),
-            (0.0145, Period(6,Months)),
-            (0.0194, Period(1,Years))]
+zcQuotes = [(0.0096, ql.Period(3, ql.Months)), (0.0145, ql.Period(6, ql.Months)), (0.0194, ql.Period(1, ql.Years))]
 
-zcBondsDayCounter = Actual365Fixed()
+zcBondsDayCounter = ql.Actual365Fixed()
 
-zcHelpers = [ DepositRateHelper(QuoteHandle(SimpleQuote(r)),
-                                tenor, fixingDays,
-                                calendar, ModifiedFollowing,
-                                True, zcBondsDayCounter)
-              for (r,tenor) in zcQuotes ]
+zcHelpers = [
+    ql.DepositRateHelper(
+        ql.QuoteHandle(ql.SimpleQuote(r)), tenor, fixingDays, calendar, ql.ModifiedFollowing, True, zcBondsDayCounter
+    )
+    for (r, tenor) in zcQuotes
+]
 
 # setup bonds
 
@@ -56,99 +55,116 @@ redemption = 100.0
 numberOfBonds = 5
 
 bondQuotes = [
-    (Date(15,March,2005),    Date(31,August,2010), 0.02375, 100.390625),
-    (Date(15,June,2005),     Date(31,August,2011), 0.04625, 106.21875),
-    (Date(30,June,2006),     Date(31,August,2013), 0.03125, 100.59375),
-    (Date(15,November,2002), Date(15,August,2018), 0.04000, 101.6875),
-    (Date(15,May,1987),      Date (15,May,2038),   0.04500, 102.140625)
+    (ql.Date(15, ql.March, 2005), ql.Date(31, ql.August, 2010), 0.02375, 100.390625),
+    (ql.Date(15, ql.June, 2005), ql.Date(31, ql.August, 2011), 0.04625, 106.21875),
+    (ql.Date(30, ql.June, 2006), ql.Date(31, ql.August, 2013), 0.03125, 100.59375),
+    (ql.Date(15, ql.November, 2002), ql.Date(15, ql.August, 2018), 0.04000, 101.6875),
+    (ql.Date(15, ql.May, 1987), ql.Date(15, ql.May, 2038), 0.04500, 102.140625),
 ]
 
 # Definition of the rate helpers
 
-bondsHelpers =[]
+bondsHelpers = []
 
 for issueDate, maturity, couponRate, marketQuote in bondQuotes:
-    schedule = Schedule(issueDate, maturity, Period(Semiannual),
-                        UnitedStates(UnitedStates.GovernmentBond),
-                        Unadjusted, Unadjusted,
-                        DateGeneration.Backward, False)
+    schedule = ql.Schedule(
+        issueDate,
+        maturity,
+        ql.Period(ql.Semiannual),
+        ql.UnitedStates(ql.UnitedStates.GovernmentBond),
+        ql.Unadjusted,
+        ql.Unadjusted,
+        ql.DateGeneration.Backward,
+        False,
+    )
     bondsHelpers.append(
-        FixedRateBondHelper(QuoteHandle(SimpleQuote(marketQuote)),
-                            settlementDays,
-                            100.0,
-                            schedule,
-                            [couponRate],
-                            ActualActual(ActualActual.Bond),
-                            Unadjusted,
-                            redemption,
-                            issueDate))
+        ql.FixedRateBondHelper(
+            ql.QuoteHandle(ql.SimpleQuote(marketQuote)),
+            settlementDays,
+            100.0,
+            schedule,
+            [couponRate],
+            ql.ActualActual(ql.ActualActual.Bond),
+            ql.Unadjusted,
+            redemption,
+            issueDate,
+        )
+    )
 
 ###################################
 ####  **  CURVE BUILDING  **  #####
 ###################################
 
-termStructureDayCounter =  ActualActual(ActualActual.ISDA)  
+termStructureDayCounter = ql.ActualActual(ql.ActualActual.ISDA)
 
 # not needed as defined in the interface file:  tolerance = 1.0e-15
 
 bondInstruments = zcHelpers + bondsHelpers
 
-bondDiscountingTermStructure = PiecewiseFlatForward(
-    settlementDate, bondInstruments,
-    termStructureDayCounter)
+bondDiscountingTermStructure = ql.PiecewiseFlatForward(settlementDate, bondInstruments, termStructureDayCounter)
 
 # Building of the Libor forecasting curve
 # deposits
-dQuotes = [(0.043375, Period(1,Weeks)),
-           (0.031875, Period(1,Months)),
-           (0.0320375, Period(3,Months)),
-           (0.03385, Period(6,Months)),
-           (0.0338125, Period(9,Months)),
-           (0.0335125, Period(1,Years))]
-sQuotes = [(0.0295, Period(2,Years)),
-           (0.0323, Period(3,Years)),
-           (0.0359, Period(5,Years)),
-           (0.0412, Period(10,Years)),
-           (0.0433, Period(15,Years))]
+dQuotes = [
+    (0.043375, ql.Period(1, ql.Weeks)),
+    (0.031875, ql.Period(1, ql.Months)),
+    (0.0320375, ql.Period(3, ql.Months)),
+    (0.03385, ql.Period(6, ql.Months)),
+    (0.0338125, ql.Period(9, ql.Months)),
+    (0.0335125, ql.Period(1, ql.Years)),
+]
+sQuotes = [
+    (0.0295, ql.Period(2, ql.Years)),
+    (0.0323, ql.Period(3, ql.Years)),
+    (0.0359, ql.Period(5, ql.Years)),
+    (0.0412, ql.Period(10, ql.Years)),
+    (0.0433, ql.Period(15, ql.Years)),
+]
 
 # deposits
 
-depositDayCounter = Actual360()
+depositDayCounter = ql.Actual360()
 depositHelpers = [
-    DepositRateHelper(QuoteHandle(SimpleQuote(rate)),
-                      tenor, fixingDays,
-                      calendar, ModifiedFollowing,
-                      True, depositDayCounter)
-    for rate, tenor in dQuotes ]
+    ql.DepositRateHelper(
+        ql.QuoteHandle(ql.SimpleQuote(rate)), tenor, fixingDays, calendar, ql.ModifiedFollowing, True, depositDayCounter
+    )
+    for rate, tenor in dQuotes
+]
 
 # swaps
 
-swFixedLegFrequency = Annual
-swFixedLegConvention = Unadjusted
-swFixedLegDayCounter = Thirty360(Thirty360.European)
-swFloatingLegIndex = Euribor6M()
-forwardStart = Period(1,Days)
+swFixedLegFrequency = ql.Annual
+swFixedLegConvention = ql.Unadjusted
+swFixedLegDayCounter = ql.Thirty360(ql.Thirty360.European)
+swFloatingLegIndex = ql.Euribor6M()
+forwardStart = ql.Period(1, ql.Days)
 swapHelpers = [
-    SwapRateHelper(QuoteHandle(SimpleQuote(rate)), tenor,
-                   calendar, swFixedLegFrequency,
-                   swFixedLegConvention, swFixedLegDayCounter,
-                   swFloatingLegIndex, QuoteHandle(),forwardStart)
-    for rate, tenor in sQuotes ]
+    ql.SwapRateHelper(
+        ql.QuoteHandle(ql.SimpleQuote(rate)),
+        tenor,
+        calendar,
+        swFixedLegFrequency,
+        swFixedLegConvention,
+        swFixedLegDayCounter,
+        swFloatingLegIndex,
+        ql.QuoteHandle(),
+        forwardStart,
+    )
+    for rate, tenor in sQuotes
+]
 
 depoSwapInstruments = depositHelpers + swapHelpers
 
-depoSwapTermStructure = PiecewiseFlatForward(
-    settlementDate, depoSwapInstruments,
-    termStructureDayCounter)
+depoSwapTermStructure = ql.PiecewiseFlatForward(settlementDate, depoSwapInstruments, termStructureDayCounter)
 
 # Term structures that will be used for pricing:
 # the one used for discounting cash flows
 
-discountingTermStructure = RelinkableYieldTermStructureHandle()
+discountingTermStructure = ql.RelinkableYieldTermStructureHandle()
 
 # the one used for forward rate forecasting
 
-forecastingTermStructure = RelinkableYieldTermStructureHandle()
+forecastingTermStructure = ql.RelinkableYieldTermStructureHandle()
 
 #######################################
 #        BONDS TO BE PRICED           #
@@ -156,87 +172,100 @@ forecastingTermStructure = RelinkableYieldTermStructureHandle()
 
 # common data
 
-faceAmount = 100;
+faceAmount = 100
 
 # pricing engine
-bondEngine = DiscountingBondEngine(discountingTermStructure)
+bondEngine = ql.DiscountingBondEngine(discountingTermStructure)
 
 # zero coupon bond
 
-zeroCouponBond = ZeroCouponBond(settlementDays,
-                                UnitedStates(UnitedStates.GovernmentBond),
-                                faceAmount,
-                                Date(15,August,2013),
-                                Following,
-                                116.92,
-                                Date(15,August,2003))
+zeroCouponBond = ql.ZeroCouponBond(
+    settlementDays,
+    ql.UnitedStates(ql.UnitedStates.GovernmentBond),
+    faceAmount,
+    ql.Date(15, ql.August, 2013),
+    ql.Following,
+    116.92,
+    ql.Date(15, ql.August, 2003),
+)
 
 zeroCouponBond.setPricingEngine(bondEngine)
 
 # fixed 4.5% US Treasury note
 
-fixedBondSchedule = Schedule(Date(15, May, 2007),
-                             Date(15,May,2017), Period(Semiannual),
-                             UnitedStates(UnitedStates.GovernmentBond),
-                             Unadjusted, Unadjusted,
-                             DateGeneration.Backward, False)
+fixedBondSchedule = ql.Schedule(
+    ql.Date(15, ql.May, 2007),
+    ql.Date(15, ql.May, 2017),
+    ql.Period(ql.Semiannual),
+    ql.UnitedStates(ql.UnitedStates.GovernmentBond),
+    ql.Unadjusted,
+    ql.Unadjusted,
+    ql.DateGeneration.Backward,
+    False,
+)
 
-fixedRateBond = FixedRateBond(settlementDays,
-                              faceAmount,
-                              fixedBondSchedule,
-                              [0.045],
-                              ActualActual(ActualActual.Bond),
-                              ModifiedFollowing,
-                              100.0, Date(15, May, 2007))
+fixedRateBond = ql.FixedRateBond(
+    settlementDays,
+    faceAmount,
+    fixedBondSchedule,
+    [0.045],
+    ql.ActualActual(ql.ActualActual.Bond),
+    ql.ModifiedFollowing,
+    100.0,
+    ql.Date(15, ql.May, 2007),
+)
 
-fixedRateBond.setPricingEngine(bondEngine);
+fixedRateBond.setPricingEngine(bondEngine)
 
 # Floating rate bond (3M USD Libor + 0.1%)
 # Should and will be priced on another curve later...
 
-liborTermStructure = RelinkableYieldTermStructureHandle()
+liborTermStructure = ql.RelinkableYieldTermStructureHandle()
 
-libor3m = USDLibor(Period(3,Months),liborTermStructure)
-libor3m.addFixing(Date(17, July, 2008),0.0278625)
+libor3m = ql.USDLibor(ql.Period(3, ql.Months), liborTermStructure)
+libor3m.addFixing(ql.Date(17, ql.July, 2008), 0.0278625)
 
-floatingBondSchedule = Schedule(Date(21, October, 2005),
-                                Date(21, October, 2010), Period(Quarterly),
-                                UnitedStates(UnitedStates.NYSE),
-                                Unadjusted, Unadjusted,
-                                DateGeneration.Backward, True);
+floatingBondSchedule = ql.Schedule(
+    ql.Date(21, ql.October, 2005),
+    ql.Date(21, ql.October, 2010),
+    ql.Period(ql.Quarterly),
+    ql.UnitedStates(ql.UnitedStates.NYSE),
+    ql.Unadjusted,
+    ql.Unadjusted,
+    ql.DateGeneration.Backward,
+    True,
+)
 
-floatingRateBond = FloatingRateBond(settlementDays,
-                                    faceAmount,
-                                    floatingBondSchedule,
-                                    libor3m,
-                                    Actual360(),
-                                    ModifiedFollowing,
-                                    spreads=[0.001],
-                                    inArrears=True,
-                                    issueDate=Date(21, October, 2005))
+floatingRateBond = ql.FloatingRateBond(
+    settlementDays,
+    faceAmount,
+    floatingBondSchedule,
+    libor3m,
+    ql.Actual360(),
+    ql.ModifiedFollowing,
+    spreads=[0.001],
+    inArrears=True,
+    issueDate=ql.Date(21, ql.October, 2005),
+)
 
-floatingRateBond.setPricingEngine(bondEngine);
+floatingRateBond.setPricingEngine(bondEngine)
 
 # coupon pricers
 
-pricer = BlackIborCouponPricer()
+pricer = ql.BlackIborCouponPricer()
 
 # optionlet volatilities
-volatility = 0.0;
-vol = ConstantOptionletVolatility(settlementDays,
-                                  calendar,
-                                  ModifiedFollowing,
-                                  volatility,
-                                  Actual365Fixed())
+volatility = 0.0
+vol = ql.ConstantOptionletVolatility(settlementDays, calendar, ql.ModifiedFollowing, volatility, ql.Actual365Fixed())
 
-pricer.setCapletVolatility(OptionletVolatilityStructureHandle(vol))
-setCouponPricer(floatingRateBond.cashflows(),pricer)
+pricer.setCapletVolatility(ql.OptionletVolatilityStructureHandle(vol))
+ql.setCouponPricer(floatingRateBond.cashflows(), pricer)
 
 # Yield curve bootstrapping
 forecastingTermStructure.linkTo(depoSwapTermStructure)
 discountingTermStructure.linkTo(bondDiscountingTermStructure)
 
-#We are using the depo & swap curve to estimate the future Libor rates
+# We are using the depo & swap curve to estimate the future Libor rates
 liborTermStructure.linkTo(depoSwapTermStructure)
 
 #############################
@@ -244,91 +273,86 @@ liborTermStructure.linkTo(depoSwapTermStructure)
 #############################
 
 # write column headings
-def formatPrice(p,digits=2):
-    format = '%%.%df' % digits
+def formatPrice(p, digits=2):
+    format = "%%.%df" % digits
     return format % p
 
-def formatRate(r,digits=2):
-    format = '%%.%df %%%%' % digits
-    return format % (r*100)
+
+def formatRate(r, digits=2):
+    format = "%%.%df %%%%" % digits
+    return format % (r * 100)
+
 
 def report(Info, Zc, Fix, Frn, format):
-    if format== "Price":
+    if format == "Price":
         Zc = formatPrice(Zc)
         Fix = formatPrice(Fix)
         Frn = formatPrice(Frn)
     else:
-        if Info.find("coupon")==-1:
-            Zc  = formatRate(Zc)
+        if Info.find("coupon") == -1:
+            Zc = formatRate(Zc)
         else:
-            Zc  = "N/A"
+            Zc = "N/A"
         Fix = formatRate(Fix)
         Frn = formatRate(Frn)
-        
-    print('%19s' % Info + ' |' +
-          ' |'.join(['%10s' % y for y in [Zc, Fix, Frn] ]))
+
+    print("%19s" % Info + " |" + " |".join(["%10s" % y for y in [Zc, Fix, Frn]]))
 
 
+headers = ["ZC", "Fixed", "Floating"]
+print("")
+print("%19s" % "" + " |" + " |".join(["%10s" % y for y in headers]))
 
-headers = [ "ZC", "Fixed", "Floating" ]
-print('')
-print('%19s' % '' + ' |' +
-          ' |'.join(['%10s' % y for y in headers]))
-                     
 separator = " | "
-widths = [ 18, 10, 10, 10 ]
-width = widths[0] + widths[1] + widths[2]  + widths[3] + widths[3];
+widths = [18, 10, 10, 10]
+width = widths[0] + widths[1] + widths[2] + widths[3] + widths[3]
 rule = "-" * width
 dblrule = "=" * width
 tab = " " * 8
 
 print(rule)
-report( "Net present value",
-        zeroCouponBond.NPV(),
-        fixedRateBond.NPV(),
-        floatingRateBond.NPV(),
-        "Price")
-report( "Clean price",
-        zeroCouponBond.cleanPrice(),
-        fixedRateBond.cleanPrice(),
-        floatingRateBond.cleanPrice(),
-        "Price")
-report( "Dirty price",
-        zeroCouponBond.dirtyPrice(),
-        fixedRateBond.dirtyPrice(),
-        floatingRateBond.dirtyPrice(),
-        "Price")
-report( "Accrued coupon",
-        zeroCouponBond.accruedAmount(),
-        fixedRateBond.accruedAmount(),
-        floatingRateBond.accruedAmount(),
-        "Price")
-report( "Previous coupon",
-        0,
-        fixedRateBond.previousCouponRate(),
-        floatingRateBond.previousCouponRate(),
-        "Rate")
-report( "Next coupon",
-        0,
-        fixedRateBond.nextCouponRate(),
-        floatingRateBond.nextCouponRate(),
-        "Rate")
-report( "Yield",
-        zeroCouponBond.bondYield(Actual360(),Compounded,Annual)
-        ,fixedRateBond.bondYield(Actual360(),Compounded,Annual),
-        floatingRateBond.bondYield(Actual360(),Compounded,Annual),
-        "Rate")
-print('')
+report("Net present value", zeroCouponBond.NPV(), fixedRateBond.NPV(), floatingRateBond.NPV(), "Price")
+report("Clean price", zeroCouponBond.cleanPrice(), fixedRateBond.cleanPrice(), floatingRateBond.cleanPrice(), "Price")
+report("Dirty price", zeroCouponBond.dirtyPrice(), fixedRateBond.dirtyPrice(), floatingRateBond.dirtyPrice(), "Price")
+report(
+    "Accrued coupon",
+    zeroCouponBond.accruedAmount(),
+    fixedRateBond.accruedAmount(),
+    floatingRateBond.accruedAmount(),
+    "Price",
+)
+report("Previous coupon", 0, fixedRateBond.previousCouponRate(), floatingRateBond.previousCouponRate(), "Rate")
+report("Next coupon", 0, fixedRateBond.nextCouponRate(), floatingRateBond.nextCouponRate(), "Rate")
+report(
+    "Yield",
+    zeroCouponBond.bondYield(ql.Actual360(), ql.Compounded, ql.Annual),
+    fixedRateBond.bondYield(ql.Actual360(), ql.Compounded, ql.Annual),
+    floatingRateBond.bondYield(ql.Actual360(), ql.Compounded, ql.Annual),
+    "Rate",
+)
+print("")
 
 # Other computations
 
 print("Sample indirect computations (for the floating rate bond): ")
 print(rule)
-print("Yield to Clean Price: " + formatPrice(
-    floatingRateBond.cleanPrice(floatingRateBond.bondYield(Actual360(),
-                                                           Compounded,Annual),
-                                Actual360(),Compounded,Annual,settlementDate)))
-print("Clean Price to Yield: " + formatRate(
-    floatingRateBond.bondYield(floatingRateBond.cleanPrice(),
-                               Actual360(),Compounded,
-                               Annual,settlementDate)))
+print(
+    "Yield to Clean Price: "
+    + formatPrice(
+        floatingRateBond.cleanPrice(
+            floatingRateBond.bondYield(ql.Actual360(), ql.Compounded, ql.Annual),
+            ql.Actual360(),
+            ql.Compounded,
+            ql.Annual,
+            settlementDate,
+        )
+    )
+)
+print(
+    "Clean Price to Yield: "
+    + formatRate(
+        floatingRateBond.bondYield(
+            floatingRateBond.cleanPrice(), ql.Actual360(), ql.Compounded, ql.Annual, settlementDate
+        )
+    )
+)

--- a/Python/examples/cds.py
+++ b/Python/examples/cds.py
@@ -15,65 +15,73 @@
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See the license for more details.
 
-from QuantLib import *
+import QuantLib as ql
 
-calendar = TARGET()
+calendar = ql.TARGET()
 
 # set evaluation date
-todaysDate = Date(15,May,2007);
+todaysDate = ql.Date(15, ql.May, 2007)
 todaysDate = calendar.adjust(todaysDate)
-Settings.instance().evaluationDate = todaysDate
+ql.Settings.instance().evaluationDate = todaysDate
 
-risk_free_rate = YieldTermStructureHandle(
-        FlatForward(todaysDate, 0.01, Actual365Fixed()))
+risk_free_rate = ql.YieldTermStructureHandle(ql.FlatForward(todaysDate, 0.01, ql.Actual365Fixed()))
 
 # CDS parameters
 recovery_rate = 0.5
-quoted_spreads = [ 0.0150, 0.0150, 0.0150, 0.0150 ]
-tenors = [ Period(3, Months), Period(6, Months),
-           Period(1, Years), Period(2, Years) ]
-maturities = [ calendar.adjust(todaysDate + x, Following) for x in tenors]
+quoted_spreads = [0.0150, 0.0150, 0.0150, 0.0150]
+tenors = [ql.Period(3, ql.Months), ql.Period(6, ql.Months), ql.Period(1, ql.Years), ql.Period(2, ql.Years)]
+maturities = [calendar.adjust(todaysDate + x, ql.Following) for x in tenors]
 
 instruments = [
-    SpreadCdsHelper(QuoteHandle(SimpleQuote(s)),
-                    tenor,
-                    0,
-                    calendar,
-                    Quarterly,
-                    Following,
-                    DateGeneration.TwentiethIMM,
-                    Actual365Fixed(),
-                    recovery_rate,
-                    risk_free_rate)
-    for s,tenor in zip(quoted_spreads, tenors) ]
+    ql.SpreadCdsHelper(
+        ql.QuoteHandle(ql.SimpleQuote(s)),
+        tenor,
+        0,
+        calendar,
+        ql.Quarterly,
+        ql.Following,
+        ql.DateGeneration.TwentiethIMM,
+        ql.Actual365Fixed(),
+        recovery_rate,
+        risk_free_rate,
+    )
+    for s, tenor in zip(quoted_spreads, tenors)
+]
 
-hazard_curve = PiecewiseFlatHazardRate(todaysDate, instruments,
-                                       Actual365Fixed())
+hazard_curve = ql.PiecewiseFlatHazardRate(todaysDate, instruments, ql.Actual365Fixed())
 print("Calibrated hazard rate values: ")
 for x in hazard_curve.nodes():
     print("hazard rate on %s is %.7f" % x)
 
 print("Some survival probability values: ")
-print("1Y survival probability: %.4g, \n\t\texpected %.4g" % (
-    hazard_curve.survivalProbability(todaysDate + Period("1Y")),
-    0.9704))
-print("2Y survival probability: %.4g, \n\t\texpected %.4g" % (
-    hazard_curve.survivalProbability(todaysDate + Period("2Y")),
-    0.9418))
+print(
+    "1Y survival probability: %.4g, \n\t\texpected %.4g"
+    % (hazard_curve.survivalProbability(todaysDate + ql.Period("1Y")), 0.9704)
+)
+print(
+    "2Y survival probability: %.4g, \n\t\texpected %.4g"
+    % (hazard_curve.survivalProbability(todaysDate + ql.Period("2Y")), 0.9418)
+)
 
 # reprice instruments
 nominal = 1000000.0
-probability = DefaultProbabilityTermStructureHandle(hazard_curve)
+probability = ql.DefaultProbabilityTermStructureHandle(hazard_curve)
 
 # create a cds for every maturity
 all_cds = []
 for maturity, s in zip(maturities, quoted_spreads):
-    schedule = Schedule(todaysDate, maturity, Period(Quarterly),
-                        calendar, Following, Unadjusted,
-                        DateGeneration.TwentiethIMM, False)
-    cds = CreditDefaultSwap(Protection.Seller, nominal, s,
-                            schedule, Following, Actual365Fixed())
-    engine = MidPointCdsEngine(probability, recovery_rate, risk_free_rate)
+    schedule = ql.Schedule(
+        todaysDate,
+        maturity,
+        ql.Period(ql.Quarterly),
+        calendar,
+        ql.Following,
+        ql.Unadjusted,
+        ql.DateGeneration.TwentiethIMM,
+        False,
+    )
+    cds = ql.CreditDefaultSwap(ql.Protection.Seller, nominal, s, schedule, ql.Following, ql.Actual365Fixed())
+    engine = ql.MidPointCdsEngine(probability, recovery_rate, risk_free_rate)
     cds.setPricingEngine(engine)
     all_cds.append(cds)
 

--- a/Python/examples/european-option.py
+++ b/Python/examples/european-option.py
@@ -13,22 +13,22 @@
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See the license for more details.
 
-from QuantLib import *
+import QuantLib as ql
 
 # global data
-todaysDate = Date(15, May, 1998)
-Settings.instance().evaluationDate = todaysDate
-settlementDate = Date(17, May, 1998)
-riskFreeRate = FlatForward(settlementDate, 0.05, Actual365Fixed())
+todaysDate = ql.Date(15, ql.May, 1998)
+ql.Settings.instance().evaluationDate = todaysDate
+settlementDate = ql.Date(17, ql.May, 1998)
+riskFreeRate = ql.FlatForward(settlementDate, 0.05, ql.Actual365Fixed())
 
 # option parameters
-exercise = EuropeanExercise(Date(17, May, 1999))
-payoff = PlainVanillaPayoff(Option.Call, 8.0)
+exercise = ql.EuropeanExercise(ql.Date(17, ql.May, 1999))
+payoff = ql.PlainVanillaPayoff(ql.Option.Call, 8.0)
 
 # market data
-underlying = SimpleQuote(7.0)
-volatility = BlackConstantVol(settlementDate, TARGET(), 0.10, Actual365Fixed())
-dividendYield = FlatForward(settlementDate, 0.05, Actual365Fixed())
+underlying = ql.SimpleQuote(7.0)
+volatility = ql.BlackConstantVol(settlementDate, ql.TARGET(), 0.10, ql.Actual365Fixed())
+dividendYield = ql.FlatForward(settlementDate, 0.05, ql.Actual365Fixed())
 
 # report
 header = " |".join(["%17s" % tag for tag in ["method", "value", "estimated error", "actual error"]])
@@ -51,82 +51,82 @@ def report(method, x, dx=None):
 
 # good to go
 
-process = BlackScholesMertonProcess(
-    QuoteHandle(underlying),
-    YieldTermStructureHandle(dividendYield),
-    YieldTermStructureHandle(riskFreeRate),
-    BlackVolTermStructureHandle(volatility),
+process = ql.BlackScholesMertonProcess(
+    ql.QuoteHandle(underlying),
+    ql.YieldTermStructureHandle(dividendYield),
+    ql.YieldTermStructureHandle(riskFreeRate),
+    ql.BlackVolTermStructureHandle(volatility),
 )
 
-hestonProcess = HestonProcess(
-    YieldTermStructureHandle(riskFreeRate),
-    YieldTermStructureHandle(dividendYield),
-    QuoteHandle(underlying),
+hestonProcess = ql.HestonProcess(
+    ql.YieldTermStructureHandle(riskFreeRate),
+    ql.YieldTermStructureHandle(dividendYield),
+    ql.QuoteHandle(underlying),
     0.1 * 0.1,
     1.0,
     0.1 * 0.1,
     0.0001,
     0.0,
 )
-hestonModel = HestonModel(hestonProcess)
+hestonModel = ql.HestonModel(hestonProcess)
 
-option = VanillaOption(payoff, exercise)
+option = ql.VanillaOption(payoff, exercise)
 
 # method: analytic
-option.setPricingEngine(AnalyticEuropeanEngine(process))
+option.setPricingEngine(ql.AnalyticEuropeanEngine(process))
 value = option.NPV()
 refValue = value
 report("analytic", value)
 
 # method: Heston semi-analytic
-option.setPricingEngine(AnalyticHestonEngine(hestonModel))
+option.setPricingEngine(ql.AnalyticHestonEngine(hestonModel))
 report("Heston analytic", option.NPV())
 
 # method: Heston COS method
-option.setPricingEngine(COSHestonEngine(hestonModel))
+option.setPricingEngine(ql.COSHestonEngine(hestonModel))
 report("Heston COS Method", option.NPV())
 
 # method: integral
-option.setPricingEngine(IntegralEngine(process))
+option.setPricingEngine(ql.IntegralEngine(process))
 report("integral", option.NPV())
 
 # method: finite differences
 timeSteps = 801
 gridPoints = 800
 
-option.setPricingEngine(FDEuropeanEngine(process, timeSteps, gridPoints))
+option.setPricingEngine(ql.FDEuropeanEngine(process, timeSteps, gridPoints))
 report("finite diff.", option.NPV())
 
 # method: binomial
 timeSteps = 801
 
-option.setPricingEngine(BinomialVanillaEngine(process, "JR", timeSteps))
+option.setPricingEngine(ql.BinomialVanillaEngine(process, "JR", timeSteps))
 report("binomial (JR)", option.NPV())
 
-option.setPricingEngine(BinomialVanillaEngine(process, "CRR", timeSteps))
+option.setPricingEngine(ql.BinomialVanillaEngine(process, "CRR", timeSteps))
 report("binomial (CRR)", option.NPV())
 
-option.setPricingEngine(BinomialVanillaEngine(process, "EQP", timeSteps))
+option.setPricingEngine(ql.BinomialVanillaEngine(process, "EQP", timeSteps))
 report("binomial (EQP)", option.NPV())
 
-option.setPricingEngine(BinomialVanillaEngine(process, "Trigeorgis", timeSteps))
+option.setPricingEngine(ql.BinomialVanillaEngine(process, "Trigeorgis", timeSteps))
 report("bin. (Trigeorgis)", option.NPV())
 
-option.setPricingEngine(BinomialVanillaEngine(process, "Tian", timeSteps))
+option.setPricingEngine(ql.BinomialVanillaEngine(process, "Tian", timeSteps))
 report("binomial (Tian)", option.NPV())
 
-option.setPricingEngine(BinomialVanillaEngine(process, "LR", timeSteps))
+option.setPricingEngine(ql.BinomialVanillaEngine(process, "LR", timeSteps))
 report("binomial (LR)", option.NPV())
 
-option.setPricingEngine(BinomialVanillaEngine(process, "Joshi4", timeSteps))
+option.setPricingEngine(ql.BinomialVanillaEngine(process, "Joshi4", timeSteps))
 report("binomial (Joshi)", option.NPV())
 
 # method: finite differences
 # not yet implemented
 
 # method: Monte Carlo
-option.setPricingEngine(MCEuropeanEngine(process, "pseudorandom", timeSteps=1, requiredTolerance=0.02, seed=42))
+option.setPricingEngine(ql.MCEuropeanEngine(process, "pseudorandom", timeSteps=1, requiredTolerance=0.02, seed=42))
 report("MC (crude)", option.NPV(), option.errorEstimate())
 
-option.setPricingEngine(MCEuropeanEngine(process, "lowdiscrepancy", timeSteps=1, requiredSamples=32768))
+option.setPricingEngine(ql.MCEuropeanEngine(process, "lowdiscrepancy", timeSteps=1, requiredSamples=32768))
 report("MC (Sobol)", option.NPV())

--- a/Python/examples/swap.py
+++ b/Python/examples/swap.py
@@ -1,4 +1,3 @@
-
 # Copyright (C) 2004, 2005, 2006, 2007 StatPro Italia srl
 #
 # This file is part of QuantLib, a free-software/open-source library
@@ -14,194 +13,258 @@
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See the license for more details.
 
-from QuantLib import *
+import QuantLib as ql
 
 # global data
-calendar = TARGET()
-todaysDate = Date(6,November,2001);
-Settings.instance().evaluationDate = todaysDate
-settlementDate = Date(8,November,2001);
+calendar = ql.TARGET()
+todaysDate = ql.Date(6, ql.November, 2001)
+ql.Settings.instance().evaluationDate = todaysDate
+settlementDate = ql.Date(8, ql.November, 2001)
 
 # market quotes
-deposits = { (1,Weeks): 0.0382,
-             (1,Months): 0.0372,
-             (3,Months): 0.0363,
-             (6,Months): 0.0353,
-             (9,Months): 0.0348,
-             (1,Years): 0.0345 }
+deposits = {
+    (1, ql.Weeks): 0.0382,
+    (1, ql.Months): 0.0372,
+    (3, ql.Months): 0.0363,
+    (6, ql.Months): 0.0353,
+    (9, ql.Months): 0.0348,
+    (1, ql.Years): 0.0345,
+}
 
-FRAs = { (3,6): 0.037125,
-         (6,9): 0.037125,
-         (9,12): 0.037125 }
+FRAs = {(3, 6): 0.037125, (6, 9): 0.037125, (9, 12): 0.037125}
 
-futures = { Date(19,12,2001): 96.2875,
-            Date(20,3,2002): 96.7875,
-            Date(19,6,2002): 96.9875,
-            Date(18,9,2002): 96.6875,
-            Date(18,12,2002): 96.4875,
-            Date(19,3,2003): 96.3875,
-            Date(18,6,2003): 96.2875,
-            Date(17,9,2003): 96.0875 }
+futures = {
+    ql.Date(19, 12, 2001): 96.2875,
+    ql.Date(20, 3, 2002): 96.7875,
+    ql.Date(19, 6, 2002): 96.9875,
+    ql.Date(18, 9, 2002): 96.6875,
+    ql.Date(18, 12, 2002): 96.4875,
+    ql.Date(19, 3, 2003): 96.3875,
+    ql.Date(18, 6, 2003): 96.2875,
+    ql.Date(17, 9, 2003): 96.0875,
+}
 
-swaps = { (2,Years): 0.037125,
-          (3,Years): 0.0398,
-          (5,Years): 0.0443,
-          (10,Years): 0.05165,
-          (15,Years): 0.055175 }
+swaps = {
+    (2, ql.Years): 0.037125,
+    (3, ql.Years): 0.0398,
+    (5, ql.Years): 0.0443,
+    (10, ql.Years): 0.05165,
+    (15, ql.Years): 0.055175,
+}
 
 # convert them to Quote objects
-for n,unit in deposits.keys():
-    deposits[(n,unit)] = SimpleQuote(deposits[(n,unit)])
-for n,m in FRAs.keys():
-    FRAs[(n,m)] = SimpleQuote(FRAs[(n,m)])
+for n, unit in deposits.keys():
+    deposits[(n, unit)] = ql.SimpleQuote(deposits[(n, unit)])
+for n, m in FRAs.keys():
+    FRAs[(n, m)] = ql.SimpleQuote(FRAs[(n, m)])
 for d in futures.keys():
-    futures[d] = SimpleQuote(futures[d])
-for n,unit in swaps.keys():
-    swaps[(n,unit)] = SimpleQuote(swaps[(n,unit)])
+    futures[d] = ql.SimpleQuote(futures[d])
+for n, unit in swaps.keys():
+    swaps[(n, unit)] = ql.SimpleQuote(swaps[(n, unit)])
 
 # build rate helpers
 
-dayCounter = Actual360()
+dayCounter = ql.Actual360()
 settlementDays = 2
-depositHelpers = [ DepositRateHelper(QuoteHandle(deposits[(n,unit)]),
-                                     Period(n,unit), settlementDays,
-                                     calendar, ModifiedFollowing,
-                                     False, dayCounter)
-                   for n, unit in [(1,Weeks),(1,Months),(3,Months),
-                                   (6,Months),(9,Months),(1,Years)] ]
+depositHelpers = [
+    ql.DepositRateHelper(
+        ql.QuoteHandle(deposits[(n, unit)]),
+        ql.Period(n, unit),
+        settlementDays,
+        calendar,
+        ql.ModifiedFollowing,
+        False,
+        dayCounter,
+    )
+    for n, unit in [(1, ql.Weeks), (1, ql.Months), (3, ql.Months), (6, ql.Months), (9, ql.Months), (1, ql.Years)]
+]
 
-dayCounter = Actual360()
+dayCounter = ql.Actual360()
 settlementDays = 2
-fraHelpers = [ FraRateHelper(QuoteHandle(FRAs[(n,m)]),
-                             n, m, settlementDays,
-                             calendar, ModifiedFollowing,
-                             False, dayCounter)
-               for n, m in FRAs.keys() ]
+fraHelpers = [
+    ql.FraRateHelper(
+        ql.QuoteHandle(FRAs[(n, m)]), n, m, settlementDays, calendar, ql.ModifiedFollowing, False, dayCounter
+    )
+    for n, m in FRAs.keys()
+]
 
-dayCounter = Actual360()
+dayCounter = ql.Actual360()
 months = 3
-futuresHelpers = [ FuturesRateHelper(QuoteHandle(futures[d]),
-                                     d, months,
-                                     calendar, ModifiedFollowing,
-                                     True, dayCounter,
-                                     QuoteHandle(SimpleQuote(0.0)))
-                   for d in futures.keys() ]
+futuresHelpers = [
+    ql.FuturesRateHelper(
+        ql.QuoteHandle(futures[d]),
+        d,
+        months,
+        calendar,
+        ql.ModifiedFollowing,
+        True,
+        dayCounter,
+        ql.QuoteHandle(ql.SimpleQuote(0.0)),
+    )
+    for d in futures.keys()
+]
 
 settlementDays = 2
-fixedLegFrequency = Annual
-fixedLegTenor = Period(1,Years)
-fixedLegAdjustment = Unadjusted
-fixedLegDayCounter = Thirty360()
-floatingLegFrequency = Semiannual
-floatingLegTenor = Period(6,Months)
-floatingLegAdjustment = ModifiedFollowing
-swapHelpers = [ SwapRateHelper(QuoteHandle(swaps[(n,unit)]),
-                               Period(n,unit), calendar,
-                               fixedLegFrequency, fixedLegAdjustment,
-                               fixedLegDayCounter, Euribor6M())
-                for n, unit in swaps.keys() ]
+fixedLegFrequency = ql.Annual
+fixedLegTenor = ql.Period(1, ql.Years)
+fixedLegAdjustment = ql.Unadjusted
+fixedLegDayCounter = ql.Thirty360()
+floatingLegFrequency = ql.Semiannual
+floatingLegTenor = ql.Period(6, ql.Months)
+floatingLegAdjustment = ql.ModifiedFollowing
+swapHelpers = [
+    ql.SwapRateHelper(
+        ql.QuoteHandle(swaps[(n, unit)]),
+        ql.Period(n, unit),
+        calendar,
+        fixedLegFrequency,
+        fixedLegAdjustment,
+        fixedLegDayCounter,
+        ql.Euribor6M(),
+    )
+    for n, unit in swaps.keys()
+]
 
 # term structure handles
 
-discountTermStructure = RelinkableYieldTermStructureHandle()
-forecastTermStructure = RelinkableYieldTermStructureHandle()
+discountTermStructure = ql.RelinkableYieldTermStructureHandle()
+forecastTermStructure = ql.RelinkableYieldTermStructureHandle()
 
 # term-structure construction
 
 helpers = depositHelpers[:2] + futuresHelpers + swapHelpers[1:]
-depoFuturesSwapCurve = PiecewiseFlatForward(settlementDate, helpers,
-                                            Actual360())
+depoFuturesSwapCurve = ql.PiecewiseFlatForward(settlementDate, helpers, ql.Actual360())
 
 helpers = depositHelpers[:3] + fraHelpers + swapHelpers
-depoFraSwapCurve = PiecewiseFlatForward(settlementDate, helpers, Actual360())
+depoFraSwapCurve = ql.PiecewiseFlatForward(settlementDate, helpers, ql.Actual360())
 
 # swaps to be priced
 
-swapEngine = DiscountingSwapEngine(discountTermStructure)
+swapEngine = ql.DiscountingSwapEngine(discountTermStructure)
 
 nominal = 1000000
 length = 5
-maturity = calendar.advance(settlementDate,length,Years)
+maturity = calendar.advance(settlementDate, length, ql.Years)
 payFixed = True
 
-fixedLegFrequency = Annual
-fixedLegAdjustment = Unadjusted
-fixedLegDayCounter = Thirty360()
+fixedLegFrequency = ql.Annual
+fixedLegAdjustment = ql.Unadjusted
+fixedLegDayCounter = ql.Thirty360()
 fixedRate = 0.04
 
-floatingLegFrequency = Semiannual
+floatingLegFrequency = ql.Semiannual
 spread = 0.0
 fixingDays = 2
-index = Euribor6M(forecastTermStructure)
-floatingLegAdjustment = ModifiedFollowing
+index = ql.Euribor6M(forecastTermStructure)
+floatingLegAdjustment = ql.ModifiedFollowing
 floatingLegDayCounter = index.dayCounter()
 
-fixedSchedule = Schedule(settlementDate, maturity,
-                         fixedLegTenor, calendar,
-                         fixedLegAdjustment, fixedLegAdjustment,
-                         DateGeneration.Forward, False)
-floatingSchedule = Schedule(settlementDate, maturity,
-                            floatingLegTenor, calendar,
-                            floatingLegAdjustment, floatingLegAdjustment,
-                            DateGeneration.Forward, False)
+fixedSchedule = ql.Schedule(
+    settlementDate,
+    maturity,
+    fixedLegTenor,
+    calendar,
+    fixedLegAdjustment,
+    fixedLegAdjustment,
+    ql.DateGeneration.Forward,
+    False,
+)
+floatingSchedule = ql.Schedule(
+    settlementDate,
+    maturity,
+    floatingLegTenor,
+    calendar,
+    floatingLegAdjustment,
+    floatingLegAdjustment,
+    ql.DateGeneration.Forward,
+    False,
+)
 
-spot = VanillaSwap(VanillaSwap.Payer, nominal,
-                   fixedSchedule, fixedRate, fixedLegDayCounter,
-                   floatingSchedule, index, spread,
-                   floatingLegDayCounter)
+spot = ql.VanillaSwap(
+    ql.VanillaSwap.Payer,
+    nominal,
+    fixedSchedule,
+    fixedRate,
+    fixedLegDayCounter,
+    floatingSchedule,
+    index,
+    spread,
+    floatingLegDayCounter,
+)
 spot.setPricingEngine(swapEngine)
 
-forwardStart = calendar.advance(settlementDate,1,Years)
-forwardEnd = calendar.advance(forwardStart,length,Years)
-fixedSchedule = Schedule(forwardStart, forwardEnd,
-                         fixedLegTenor, calendar,
-                         fixedLegAdjustment, fixedLegAdjustment,
-                         DateGeneration.Forward, False)
-floatingSchedule = Schedule(forwardStart, forwardEnd,
-                            floatingLegTenor, calendar,
-                            floatingLegAdjustment, floatingLegAdjustment,
-                            DateGeneration.Forward, False)
+forwardStart = calendar.advance(settlementDate, 1, ql.Years)
+forwardEnd = calendar.advance(forwardStart, length, ql.Years)
+fixedSchedule = ql.Schedule(
+    forwardStart,
+    forwardEnd,
+    fixedLegTenor,
+    calendar,
+    fixedLegAdjustment,
+    fixedLegAdjustment,
+    ql.DateGeneration.Forward,
+    False,
+)
+floatingSchedule = ql.Schedule(
+    forwardStart,
+    forwardEnd,
+    floatingLegTenor,
+    calendar,
+    floatingLegAdjustment,
+    floatingLegAdjustment,
+    ql.DateGeneration.Forward,
+    False,
+)
 
-forward = VanillaSwap(VanillaSwap.Payer, nominal,
-                      fixedSchedule, fixedRate, fixedLegDayCounter,
-                      floatingSchedule, index, spread,
-                      floatingLegDayCounter)
+forward = ql.VanillaSwap(
+    ql.VanillaSwap.Payer,
+    nominal,
+    fixedSchedule,
+    fixedRate,
+    fixedLegDayCounter,
+    floatingSchedule,
+    index,
+    spread,
+    floatingLegDayCounter,
+)
 forward.setPricingEngine(swapEngine)
 
 # price on the bootstrapped curves
 
-def formatPrice(p,digits=2):
-    format = '%%.%df' % digits
+
+def formatPrice(p, digits=2):
+    format = "%%.%df" % digits
     return format % p
 
-def formatRate(r,digits=2):
-    format = '%%.%df %%%%' % digits
-    return format % (r*100)
 
-headers = ("term structure", "net present value",
-           "fair spread", "fair fixed rate" )
+def formatRate(r, digits=2):
+    format = "%%.%df %%%%" % digits
+    return format % (r * 100)
+
+
+headers = ("term structure", "net present value", "fair spread", "fair fixed rate")
 separator = " | "
 
-format = ''
+format = ""
 width = 0
 for h in headers[:-1]:
-    format += '%%%ds' % len(h)
+    format += "%%%ds" % len(h)
     format += separator
     width += len(h) + len(separator)
-format += '%%%ds' % len(headers[-1])
+format += "%%%ds" % len(headers[-1])
 width += len(headers[-1])
 
 rule = "-" * width
 dblrule = "=" * width
 tab = " " * 8
 
+
 def report(swap, name):
-    print(format % (name, formatPrice(swap.NPV(),2),
-                    formatRate(swap.fairSpread(),4),
-                    formatRate(swap.fairRate(),4)))
+    print(format % (name, formatPrice(swap.NPV(), 2), formatRate(swap.fairSpread(), 4), formatRate(swap.fairRate(), 4)))
+
 
 print(dblrule)
-print("5-year market swap-rate = %s" % formatRate(swaps[(5,Years)].value()))
+print("5-year market swap-rate = %s" % formatRate(swaps[(5, ql.Years)].value()))
 print(dblrule)
 
 # price on two different term structures
@@ -212,11 +275,11 @@ print(rule)
 
 discountTermStructure.linkTo(depoFuturesSwapCurve)
 forecastTermStructure.linkTo(depoFuturesSwapCurve)
-report(spot,'depo-fut-swap')
+report(spot, "depo-fut-swap")
 
 discountTermStructure.linkTo(depoFraSwapCurve)
 forecastTermStructure.linkTo(depoFraSwapCurve)
-report(spot,'depo-FRA-swap')
+report(spot, "depo-FRA-swap")
 
 print(rule)
 
@@ -227,18 +290,18 @@ print(rule)
 
 discountTermStructure.linkTo(depoFuturesSwapCurve)
 forecastTermStructure.linkTo(depoFuturesSwapCurve)
-report(forward,'depo-fut-swap')
+report(forward, "depo-fut-swap")
 
 discountTermStructure.linkTo(depoFraSwapCurve)
 forecastTermStructure.linkTo(depoFraSwapCurve)
-report(forward,'depo-FRA-swap')
+report(forward, "depo-FRA-swap")
 
 # modify the 5-years swap rate and reprice
 
-swaps[(5,Years)].setValue(0.046)
+swaps[(5, ql.Years)].setValue(0.046)
 
 print(dblrule)
-print("5-year market swap-rate = %s" % formatRate(swaps[(5,Years)].value()))
+print("5-year market swap-rate = %s" % formatRate(swaps[(5, ql.Years)].value()))
 print(dblrule)
 
 print(tab + "5-years swap paying %s" % formatRate(fixedRate))
@@ -247,11 +310,11 @@ print(rule)
 
 discountTermStructure.linkTo(depoFuturesSwapCurve)
 forecastTermStructure.linkTo(depoFuturesSwapCurve)
-report(spot,'depo-fut-swap')
+report(spot, "depo-fut-swap")
 
 discountTermStructure.linkTo(depoFraSwapCurve)
 forecastTermStructure.linkTo(depoFraSwapCurve)
-report(spot,'depo-FRA-swap')
+report(spot, "depo-FRA-swap")
 
 print(rule)
 
@@ -260,8 +323,8 @@ print(rule)
 
 discountTermStructure.linkTo(depoFuturesSwapCurve)
 forecastTermStructure.linkTo(depoFuturesSwapCurve)
-report(forward,'depo-fut-swap')
+report(forward, "depo-fut-swap")
 
 discountTermStructure.linkTo(depoFraSwapCurve)
 forecastTermStructure.linkTo(depoFraSwapCurve)
-report(forward,'depo-FRA-swap')
+report(forward, "depo-FRA-swap")

--- a/Python/examples/swing.py
+++ b/Python/examples/swing.py
@@ -13,31 +13,32 @@
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See the license for more details.
 
-from QuantLib import *
+import QuantLib as ql
 import math
 
-todaysDate = Date(30,September,2018)
-Settings.instance().evaluationDate = todaysDate
+todaysDate = ql.Date(30, ql.September, 2018)
+ql.Settings.instance().evaluationDate = todaysDate
 settlementDate = todaysDate
-riskFreeRate = FlatForward(settlementDate, 0.0, Actual365Fixed())
-dividendYield = FlatForward(settlementDate, 0.0, Actual365Fixed())
-underlying = SimpleQuote(30.0)
-volatility = BlackConstantVol(todaysDate, TARGET(), 0.20, Actual365Fixed())
+riskFreeRate = ql.FlatForward(settlementDate, 0.0, ql.Actual365Fixed())
+dividendYield = ql.FlatForward(settlementDate, 0.0, ql.Actual365Fixed())
+underlying = ql.SimpleQuote(30.0)
+volatility = ql.BlackConstantVol(todaysDate, ql.TARGET(), 0.20, ql.Actual365Fixed())
 
 
-exerciseDates = [ Date(1, January, 2019) + i
-                  for i in range(31) ]
+exerciseDates = [ql.Date(1, ql.January, 2019) + i for i in range(31)]
 
-swingOption = VanillaSwingOption(VanillaForwardPayoff(Option.Call, underlying.value()),
-                                 SwingExercise(exerciseDates), 0, len(exerciseDates))
+swingOption = ql.VanillaSwingOption(
+    ql.VanillaForwardPayoff(ql.Option.Call, underlying.value()), ql.SwingExercise(exerciseDates), 0, len(exerciseDates)
+)
 
-bsProcess = BlackScholesMertonProcess(
-    QuoteHandle(underlying),
-    YieldTermStructureHandle(dividendYield),
-    YieldTermStructureHandle(riskFreeRate),
-    BlackVolTermStructureHandle(volatility))
+bsProcess = ql.BlackScholesMertonProcess(
+    ql.QuoteHandle(underlying),
+    ql.YieldTermStructureHandle(dividendYield),
+    ql.YieldTermStructureHandle(riskFreeRate),
+    ql.BlackVolTermStructureHandle(volatility),
+)
 
-swingOption.setPricingEngine(FdSimpleBSSwingEngine(bsProcess))
+swingOption.setPricingEngine(ql.FdSimpleBSSwingEngine(bsProcess))
 
 print("Black Scholes Price: %f" % swingOption.NPV())
 
@@ -52,16 +53,17 @@ volatility = 0.1
 
 curveShape = []
 for d in exerciseDates:
-    t = Actual365Fixed().yearFraction(todaysDate, d)
-    gs = math.log(underlying.value())                                   \
-        - volatility*volatility/(4*speed)*(1-math.exp(-2*speed*t))      \
-        - jumpIntensity/beta*math.log((eta-math.exp(-beta*t))/(eta-1.0))
+    t = ql.Actual365Fixed().yearFraction(todaysDate, d)
+    gs = (
+        math.log(underlying.value())
+        - volatility * volatility / (4 * speed) * (1 - math.exp(-2 * speed * t))
+        - jumpIntensity / beta * math.log((eta - math.exp(-beta * t)) / (eta - 1.0))
+    )
     curveShape.append((t, gs))
 
-ouProcess = ExtendedOrnsteinUhlenbeckProcess(speed, volatility, x0, lambda x: x0)
-jProcess = ExtOUWithJumpsProcess(ouProcess, x1, beta, jumpIntensity, eta)
+ouProcess = ql.ExtendedOrnsteinUhlenbeckProcess(speed, volatility, x0, lambda x: x0)
+jProcess = ql.ExtOUWithJumpsProcess(ouProcess, x1, beta, jumpIntensity, eta)
 
-swingOption.setPricingEngine(FdSimpleExtOUJumpSwingEngine(
-    jProcess, riskFreeRate, 25, 25, 200, curveShape))
+swingOption.setPricingEngine(ql.FdSimpleExtOUJumpSwingEngine(jProcess, riskFreeRate, 25, 25, 200, curveShape))
 
 print("Kluge Model Price  : %f" % swingOption.NPV())

--- a/Python/examples/visualization/basketoption.py
+++ b/Python/examples/visualization/basketoption.py
@@ -1,73 +1,69 @@
 # Example of option baskets
 # Distributed under BSD License
 
-from QuantLib import *
+import QuantLib as ql
+
+
 class BasketOptionClass:
     def __init__(self, btype):
         # global data
-        self.todaysDate = Date(15,May,1998)
-        Settings.instance().evaluationDate = self.todaysDate
-        self.settlementDate = Date(17,May,1998)
-        self.riskFreeQuote = SimpleQuote(0.05)
-        self.riskFreeRate = FlatForward(self.settlementDate,
-                                        QuoteHandle(self.riskFreeQuote),
-                                        Actual365Fixed())
+        self.todaysDate = ql.Date(15, ql.May, 1998)
+        ql.Settings.instance().evaluationDate = self.todaysDate
+        self.settlementDate = ql.Date(17, ql.May, 1998)
+        self.riskFreeQuote = ql.SimpleQuote(0.05)
+        self.riskFreeRate = ql.FlatForward(self.settlementDate, ql.QuoteHandle(self.riskFreeQuote), ql.Actual365Fixed())
 
         # option parameters
-        self.exercise = EuropeanExercise(Date(17,May,1999))
-        self.payoff = PlainVanillaPayoff(Option.Call, 8.0)
+        self.exercise = ql.EuropeanExercise(ql.Date(17, ql.May, 1999))
+        self.payoff = ql.PlainVanillaPayoff(ql.Option.Call, 8.0)
 
         # market data
-        self.underlying1 = SimpleQuote(10.0)
-        self.volatility1 = BlackConstantVol(self.todaysDate, 0.20,
-                                            Actual365Fixed())
-        self.dividendYield1 = FlatForward(self.settlementDate,
-                                          0.05, Actual365Fixed())
-        self.underlying2 = SimpleQuote(7.0)
-        self.volatility2 = BlackConstantVol(self.todaysDate,
-                                            0.10, Actual365Fixed())
-        self.dividendYield2 = FlatForward(self.settlementDate,
-                                          0.05, Actual365Fixed())
+        self.underlying1 = ql.SimpleQuote(10.0)
+        self.volatility1 = ql.BlackConstantVol(self.todaysDate, 0.20, ql.Actual365Fixed())
+        self.dividendYield1 = ql.FlatForward(self.settlementDate, 0.05, ql.Actual365Fixed())
+        self.underlying2 = ql.SimpleQuote(7.0)
+        self.volatility2 = ql.BlackConstantVol(self.todaysDate, 0.10, ql.Actual365Fixed())
+        self.dividendYield2 = ql.FlatForward(self.settlementDate, 0.05, ql.Actual365Fixed())
 
-        self.process1 = BlackScholesMertonProcess(QuoteHandle(self.underlying1),
-                                                  YieldTermStructureHandle(self.dividendYield1),
-                                                  YieldTermStructureHandle(self.riskFreeRate),
-                                                  BlackVolTermStructureHandle(self.volatility1))
+        self.process1 = ql.BlackScholesMertonProcess(
+            ql.QuoteHandle(self.underlying1),
+            ql.YieldTermStructureHandle(self.dividendYield1),
+            ql.YieldTermStructureHandle(self.riskFreeRate),
+            ql.BlackVolTermStructureHandle(self.volatility1),
+        )
 
-        self.process2 = BlackScholesMertonProcess(QuoteHandle(self.underlying2),
-                                                  YieldTermStructureHandle(self.dividendYield2),
-                                                  YieldTermStructureHandle(self.riskFreeRate),
-                                                  BlackVolTermStructureHandle(self.volatility2))
+        self.process2 = ql.BlackScholesMertonProcess(
+            ql.QuoteHandle(self.underlying2),
+            ql.YieldTermStructureHandle(self.dividendYield2),
+            ql.YieldTermStructureHandle(self.riskFreeRate),
+            ql.BlackVolTermStructureHandle(self.volatility2),
+        )
 
-        self.procs = StochasticProcessVector();
+        self.procs = ql.StochasticProcessVector()
         self.procs.push_back(self.process1)
         self.procs.push_back(self.process2)
 
-        self.matrix = Matrix(2,2)
+        self.matrix = ql.Matrix(2, 2)
         self.matrix[0][0] = 1.0
         self.matrix[1][1] = 1.0
         self.matrix[0][1] = 0.25
         self.matrix[1][0] = 0.25
 
-        self.process = StochasticProcessArray(self.procs, self.matrix)
-        self.engine = MCBasketEngine('lowdiscrepancy',
-                                     timeStepsPerYear = 1,
-                                     requiredTolerance = 0.02,
-                                     seed = 42)
-        if (btype == 'min'):
-            bpayoff = MinBasketPayoff(self.payoff)
-        elif (btype == 'max'):
-            bpayoff = MaxBasketPayoff(self.payoff)
+        self.process = ql.StochasticProcessArray(self.procs, self.matrix)
+        self.engine = ql.MCBasketEngine("lowdiscrepancy", timeStepsPerYear=1, requiredTolerance=0.02, seed=42)
+        if btype == "min":
+            bpayoff = ql.MinBasketPayoff(self.payoff)
+        elif btype == "max":
+            bpayoff = ql.MaxBasketPayoff(self.payoff)
         else:
-            bpayoff = AverageBasketPayoff(self.payoff, 2)
-        
-        self.option = BasketOption(self.process,
-                                   bpayoff,
-                                   self.exercise,
-                                   self.engine)
-    def npv(self, x,y):
+            bpayoff = ql.AverageBasketPayoff(self.payoff, 2)
+
+        self.option = ql.BasketOption(self.process, bpayoff, self.exercise, self.engine)
+
+    def npv(self, x, y):
         self.underlying1.setValue(x)
         self.underlying2.setValue(y)
         return self.option.NPV()
-    def setQuote(r):
+
+    def setQuote(self, r):
         self.riskFreeQuote.setValue(r)

--- a/Python/examples/visualization/eurooption.py
+++ b/Python/examples/visualization/eurooption.py
@@ -1,40 +1,41 @@
 # Example of option baskets
 # Distributed under BSD license
 
-from QuantLib import *
-todaysDate = Date(15, May, 1998)
-Settings.instance().evaluationDate = todaysDate
-settlementDate = Date(17, May, 1998)
-riskFreeQuote = SimpleQuote(0.05)
-riskFreeRate = FlatForward(settlementDate,
-                           QuoteHandle(riskFreeQuote), Actual365Fixed())
+import QuantLib as ql
+
+todaysDate = ql.Date(15, ql.May, 1998)
+ql.Settings.instance().evaluationDate = todaysDate
+settlementDate = ql.Date(17, ql.May, 1998)
+riskFreeQuote = ql.SimpleQuote(0.05)
+riskFreeRate = ql.FlatForward(settlementDate, ql.QuoteHandle(riskFreeQuote), ql.Actual365Fixed())
 
 # option parameters
-exercise1 = AmericanExercise(settlementDate, Date(17,May,1999))
-exercise2 = EuropeanExercise(settlementDate)
-payoff = PlainVanillaPayoff(Option.Call, 40.0)
+exercise1 = ql.AmericanExercise(settlementDate, ql.Date(17, ql.May, 1999))
+exercise2 = ql.EuropeanExercise(settlementDate)
+payoff = ql.PlainVanillaPayoff(ql.Option.Call, 40.0)
 
 # market data
-underlying = SimpleQuote(36.0)
-volatilityQuote = SimpleQuote(0.05)
-volatility = BlackConstantVol(todaysDate,
-                              QuoteHandle(volatilityQuote),
-                              Actual365Fixed())
-dividendYield = FlatForward(settlementDate, 0.00, Actual365Fixed())
+underlying = ql.SimpleQuote(36.0)
+volatilityQuote = ql.SimpleQuote(0.05)
+volatility = ql.BlackConstantVol(todaysDate, ql.QuoteHandle(volatilityQuote), ql.Actual365Fixed())
+dividendYield = ql.FlatForward(settlementDate, 0.00, ql.Actual365Fixed())
 
 # good to go
-process = BlackScholesMertonProcess(QuoteHandle(underlying),
-                                    YieldTermStructureHandle(dividendYield),
-                                    YieldTermStructureHandle(riskFreeRate),
-                                    BlackVolTermStructureHandle(volatility))
-option1 = VanillaOption(process, payoff, exercise1)
-option1.setPricingEngine(BaroneAdesiWhaleyEngine())
+process = ql.BlackScholesMertonProcess(
+    ql.QuoteHandle(underlying),
+    ql.YieldTermStructureHandle(dividendYield),
+    ql.YieldTermStructureHandle(riskFreeRate),
+    ql.BlackVolTermStructureHandle(volatility),
+)
+option1 = ql.VanillaOption(process, payoff, exercise1)
+option1.setPricingEngine(ql.BaroneAdesiWhaleyEngine())
 
 
-def f(x,y):
+def f(x, y):
     underlying.setValue(x)
     volatilityQuote.setValue(y)
     return option1.NPV()
+
 
 def setQuote(r):
     riskFreeQuote.setValue(r)

--- a/Python/examples/visualization/option.basket.py
+++ b/Python/examples/visualization/option.basket.py
@@ -1,17 +1,14 @@
 # Example of option baskets
-# 
+#
 # Distributed under BSD License
 
 from enthought.mayavi.scripts import mayavi2
-from enthought.tvtk.tools import mlab
 from plotspace import PlotSpace
+
 mayavi2.standalone(globals())
-import eurooption
 import basketoption
 
 import scipy
-import numpy
-import threading
 
 spot = scipy.arange(10.0, 100.0, 5.0)
 vol = scipy.arange(0.1, 1.0, 0.1)
@@ -20,16 +17,13 @@ riskfree = scipy.arange(0.0, 5.0, 1.0)
 u1 = scipy.arange(0.5, 15.0, 0.5)
 u2 = scipy.arange(0.5, 15.0, 0.5)
 
-if __name__ == '__main__':
-    bmin = basketoption.BasketOptionClass('min')
-    bmax = basketoption.BasketOptionClass('max')
-    bavg = basketoption.BasketOptionClass('avg')
+if __name__ == "__main__":
+    bmin = basketoption.BasketOptionClass("min")
+    bmax = basketoption.BasketOptionClass("max")
+    bavg = basketoption.BasketOptionClass("avg")
     mayavi.new_scene()
-    p = PlotSpace(mayavi.engine.current_scene, [1,1,1])
+    p = PlotSpace(mayavi.engine.current_scene, [1, 1, 1])
 
     p.add_surface_data(u1, u2, bmin.npv)
     p.add_surface_data(u1, u2, bmax.npv)
     p.add_surface_data(u1, u2, bavg.npv)
-
-
-    

--- a/Python/examples/visualization/option.mayavi.py
+++ b/Python/examples/visualization/option.mayavi.py
@@ -2,16 +2,15 @@
 # Distributed under BSD License
 
 from enthought.mayavi.scripts import mayavi2
+
 mayavi2.standalone(globals())
 
 
 import scipy
-import numpy
-from QuantLib import *
+import QuantLib as ql
 from enthought.tvtk.tools import mlab
 from enthought.mayavi.sources.vtk_data_source import VTKDataSource
 from enthought.mayavi.filters.warp_scalar import WarpScalar
-from enthought.mayavi.modules.outline import Outline
 from enthought.mayavi.modules.surface import Surface
 
 
@@ -19,41 +18,40 @@ spot = scipy.arange(10.0, 100.0, 5.0)
 vol = scipy.arange(0.1, 1.0, 0.1)
 riskfree = scipy.arange(0.0, 5.0, 1.0)
 
-todaysDate = Date(15, May, 1998)
-Settings.instance().evaluationDate = todaysDate
-settlementDate = Date(17, May, 1998)
-riskFreeQuote = SimpleQuote(0.05)
-riskFreeRate = FlatForward(settlementDate,
-                           QuoteHandle(riskFreeQuote), Actual365Fixed())
+todaysDate = ql.Date(15, ql.May, 1998)
+ql.Settings.instance().evaluationDate = todaysDate
+settlementDate = ql.Date(17, ql.May, 1998)
+riskFreeQuote = ql.SimpleQuote(0.05)
+riskFreeRate = ql.FlatForward(settlementDate, ql.QuoteHandle(riskFreeQuote), ql.Actual365Fixed())
 
 # option parameters
-exercise1 = AmericanExercise(settlementDate, Date(17,May,1999))
-exercise2 = EuropeanExercise(settlementDate)
-payoff = PlainVanillaPayoff(Option.Call, 40.0)
+exercise1 = ql.AmericanExercise(settlementDate, ql.Date(17, ql.May, 1999))
+exercise2 = ql.EuropeanExercise(settlementDate)
+payoff = ql.PlainVanillaPayoff(ql.Option.Call, 40.0)
 
 # market data
-underlying = SimpleQuote(36.0)
-volatilityQuote = SimpleQuote(0.05)
-volatility = BlackConstantVol(todaysDate,
-                              QuoteHandle(volatilityQuote),
-                              Actual365Fixed())
-dividendYield = FlatForward(settlementDate, 0.00, Actual365Fixed())
+underlying = ql.SimpleQuote(36.0)
+volatilityQuote = ql.SimpleQuote(0.05)
+volatility = ql.BlackConstantVol(todaysDate, ql.QuoteHandle(volatilityQuote), ql.Actual365Fixed())
+dividendYield = ql.FlatForward(settlementDate, 0.00, ql.Actual365Fixed())
 
 # good to go
-process = BlackScholesMertonProcess(QuoteHandle(underlying),
-                                    YieldTermStructureHandle(dividendYield),
-                                    YieldTermStructureHandle(riskFreeRate),
-                                    BlackVolTermStructureHandle(volatility))
-option1 = VanillaOption(process, payoff, exercise1)
-option1.setPricingEngine(BaroneAdesiWhaleyEngine())
+process = ql.BlackScholesMertonProcess(
+    ql.QuoteHandle(underlying),
+    ql.YieldTermStructureHandle(dividendYield),
+    ql.YieldTermStructureHandle(riskFreeRate),
+    ql.BlackVolTermStructureHandle(volatility),
+)
+option1 = ql.VanillaOption(process, payoff, exercise1)
+option1.setPricingEngine(ql.BaroneAdesiWhaleyEngine())
 
 
-def f(x,y):
+def f(x, y):
     underlying.setValue(x)
     volatilityQuote.setValue(y)
     return option1.NPV()
 
-    
+
 def add_data(tvtk_data):
     """Add a TVTK data object `tvtk_data` to the mayavi pipleine.
     """
@@ -61,6 +59,7 @@ def add_data(tvtk_data):
     d.data = tvtk_data
     mayavi.add_source(d)
     return d
+
 
 def surf_regular(source):
     """Now visualize the data as done in mlab.
@@ -72,14 +71,12 @@ def surf_regular(source):
 
 
 # 3D visualization of f:
-from enthought.tvtk.tools import mlab
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     mayavi.new_scene()
     for r in riskfree:
         riskFreeQuote.setValue(r)
-        s1 = mlab.SurfRegular(spot, vol, scipy.vectorize(f), scale=[1,100, 1])
-        s1.lut.alpha_range=(0.2,0.2)
+        s1 = mlab.SurfRegular(spot, vol, scipy.vectorize(f), scale=[1, 100, 1])
+        s1.lut.alpha_range = (0.2, 0.2)
         d = add_data(s1.data)
         surf_regular(d)
-

--- a/Python/examples/visualization/option.plotspace.py
+++ b/Python/examples/visualization/option.plotspace.py
@@ -2,15 +2,12 @@
 # Distributed under BSD License
 
 from enthought.mayavi.scripts import mayavi2
-from enthought.tvtk.tools import mlab
 from plotspace import PlotSpace
+
 mayavi2.standalone(globals())
 import eurooption
-import basketoption
 
 import scipy
-import numpy
-import threading
 
 spot = scipy.arange(10.0, 100.0, 5.0)
 vol = scipy.arange(0.1, 1.0, 0.1)
@@ -19,27 +16,15 @@ riskfree = scipy.arange(0.0, 5.0, 1.0)
 u1 = scipy.arange(0.5, 15.0, 0.5)
 u2 = scipy.arange(0.5, 15.0, 0.5)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     mayavi.new_scene()
-    p = PlotSpace(mayavi.engine.current_scene,
-                  [1,100,1])
+    p = PlotSpace(mayavi.engine.current_scene, [1, 100, 1])
 
-    p.add_points([[1,2,1],
-                  [1,3,1],
-                  [2,4,2]])
-    p.add_lines([[2,2,1],
-                 [3,3,1],
-                 [3,3,1],
-                 [3,4,1],                 
-                 [4,4,2]])
+    p.add_points([[1, 2, 1], [1, 3, 1], [2, 4, 2]])
+    p.add_lines([[2, 2, 1], [3, 3, 1], [3, 3, 1], [3, 4, 1], [4, 4, 2]])
     mayavi.new_scene()
-    p = PlotSpace(mayavi.engine.current_scene,
-                  [1,100,1])
+    p = PlotSpace(mayavi.engine.current_scene, [1, 100, 1])
 
     for r in riskfree:
         eurooption.setQuote(r)
         p.add_surface_data_immediate(spot, vol, eurooption.f)
-    
-
-
-    

--- a/Python/examples/visualization/plotspace.py
+++ b/Python/examples/visualization/plotspace.py
@@ -1,24 +1,20 @@
-from enthought.mayavi.scripts import mayavi2
 from enthought.tvtk.tools import mlab
 from enthought.tvtk.api import tvtk
 import scipy
-import numpy
-import thread
 from enthought.mayavi.sources.vtk_data_source import VTKDataSource
 from enthought.mayavi.filters.warp_scalar import WarpScalar
 from enthought.mayavi.filters.filter_base import FilterBase
-from enthought.mayavi.modules.outline import Outline
 from enthought.mayavi.modules.surface import Surface
 from enthought.mayavi.modules.vectors import Vectors
 from enthought.pyface.gui import GUI
 from threading import Thread
 
 
-
 class PlotSpace:
     def __init__(self, scene, scale):
         self.scale = scale
         self.scene = scene
+
     class CalcThread(Thread):
         def __init__(self, p, xrange, yrange, f):
             self.p = p
@@ -26,26 +22,26 @@ class PlotSpace:
             self.yrange = yrange
             self.f = f
             Thread.__init__(self)
+
         def run(self):
-            s1 = mlab.SurfRegular(self.xrange, self.yrange,
-                                  scipy.vectorize(self.f),
-                                  scale=self.p.scale)
+            s1 = mlab.SurfRegular(self.xrange, self.yrange, scipy.vectorize(self.f), scale=self.p.scale)
             GUI.invoke_later(self.p.add_source_data, s1.data)
 
     def add_surface_data(self, xrange, yrange, f):
         print("Start!!!")
         calc_thread = self.CalcThread(self, xrange, yrange, f)
         calc_thread.start()
+
     def add_surface_data_immediate(self, xrange, yrange, f):
-        s1 = mlab.SurfRegular(xrange, yrange,
-                                  scipy.vectorize(f),
-                                  scale=self.scale)
+        s1 = mlab.SurfRegular(xrange, yrange, scipy.vectorize(f), scale=self.scale)
         self.add_source_data(s1.data)
+
     def add_source_data(self, data):
         from enthought.mayavi.filters.poly_data_normals import PolyDataNormals
+
         d = VTKDataSource()
         d.data = data
-        obj = self.scene.add_child(d)
+        self.scene.add_child(d)
         w = WarpScalar()
         d.add_child(w)
         n = PolyDataNormals()
@@ -53,32 +49,30 @@ class PlotSpace:
         w.add_child(n)
         s = Surface()
         n.add_child(s)
-        
+
     def add_points(self, points):
         g = mlab.Glyphs(points, None, None)
         d = VTKDataSource()
         d.data = g.poly_data
         self.scene.add_child(d)
         v = Vectors()
-        v.glyph.color_mode = 'no_coloring'
-        v.glyph.glyph_source = tvtk.PointSource(radius=0,
-                                                number_of_points=1)
+        v.glyph.color_mode = "no_coloring"
+        v.glyph.glyph_source = tvtk.PointSource(radius=0, number_of_points=1)
         d.add_child(v)
+
     def add_lines(self, points):
         np = len(points) - 1
-        lines = scipy.zeros((np, 2), 'l')
-        lines[:,0] = scipy.arange(0, np-0.5, 1, 'l')
-        lines[:,1] = scipy.arange(1, np+0.5, 1, 'l')
+        lines = scipy.zeros((np, 2), "l")
+        lines[:, 0] = scipy.arange(0, np - 0.5, 1, "l")
+        lines[:, 1] = scipy.arange(1, np + 0.5, 1, "l")
         pd = tvtk.PolyData(points=points, lines=lines)
         d = VTKDataSource()
         d.data = pd
         self.scene.add_child(d)
         filter = tvtk.TubeFilter(number_of_sides=6)
         filter.radius = 0.01
-        f = FilterBase(filter=filter, name='TubeFilter')
+        f = FilterBase(filter=filter, name="TubeFilter")
         d.add_child(f)
         s = Surface()
         s.actor.mapper.scalar_visibility = False
         d.add_child(s)
-
-    

--- a/Python/examples/visualization/slv.py
+++ b/Python/examples/visualization/slv.py
@@ -15,77 +15,90 @@
 
 import math
 
-from QuantLib import *
+import QuantLib as ql
 
-from mpl_toolkits import mplot3d
-from matplotlib import cm
 import matplotlib.pyplot as plt
 import numpy as np
 
-todaysDate = Date(15,May,2019)
-exerciseDate = todaysDate + Period(4, Years)
-Settings.instance().evaluationDate = todaysDate
-settlementDate = todaysDate + Period(2, Days)
-dc = Actual365Fixed()
-riskFreeRate = YieldTermStructureHandle(FlatForward(settlementDate, 0.05, dc))
-dividendYield = YieldTermStructureHandle(FlatForward(settlementDate, 0.025, dc))
+todaysDate = ql.Date(15, ql.May, 2019)
+exerciseDate = todaysDate + ql.Period(4, ql.Years)
+ql.Settings.instance().evaluationDate = todaysDate
+settlementDate = todaysDate + ql.Period(2, ql.Days)
+dc = ql.Actual365Fixed()
+riskFreeRate = ql.YieldTermStructureHandle(ql.FlatForward(settlementDate, 0.05, dc))
+dividendYield = ql.YieldTermStructureHandle(ql.FlatForward(settlementDate, 0.025, dc))
 
 spot = 100
-underlying = QuoteHandle(SimpleQuote(spot))
+underlying = ql.QuoteHandle(ql.SimpleQuote(spot))
 
 vol = 0.30
 
-localVol = LocalVolSurface(
-    BlackVolTermStructureHandle(
-        BlackConstantVol(settlementDate, TARGET(), vol, dc)), 
-    riskFreeRate, dividendYield, underlying)
+localVol = ql.LocalVolSurface(
+    ql.BlackVolTermStructureHandle(ql.BlackConstantVol(settlementDate, ql.TARGET(), vol, dc)),
+    riskFreeRate,
+    dividendYield,
+    underlying,
+)
 
-hestonProcess = HestonProcess(riskFreeRate, dividendYield, underlying, 
-                              0.09, 1.0, 0.06, 0.4, -0.75)
+hestonProcess = ql.HestonProcess(riskFreeRate, dividendYield, underlying, 0.09, 1.0, 0.06, 0.4, -0.75)
 
-hestonModel = HestonModel(hestonProcess)
+hestonModel = ql.HestonModel(hestonProcess)
 
-leverageFct = HestonSLVMCModel(
-    localVol, hestonModel, MTBrownianGeneratorFactory(1234),
-    exerciseDate, 91).leverageFunction()
+leverageFct = ql.HestonSLVMCModel(
+    localVol, hestonModel, ql.MTBrownianGeneratorFactory(1234), exerciseDate, 91
+).leverageFunction()
 
 
-#uncomment this if you want to use PDE calibration instead of Monte-Carlo
-#
-#fdmParams = HestonSLVFokkerPlanckFdmParams(
-#    201, 101, 200, 30, 2.0, 0, 2, 0.01, 1e-4, 10000,
-#    1e-5, 1e-5, 0.0000025, 1.0, 0.1, 0.9, 1e-4,
-#    FdmHestonGreensFct.Gaussian, FdmSquareRootFwdOp.Log,
-#    FdmSchemeDesc.Hundsdorfer()
-#)
-#leverageFct = HestonSLVFDMModel(
-#    localVol, hestonModel, exerciseDate, fdmParams).leverageFunction()
+# uncomment this if you want to use PDE calibration instead of Monte-Carlo
+
+# fdmParams = ql.HestonSLVFokkerPlanckFdmParams(
+#     201,
+#     101,
+#     200,
+#     30,
+#     2.0,
+#     0,
+#     2,
+#     0.01,
+#     1e-4,
+#     10000,
+#     1e-5,
+#     1e-5,
+#     0.0000025,
+#     1.0,
+#     0.1,
+#     0.9,
+#     1e-4,
+#     ql.FdmHestonGreensFct.Gaussian,
+#     ql.FdmSquareRootFwdOp.Log,
+#     ql.FdmSchemeDesc.Hundsdorfer(),
+# )
+# leverageFct = ql.HestonSLVFDMModel(localVol, hestonModel, exerciseDate, fdmParams).leverageFunction()
 
 tSteps = 40
 uSteps = 30
 
 tv = np.linspace(0.1, dc.yearFraction(settlementDate, exerciseDate), tSteps)
 
-t = np.empty(tSteps*uSteps)
-s = np.empty(tSteps*uSteps)
-z = np.empty(tSteps*uSteps)
+t = np.empty(tSteps * uSteps)
+s = np.empty(tSteps * uSteps)
+z = np.empty(tSteps * uSteps)
 
-for i in range(0, tSteps): 
-    scale = min(4, math.exp(3*math.sqrt(tv[i])*vol))
-    sv = np.linspace(spot/scale, spot*scale, uSteps)    
-    
+for i in range(0, tSteps):
+    scale = min(4, math.exp(3 * math.sqrt(tv[i]) * vol))
+    sv = np.linspace(spot / scale, spot * scale, uSteps)
+
     for j in range(0, uSteps):
-        idx = i*uSteps + j
+        idx = i * uSteps + j
         t[idx] = tv[i]
         s[idx] = math.log(sv[j])
         z[idx] = leverageFct.localVol(t[idx], sv[j])
 
 
 fig = plt.figure()
-ax = plt.axes(projection='3d')
+ax = plt.axes(projection="3d")
 
-surf = ax.plot_trisurf(s, t, z, cmap=plt.cm.viridis, 
-                       linewidth=0, antialiased=False, edgecolor='none')
+surf = ax.plot_trisurf(s, t, z, cmap=plt.cm.viridis, linewidth=0, antialiased=False, edgecolor="none")
 ax.view_init(30, -120)
 
 ax.set_xlabel("ln(S)")

--- a/Python/test/assetswap.py
+++ b/Python/test/assetswap.py
@@ -15,383 +15,563 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
-from QuantLib import *
+import QuantLib as ql
 import unittest
+
 
 class AssetSwapTest(unittest.TestCase):
     def setUp(self):
         # initial setup
-        self.termStructure = RelinkableYieldTermStructureHandle()
+        self.termStructure = ql.RelinkableYieldTermStructureHandle()
         self.swapSettlementDays = 2
         self.faceAmount = 100.0
-        self.fixedConvention = Unadjusted
-        self.compounding = Continuous
-        self.fixedFrequency = Annual
-        self.floatingFrequency = Semiannual
-        self.iborIndex = Euribor(Period(self.floatingFrequency), self.termStructure)
+        self.fixedConvention = ql.Unadjusted
+        self.compounding = ql.Continuous
+        self.fixedFrequency = ql.Annual
+        self.floatingFrequency = ql.Semiannual
+        self.iborIndex = ql.Euribor(ql.Period(self.floatingFrequency), self.termStructure)
         self.calendar = self.iborIndex.fixingCalendar()
-        self.swapIndex=  SwapIndex("EuriborSwapIsdaFixA", Period(10,Years), self.swapSettlementDays,
-                          self.iborIndex.currency(), self.calendar,
-                          Period(self.fixedFrequency), self.fixedConvention,
-                          self.iborIndex.dayCounter(), self.iborIndex)
+        self.swapIndex = ql.SwapIndex(
+            "EuriborSwapIsdaFixA",
+            ql.Period(10, ql.Years),
+            self.swapSettlementDays,
+            self.iborIndex.currency(),
+            self.calendar,
+            ql.Period(self.fixedFrequency),
+            self.fixedConvention,
+            self.iborIndex.dayCounter(),
+            self.iborIndex,
+        )
         self.spread = 0.0
         self.nonnullspread = 0.003
-        self.today = Date(24,April,2007)
-        Settings.instance().evaluationDate = self.today
-        self.termStructure.linkTo(FlatForward(self.today, 0.05, Actual365Fixed()))
-        self.yieldCurve = FlatForward(self.today, 0.05, Actual365Fixed())
-        self.pricer = BlackIborCouponPricer()
-        self.swaptionVolatilityStructure = SwaptionVolatilityStructureHandle(ConstantSwaptionVolatility(self.today, NullCalendar(),Following,
-                                           0.2, Actual365Fixed()))
-        self.meanReversionQuote = QuoteHandle(SimpleQuote(0.01))
-        self.cmspricer = AnalyticHaganPricer(self.swaptionVolatilityStructure,
-                                GFunctionFactory.Standard,
-                                self.meanReversionQuote)
-        
-    def testConsistency(self) :
+        self.today = ql.Date(24, ql.April, 2007)
+        ql.Settings.instance().evaluationDate = self.today
+        self.termStructure.linkTo(ql.FlatForward(self.today, 0.05, ql.Actual365Fixed()))
+        self.yieldCurve = ql.FlatForward(self.today, 0.05, ql.Actual365Fixed())
+        self.pricer = ql.BlackIborCouponPricer()
+        self.swaptionVolatilityStructure = ql.SwaptionVolatilityStructureHandle(
+            ql.ConstantSwaptionVolatility(self.today, ql.NullCalendar(), ql.Following, 0.2, ql.Actual365Fixed())
+        )
+        self.meanReversionQuote = ql.QuoteHandle(ql.SimpleQuote(0.01))
+        self.cmspricer = ql.AnalyticHaganPricer(
+            self.swaptionVolatilityStructure, ql.GFunctionFactory.Standard, self.meanReversionQuote
+        )
+
+    def testConsistency(self):
         """Testing consistency between fair price and fair spread..."""
-        bondCalendar = TARGET()
+        bondCalendar = ql.TARGET()
         settlementDays = 3
 
-    ## Fixed Underlying bond (Isin: DE0001135275 DBR 4 01/04/37)
-    ## maturity doesn't occur on a business day
+        ## Fixed Underlying bond (Isin: DE0001135275 DBR 4 01/04/37)
+        ## maturity doesn't occur on a business day
 
-        bondSchedule = Schedule(Date(4,January,2005),
-                          Date(4,January,2037),
-                          Period(Annual), bondCalendar,
-                          Unadjusted, Unadjusted,
-                          DateGeneration.Backward, False)
-        bond = FixedRateBond(settlementDays, self.faceAmount,
-                      bondSchedule,[0.04],
-                      ActualActual(ActualActual.ISDA),
-                      Following,
-                      100.0, Date(4,January,2005))
+        bondSchedule = ql.Schedule(
+            ql.Date(4, ql.January, 2005),
+            ql.Date(4, ql.January, 2037),
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        bond = ql.FixedRateBond(
+            settlementDays,
+            self.faceAmount,
+            bondSchedule,
+            [0.04],
+            ql.ActualActual(ql.ActualActual.ISDA),
+            ql.Following,
+            100.0,
+            ql.Date(4, ql.January, 2005),
+        )
 
         payFixedRate = True
         bondPrice = 95.0
         isPar = True
-        parAssetSwap = AssetSwap(payFixedRate,
-                             bond, bondPrice,
-                             self.iborIndex, self.spread,
-                             Schedule(),
-                             self.iborIndex.dayCounter(),
-                             isPar)
+        parAssetSwap = ql.AssetSwap(
+            payFixedRate,
+            bond,
+            bondPrice,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            isPar,
+        )
 
-        swapEngine =  DiscountingSwapEngine(self.termStructure,
-                                  True,
-                                  bond.settlementDate(),
-                                  Settings.instance().evaluationDate)
+        swapEngine = ql.DiscountingSwapEngine(
+            self.termStructure, True, bond.settlementDate(), ql.Settings.instance().evaluationDate
+        )
 
         parAssetSwap.setPricingEngine(swapEngine)
         fairCleanPrice = parAssetSwap.fairCleanPrice()
         fairSpread = parAssetSwap.fairSpread()
 
         tolerance = 1.0e-13
-   
-        assetSwap2 = AssetSwap(payFixedRate, bond, fairCleanPrice,
-                             self.iborIndex, self.spread,
-                             Schedule(),
-                             self.iborIndex.dayCounter(),
-                             isPar)
-        
-        assetSwap2.setPricingEngine(swapEngine)
-        self.assertFalse(abs(assetSwap2.NPV())>tolerance,
-        "\npar asset swap fair clean price doesn't zero the NPV: "
-        + "\n  clean price:      " + str(bondPrice)
-        + "\n  fair clean price: " + str(fairCleanPrice)
-        + "\n  NPV:              " + str(assetSwap2.NPV())
-        + "\n  tolerance:        " + str(tolerance))
-    
-        self.assertFalse(abs(assetSwap2.fairCleanPrice() - fairCleanPrice)>tolerance,
-        "\npar asset swap fair clean price doesn't equal input "
-        + "clean price at zero NPV: "
-        + "\n  input clean price: " + str(fairCleanPrice)
-        + "\n  fair clean price:  " + str(assetSwap2.fairCleanPrice())
-        + "\n  NPV:               " + str(assetSwap2.NPV())
-        + "\n  tolerance:         " + str(tolerance))
-    
-        self.assertFalse(abs(assetSwap2.fairSpread() - self.spread)>tolerance,
-        "\npar asset swap fair spread doesn't equal input spread "
-        + "at zero NPV: " 
-        + "\n  input spread: " + str(self.spread )
-        + "\n  fair spread:  " + str(assetSwap2.fairSpread() )
-        + "\n  NPV:          " + str(assetSwap2.NPV() )
-        + "\n  tolerance:    " + str(tolerance))
 
-        assetSwap3 = AssetSwap(payFixedRate,
-                             bond, bondPrice,
-                             self.iborIndex, fairSpread,
-                             Schedule(),
-                             self.iborIndex.dayCounter(),
-                             isPar)
+        assetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            bond,
+            fairCleanPrice,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            isPar,
+        )
+
+        assetSwap2.setPricingEngine(swapEngine)
+        self.assertFalse(
+            abs(assetSwap2.NPV()) > tolerance,
+            "\npar asset swap fair clean price doesn't zero the NPV: "
+            + "\n  clean price:      "
+            + str(bondPrice)
+            + "\n  fair clean price: "
+            + str(fairCleanPrice)
+            + "\n  NPV:              "
+            + str(assetSwap2.NPV())
+            + "\n  tolerance:        "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(assetSwap2.fairCleanPrice() - fairCleanPrice) > tolerance,
+            "\npar asset swap fair clean price doesn't equal input "
+            + "clean price at zero NPV: "
+            + "\n  input clean price: "
+            + str(fairCleanPrice)
+            + "\n  fair clean price:  "
+            + str(assetSwap2.fairCleanPrice())
+            + "\n  NPV:               "
+            + str(assetSwap2.NPV())
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(assetSwap2.fairSpread() - self.spread) > tolerance,
+            "\npar asset swap fair spread doesn't equal input spread "
+            + "at zero NPV: "
+            + "\n  input spread: "
+            + str(self.spread)
+            + "\n  fair spread:  "
+            + str(assetSwap2.fairSpread())
+            + "\n  NPV:          "
+            + str(assetSwap2.NPV())
+            + "\n  tolerance:    "
+            + str(tolerance),
+        )
+
+        assetSwap3 = ql.AssetSwap(
+            payFixedRate, bond, bondPrice, self.iborIndex, fairSpread, ql.Schedule(), self.iborIndex.dayCounter(), isPar
+        )
         assetSwap3.setPricingEngine(swapEngine)
-        self.assertFalse(abs(assetSwap3.NPV())>tolerance,
-        "\npar asset swap fair spread doesn't zero the NPV: "
-        + "\n  spread:      " + str(self.spread)
-        + "\n  fair spread: " + str(fairSpread)
-        + "\n  NPV:         " + str(assetSwap3.NPV())
-        + "\n  tolerance:   " + str(tolerance))
-        
-        self.assertFalse(abs(assetSwap3.fairCleanPrice() - bondPrice)>tolerance,
-        "\npar asset swap fair clean price doesn't equal input "
-        + "clean price at zero NPV: "
-        + "\n  input clean price: " + str(bondPrice)
-        + "\n  fair clean price:  " + str(assetSwap3.fairCleanPrice())
-        + "\n  NPV:               " + str(assetSwap3.NPV())
-        + "\n  tolerance:         " + str(tolerance))
-    
-        self.assertFalse(abs(assetSwap3.fairSpread() - fairSpread)>tolerance,
-        "\npar asset swap fair spread doesn't equal input spread at"
-        + " zero NPV: "
-        + "\n  input spread: " + str(fairSpread)
-        + "\n  fair spread:  " + str(assetSwap3.fairSpread())
-        + "\n  NPV:          " + str(assetSwap3.NPV())
-        + "\n  tolerance:    " + str(tolerance))
-    
+        self.assertFalse(
+            abs(assetSwap3.NPV()) > tolerance,
+            "\npar asset swap fair spread doesn't zero the NPV: "
+            + "\n  spread:      "
+            + str(self.spread)
+            + "\n  fair spread: "
+            + str(fairSpread)
+            + "\n  NPV:         "
+            + str(assetSwap3.NPV())
+            + "\n  tolerance:   "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(assetSwap3.fairCleanPrice() - bondPrice) > tolerance,
+            "\npar asset swap fair clean price doesn't equal input "
+            + "clean price at zero NPV: "
+            + "\n  input clean price: "
+            + str(bondPrice)
+            + "\n  fair clean price:  "
+            + str(assetSwap3.fairCleanPrice())
+            + "\n  NPV:               "
+            + str(assetSwap3.NPV())
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(assetSwap3.fairSpread() - fairSpread) > tolerance,
+            "\npar asset swap fair spread doesn't equal input spread at"
+            + " zero NPV: "
+            + "\n  input spread: "
+            + str(fairSpread)
+            + "\n  fair spread:  "
+            + str(assetSwap3.fairSpread())
+            + "\n  NPV:          "
+            + str(assetSwap3.NPV())
+            + "\n  tolerance:    "
+            + str(tolerance),
+        )
 
         ## let's change the npv date
-        swapEngine = DiscountingSwapEngine(self.termStructure,
-                              True,
-                              bond.settlementDate(),
-                              bond.settlementDate())
+        swapEngine = ql.DiscountingSwapEngine(self.termStructure, True, bond.settlementDate(), bond.settlementDate())
 
         parAssetSwap.setPricingEngine(swapEngine)
         ## fair clean price and fair spread should not change
-        self.assertFalse(abs(parAssetSwap.fairCleanPrice() - fairCleanPrice)>tolerance,
+        self.assertFalse(
+            abs(parAssetSwap.fairCleanPrice() - fairCleanPrice) > tolerance,
             "\npar asset swap fair clean price changed with NpvDate:"
-            + "\n expected clean price: " + str(fairCleanPrice)
-            + "\n fair clean price:     " + str(parAssetSwap.fairCleanPrice())
-            + "\n tolerance:            " + str(tolerance))
-    
-        self.assertFalse(abs(parAssetSwap.fairSpread() - fairSpread)>tolerance, 
-            "\npar asset swap fair spread changed with NpvDate:"
-            + "\n  expected spread: " + str(fairSpread)
-            + "\n  fair spread:     " + str(parAssetSwap.fairSpread())
-            + "\n  tolerance:       " + str(tolerance))
-    
-        assetSwap2 = AssetSwap(payFixedRate,    
-                           bond, fairCleanPrice,
-                           self.iborIndex, self.spread,
-                           Schedule(),
-                           self.iborIndex.dayCounter(),
-                           isPar)
-        assetSwap2.setPricingEngine(swapEngine)
-        self.assertFalse(abs(assetSwap2.NPV())>tolerance, 
-            "\npar asset swap fair clean price doesn't zero the NPV: "
-            + "\n  clean price:      " + str(bondPrice)
-            + "\n  fair clean price: " + str(fairCleanPrice)
-            + "\n  NPV:              " + str(assetSwap2.NPV())
-            + "\n  tolerance:        " + str(tolerance))
-    
-        self.assertFalse(abs(assetSwap2.fairCleanPrice() - fairCleanPrice)>tolerance,
-            "\npar asset swap fair clean price doesn't equal input "
-            + "clean price at zero NPV: "
-            + "\n  input clean price: " + str(fairCleanPrice)
-            + "\n  fair clean price:  " + str(assetSwap2.fairCleanPrice())
-            + "\n  NPV:               " + str(assetSwap2.NPV())
-            + "\n  tolerance:         " + str(tolerance))
-    
-        self.assertFalse(abs(assetSwap2.fairSpread() - self.spread)>tolerance,
-            "\npar asset swap fair spread doesn't equal input spread at zero NPV: "
-            + "\n  input spread: " + str(self.spread)
-            + "\n  fair spread:  " + str(assetSwap2.fairSpread())
-            + "\n  NPV:          " + str(assetSwap2.NPV())
-            + "\n  tolerance:    " + str(tolerance))
+            + "\n expected clean price: "
+            + str(fairCleanPrice)
+            + "\n fair clean price:     "
+            + str(parAssetSwap.fairCleanPrice())
+            + "\n tolerance:            "
+            + str(tolerance),
+        )
 
-        assetSwap3 = AssetSwap(payFixedRate,
-                           bond, bondPrice,
-                           self.iborIndex, fairSpread,
-                           Schedule(),
-                           self.iborIndex.dayCounter(),
-                           isPar)
-        assetSwap3.setPricingEngine(swapEngine)
-        self.assertFalse(abs(assetSwap3.NPV())>tolerance, 
-            "\npar asset swap fair spread doesn't zero the NPV: "
-            + "\n  spread:      " + str(self.spread)
-            + "\n  fair spread: " + str(fairSpread)
-            + "\n  NPV:         " + str(assetSwap3.NPV())
-            + "\n  tolerance:   " + str(tolerance))
-    
-        self.assertFalse(abs(assetSwap3.fairCleanPrice() - bondPrice)>tolerance,
+        self.assertFalse(
+            abs(parAssetSwap.fairSpread() - fairSpread) > tolerance,
+            "\npar asset swap fair spread changed with NpvDate:"
+            + "\n  expected spread: "
+            + str(fairSpread)
+            + "\n  fair spread:     "
+            + str(parAssetSwap.fairSpread())
+            + "\n  tolerance:       "
+            + str(tolerance),
+        )
+
+        assetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            bond,
+            fairCleanPrice,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            isPar,
+        )
+        assetSwap2.setPricingEngine(swapEngine)
+        self.assertFalse(
+            abs(assetSwap2.NPV()) > tolerance,
+            "\npar asset swap fair clean price doesn't zero the NPV: "
+            + "\n  clean price:      "
+            + str(bondPrice)
+            + "\n  fair clean price: "
+            + str(fairCleanPrice)
+            + "\n  NPV:              "
+            + str(assetSwap2.NPV())
+            + "\n  tolerance:        "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(assetSwap2.fairCleanPrice() - fairCleanPrice) > tolerance,
             "\npar asset swap fair clean price doesn't equal input "
             + "clean price at zero NPV: "
-            + "\n  input clean price: " + str(bondPrice)
-            + "\n  fair clean price:  " + str(assetSwap3.fairCleanPrice())
-            + "\n  NPV:               " + str(assetSwap3.NPV())
-            + "\n  tolerance:         " + str(tolerance))
-    
-        self.assertFalse(abs(assetSwap3.fairSpread() - fairSpread)>tolerance,
+            + "\n  input clean price: "
+            + str(fairCleanPrice)
+            + "\n  fair clean price:  "
+            + str(assetSwap2.fairCleanPrice())
+            + "\n  NPV:               "
+            + str(assetSwap2.NPV())
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(assetSwap2.fairSpread() - self.spread) > tolerance,
             "\npar asset swap fair spread doesn't equal input spread at zero NPV: "
-            + "\n  input spread: " + str(fairSpread)
-            + "\n  fair spread:  " + str(assetSwap3.fairSpread())
-            + "\n  NPV:          " + str(assetSwap3.NPV())
-            + "\n  tolerance:    " + str(tolerance))
-    
+            + "\n  input spread: "
+            + str(self.spread)
+            + "\n  fair spread:  "
+            + str(assetSwap2.fairSpread())
+            + "\n  NPV:          "
+            + str(assetSwap2.NPV())
+            + "\n  tolerance:    "
+            + str(tolerance),
+        )
+
+        assetSwap3 = ql.AssetSwap(
+            payFixedRate, bond, bondPrice, self.iborIndex, fairSpread, ql.Schedule(), self.iborIndex.dayCounter(), isPar
+        )
+        assetSwap3.setPricingEngine(swapEngine)
+        self.assertFalse(
+            abs(assetSwap3.NPV()) > tolerance,
+            "\npar asset swap fair spread doesn't zero the NPV: "
+            + "\n  spread:      "
+            + str(self.spread)
+            + "\n  fair spread: "
+            + str(fairSpread)
+            + "\n  NPV:         "
+            + str(assetSwap3.NPV())
+            + "\n  tolerance:   "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(assetSwap3.fairCleanPrice() - bondPrice) > tolerance,
+            "\npar asset swap fair clean price doesn't equal input "
+            + "clean price at zero NPV: "
+            + "\n  input clean price: "
+            + str(bondPrice)
+            + "\n  fair clean price:  "
+            + str(assetSwap3.fairCleanPrice())
+            + "\n  NPV:               "
+            + str(assetSwap3.NPV())
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(assetSwap3.fairSpread() - fairSpread) > tolerance,
+            "\npar asset swap fair spread doesn't equal input spread at zero NPV: "
+            + "\n  input spread: "
+            + str(fairSpread)
+            + "\n  fair spread:  "
+            + str(assetSwap3.fairSpread())
+            + "\n  NPV:          "
+            + str(assetSwap3.NPV())
+            + "\n  tolerance:    "
+            + str(tolerance),
+        )
 
         ## now market asset swap
         isPar = False
-        mktAssetSwap = AssetSwap (payFixedRate,
-                               bond, bondPrice,
-                               self.iborIndex, self.spread,
-                               Schedule(),
-                               self.iborIndex.dayCounter(),
-                               isPar)
+        mktAssetSwap = ql.AssetSwap(
+            payFixedRate,
+            bond,
+            bondPrice,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            isPar,
+        )
 
-        swapEngine = DiscountingSwapEngine(self.termStructure,
-                                  True,
-                                  bond.settlementDate(),
-                                  Settings.instance().evaluationDate)
+        swapEngine = ql.DiscountingSwapEngine(
+            self.termStructure, True, bond.settlementDate(), ql.Settings.instance().evaluationDate
+        )
 
         mktAssetSwap.setPricingEngine(swapEngine)
         fairCleanPrice = mktAssetSwap.fairCleanPrice()
         fairSpread = mktAssetSwap.fairSpread()
 
-        assetSwap4 = AssetSwap (payFixedRate,
-                             bond, fairCleanPrice,
-                             self.iborIndex, self.spread,
-                             Schedule(),
-                             self.iborIndex.dayCounter(),
-                             isPar)
+        assetSwap4 = ql.AssetSwap(
+            payFixedRate,
+            bond,
+            fairCleanPrice,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            isPar,
+        )
         assetSwap4.setPricingEngine(swapEngine)
-        self.assertFalse(abs(assetSwap4.NPV())>tolerance, 
+        self.assertFalse(
+            abs(assetSwap4.NPV()) > tolerance,
             "\nmarket asset swap fair clean price doesn't zero the NPV: "
-            + "\n  clean price:      " + str(bondPrice)
-            + "\n  fair clean price: " + str(fairCleanPrice)
-            + "\n  NPV:              " + str(assetSwap4.NPV())
-            + "\n  tolerance:        " + str(tolerance))
-        
-        self.assertFalse(abs(assetSwap4.fairCleanPrice() - fairCleanPrice)>tolerance,
-            "\nmarket asset swap fair clean price doesn't equal input "
-            + "clean price at zero NPV: "   
-            + "\n  input clean price: " + str(fairCleanPrice)
-            + "\n  fair clean price:  " + str(assetSwap4.fairCleanPrice())
-            + "\n  NPV:               " + str(assetSwap4.NPV())
-            + "\n  tolerance:         " + str(tolerance))
-        
-        self.assertFalse(abs(assetSwap4.fairSpread() - self.spread)>tolerance,
-            "\nmarket asset swap fair spread doesn't equal input spread"
-            + " at zero NPV: "
-            + "\n  input spread: " + str(self.spread)
-            + "\n  fair spread:  " + str(assetSwap4.fairSpread())
-            + "\n  NPV:          " + str(assetSwap4.NPV())
-            + "\n  tolerance:    " + str(tolerance))
-        
+            + "\n  clean price:      "
+            + str(bondPrice)
+            + "\n  fair clean price: "
+            + str(fairCleanPrice)
+            + "\n  NPV:              "
+            + str(assetSwap4.NPV())
+            + "\n  tolerance:        "
+            + str(tolerance),
+        )
 
-        assetSwap5 = AssetSwap(payFixedRate,
-                             bond, bondPrice,
-                             self.iborIndex, fairSpread,
-                             Schedule(),
-                             self.iborIndex.dayCounter(),
-                             isPar)
-        assetSwap5.setPricingEngine(swapEngine)
-        self.assertFalse(abs(assetSwap5.NPV())>tolerance,
-            "\nmarket asset swap fair spread doesn't zero the NPV: "
-            + "\n  spread:      " + str(self.spread)
-            + "\n  fair spread: " + str(fairSpread)
-            + "\n  NPV:         " + str(assetSwap5.NPV())
-            + "\n  tolerance:   " + str(tolerance))
-        
-        self.assertFalse(abs(assetSwap5.fairCleanPrice() - bondPrice)>tolerance, 
+        self.assertFalse(
+            abs(assetSwap4.fairCleanPrice() - fairCleanPrice) > tolerance,
             "\nmarket asset swap fair clean price doesn't equal input "
             + "clean price at zero NPV: "
-            + "\n  input clean price: " + str(bondPrice)
-            + "\n  fair clean price:  " + str(assetSwap5.fairCleanPrice())
-            + "\n  NPV:               " + str(assetSwap5.NPV())
-            + "\n  tolerance:         " + str(tolerance))
-        
-        self.assertFalse(abs(assetSwap5.fairSpread() - fairSpread)>tolerance,
+            + "\n  input clean price: "
+            + str(fairCleanPrice)
+            + "\n  fair clean price:  "
+            + str(assetSwap4.fairCleanPrice())
+            + "\n  NPV:               "
+            + str(assetSwap4.NPV())
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(assetSwap4.fairSpread() - self.spread) > tolerance,
+            "\nmarket asset swap fair spread doesn't equal input spread"
+            + " at zero NPV: "
+            + "\n  input spread: "
+            + str(self.spread)
+            + "\n  fair spread:  "
+            + str(assetSwap4.fairSpread())
+            + "\n  NPV:          "
+            + str(assetSwap4.NPV())
+            + "\n  tolerance:    "
+            + str(tolerance),
+        )
+
+        assetSwap5 = ql.AssetSwap(
+            payFixedRate, bond, bondPrice, self.iborIndex, fairSpread, ql.Schedule(), self.iborIndex.dayCounter(), isPar
+        )
+        assetSwap5.setPricingEngine(swapEngine)
+        self.assertFalse(
+            abs(assetSwap5.NPV()) > tolerance,
+            "\nmarket asset swap fair spread doesn't zero the NPV: "
+            + "\n  spread:      "
+            + str(self.spread)
+            + "\n  fair spread: "
+            + str(fairSpread)
+            + "\n  NPV:         "
+            + str(assetSwap5.NPV())
+            + "\n  tolerance:   "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(assetSwap5.fairCleanPrice() - bondPrice) > tolerance,
+            "\nmarket asset swap fair clean price doesn't equal input "
+            + "clean price at zero NPV: "
+            + "\n  input clean price: "
+            + str(bondPrice)
+            + "\n  fair clean price:  "
+            + str(assetSwap5.fairCleanPrice())
+            + "\n  NPV:               "
+            + str(assetSwap5.NPV())
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(assetSwap5.fairSpread() - fairSpread) > tolerance,
             "\nmarket asset swap fair spread doesn't equal input spread at zero NPV: "
-            + "\n  input spread: " + str(fairSpread)
-            + "\n  fair spread:  " + str(assetSwap5.fairSpread())
-            + "\n  NPV:          " + str(assetSwap5.NPV())
-            + "\n  tolerance:    " + str(tolerance))
-        
+            + "\n  input spread: "
+            + str(fairSpread)
+            + "\n  fair spread:  "
+            + str(assetSwap5.fairSpread())
+            + "\n  NPV:          "
+            + str(assetSwap5.NPV())
+            + "\n  tolerance:    "
+            + str(tolerance),
+        )
 
         ## let's change the npv date
-        swapEngine = DiscountingSwapEngine(self.termStructure,
-                                  True,
-                                  bond.settlementDate(),
-                                  bond.settlementDate())
+        swapEngine = ql.DiscountingSwapEngine(self.termStructure, True, bond.settlementDate(), bond.settlementDate())
 
         mktAssetSwap.setPricingEngine(swapEngine)
         ## fair clean price and fair spread should not change
-        self.assertFalse(abs(mktAssetSwap.fairCleanPrice() - fairCleanPrice)>tolerance, 
+        self.assertFalse(
+            abs(mktAssetSwap.fairCleanPrice() - fairCleanPrice) > tolerance,
             "\nmarket asset swap fair clean price changed with NpvDate:"
-            + "\n  expected clean price: " + str(fairCleanPrice)
-            + "\n  fair clean price:  " + str(mktAssetSwap.fairCleanPrice())
-            + "\n  tolerance:         " + str(tolerance))
-        
-        self.assertFalse(abs(mktAssetSwap.fairSpread() - fairSpread)>tolerance,
+            + "\n  expected clean price: "
+            + str(fairCleanPrice)
+            + "\n  fair clean price:  "
+            + str(mktAssetSwap.fairCleanPrice())
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(mktAssetSwap.fairSpread() - fairSpread) > tolerance,
             "\nmarket asset swap fair spread changed with NpvDate:"
-            + "\n  expected spread: " + str(fairSpread)
-            + "\n  fair spread:  " + str(mktAssetSwap.fairSpread())
-            + "\n  tolerance:    " + str(tolerance))
-        
+            + "\n  expected spread: "
+            + str(fairSpread)
+            + "\n  fair spread:  "
+            + str(mktAssetSwap.fairSpread())
+            + "\n  tolerance:    "
+            + str(tolerance),
+        )
 
-        assetSwap4 = AssetSwap(payFixedRate,
-                               bond, fairCleanPrice,
-                               self.iborIndex, self.spread,
-                               Schedule(),
-                               self.iborIndex.dayCounter(),
-                               isPar)
+        assetSwap4 = ql.AssetSwap(
+            payFixedRate,
+            bond,
+            fairCleanPrice,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            isPar,
+        )
         assetSwap4.setPricingEngine(swapEngine)
-        self.assertFalse(abs(assetSwap4.NPV())>tolerance,
+        self.assertFalse(
+            abs(assetSwap4.NPV()) > tolerance,
             "\nmarket asset swap fair clean price doesn't zero the NPV: "
-            + "\n  clean price:      " + str(bondPrice)
-            + "\n  fair clean price: " + str(fairCleanPrice)
-            + "\n  NPV:              " + str(assetSwap4.NPV())
-            + "\n  tolerance:        " + str(tolerance))
-        
-        self.assertFalse(abs(assetSwap4.fairCleanPrice() - fairCleanPrice)>tolerance,
+            + "\n  clean price:      "
+            + str(bondPrice)
+            + "\n  fair clean price: "
+            + str(fairCleanPrice)
+            + "\n  NPV:              "
+            + str(assetSwap4.NPV())
+            + "\n  tolerance:        "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(assetSwap4.fairCleanPrice() - fairCleanPrice) > tolerance,
             "\nmarket asset swap fair clean price doesn't equal input "
             + "clean price at zero NPV: "
-            + "\n  input clean price: " + str(fairCleanPrice)
-            + "\n  fair clean price:  " + str(assetSwap4.fairCleanPrice())
-            + "\n  NPV:               " + str(assetSwap4.NPV())
-            + "\n  tolerance:         " + str(tolerance))
-        
-        self.assertFalse(abs(assetSwap4.fairSpread() - self.spread)>tolerance,
+            + "\n  input clean price: "
+            + str(fairCleanPrice)
+            + "\n  fair clean price:  "
+            + str(assetSwap4.fairCleanPrice())
+            + "\n  NPV:               "
+            + str(assetSwap4.NPV())
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(assetSwap4.fairSpread() - self.spread) > tolerance,
             "\nmarket asset swap fair spread doesn't equal input spread at zero NPV: "
-            + "\n  input spread: " + str(self.spread)
-            + "\n  fair spread:  " + str(assetSwap4.fairSpread())
-            + "\n  NPV:          " + str(assetSwap4.NPV())
-            + "\n  tolerance:    " + str(tolerance))
-        
-        assetSwap5 = AssetSwap(payFixedRate,
-                               bond, bondPrice,
-                               self.iborIndex, fairSpread,
-                               Schedule(),
-                               self.iborIndex.dayCounter(),
-                               isPar)
+            + "\n  input spread: "
+            + str(self.spread)
+            + "\n  fair spread:  "
+            + str(assetSwap4.fairSpread())
+            + "\n  NPV:          "
+            + str(assetSwap4.NPV())
+            + "\n  tolerance:    "
+            + str(tolerance),
+        )
+
+        assetSwap5 = ql.AssetSwap(
+            payFixedRate, bond, bondPrice, self.iborIndex, fairSpread, ql.Schedule(), self.iborIndex.dayCounter(), isPar
+        )
         assetSwap5.setPricingEngine(swapEngine)
-        self.assertFalse(abs(assetSwap5.NPV())>tolerance,
-            "\nmarket asset swap fair spread doesn't zero the NPV: "    
-            + "\n  spread:      " + str(self.spread)
-            + "\n  fair spread: " + str(fairSpread)
-            + "\n  NPV:         " + str(assetSwap5.NPV())
-            + "\n  tolerance:   " + str(tolerance))
-        
-        self.assertFalse(abs(assetSwap5.fairCleanPrice() - bondPrice)>tolerance,
+        self.assertFalse(
+            abs(assetSwap5.NPV()) > tolerance,
+            "\nmarket asset swap fair spread doesn't zero the NPV: "
+            + "\n  spread:      "
+            + str(self.spread)
+            + "\n  fair spread: "
+            + str(fairSpread)
+            + "\n  NPV:         "
+            + str(assetSwap5.NPV())
+            + "\n  tolerance:   "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(assetSwap5.fairCleanPrice() - bondPrice) > tolerance,
             "\nmarket asset swap fair clean price doesn't equal input "
             + "clean price at zero NPV: "
-            + "\n  input clean price: " + str(bondPrice)
-            + "\n  fair clean price:  " + str(assetSwap5.fairCleanPrice())
-            + "\n  NPV:               " + str(assetSwap5.NPV())
-            + "\n  tolerance:         " + str(tolerance))
-        
-        self.assertFalse(abs(assetSwap5.fairSpread() - fairSpread)>tolerance,
+            + "\n  input clean price: "
+            + str(bondPrice)
+            + "\n  fair clean price:  "
+            + str(assetSwap5.fairCleanPrice())
+            + "\n  NPV:               "
+            + str(assetSwap5.NPV())
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
+
+        self.assertFalse(
+            abs(assetSwap5.fairSpread() - fairSpread) > tolerance,
             "\nmarket asset swap fair spread doesn't equal input spread at zero NPV: "
-            + "\n  input spread: " + str(fairSpread)
-            + "\n  fair spread:  " + str(assetSwap5.fairSpread())
-            + "\n  NPV:          " + str(assetSwap5.NPV())
-            + "\n  tolerance:    " + str(tolerance))
-        
-
-
+            + "\n  input spread: "
+            + str(fairSpread)
+            + "\n  fair spread:  "
+            + str(assetSwap5.fairSpread())
+            + "\n  NPV:          "
+            + str(assetSwap5.NPV())
+            + "\n  tolerance:    "
+            + str(tolerance),
+        )
 
     def testImpliedValue(self):
         """Testing implied bond value against asset-swap fair price with null spread..."""
-        bondCalendar = TARGET()
+        bondCalendar = ql.TARGET()
         settlementDays = 3
         fixingDays = 2
         payFixedRate = True
@@ -401,317 +581,469 @@ class AssetSwapTest(unittest.TestCase):
         ## Fixed Underlying bond (Isin: DE0001135275 DBR 4 01/04/37)
         ## maturity doesn't occur on a business day
 
-        fixedBondSchedule1 = Schedule(Date(4,January,2005),
-                                    Date(4,January,2037),
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBond1 = FixedRateBond(settlementDays, self.faceAmount,
-                                               fixedBondSchedule1,
-                                               [0.04],
-                                               ActualActual(ActualActual.ISDA),
-                                               Following,
-                                               100.0, Date(4,January,2005))
+        fixedBondSchedule1 = ql.Schedule(
+            ql.Date(4, ql.January, 2005),
+            ql.Date(4, ql.January, 2037),
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBond1 = ql.FixedRateBond(
+            settlementDays,
+            self.faceAmount,
+            fixedBondSchedule1,
+            [0.04],
+            ql.ActualActual(ql.ActualActual.ISDA),
+            ql.Following,
+            100.0,
+            ql.Date(4, ql.January, 2005),
+        )
 
-        bondEngine = DiscountingBondEngine(self.termStructure)
-        swapEngine = DiscountingSwapEngine(self.termStructure, False)
+        bondEngine = ql.DiscountingBondEngine(self.termStructure)
+        swapEngine = ql.DiscountingSwapEngine(self.termStructure, False)
         fixedBond1.setPricingEngine(bondEngine)
 
         fixedBondPrice1 = fixedBond1.cleanPrice()
-        fixedBondAssetSwap1 = AssetSwap(payFixedRate,
-                                      fixedBond1, fixedBondPrice1,
-                                      self.iborIndex, self.spread,
-                                      Schedule(),
-                                      self.iborIndex.dayCounter(),
-                                      parAssetSwap)
+        fixedBondAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond1,
+            fixedBondPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedBondAssetSwap1.setPricingEngine(swapEngine)
         fixedBondAssetSwapPrice1 = fixedBondAssetSwap1.fairCleanPrice()
         tolerance = 1.0e-13
-        
-        error1 = abs(fixedBondAssetSwapPrice1-fixedBondPrice1)
 
-        self.assertFalse(error1>tolerance, 
+        error1 = abs(fixedBondAssetSwapPrice1 - fixedBondPrice1)
+
+        self.assertFalse(
+            error1 > tolerance,
             "wrong zero spread asset swap price for fixed bond:"
-            + "\n  bond's clean price:    " + str(fixedBondPrice1)
-            + "\n  asset swap fair price: " + str(fixedBondAssetSwapPrice1)
-            + "\n  error:                 " + str(error1)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  bond's clean price:    "
+            + str(fixedBondPrice1)
+            + "\n  asset swap fair price: "
+            + str(fixedBondAssetSwapPrice1)
+            + "\n  error:                 "
+            + str(error1)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
         ## Fixed Underlying bond (Isin: IT0006527060 IBRD 5 02/05/19)
         ## maturity occurs on a business day
 
-        fixedBondSchedule2 = Schedule(Date(5,February,2005),
-                                    Date(5,February,2019),
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBond2 = FixedRateBond(settlementDays, self.faceAmount,
-                                               fixedBondSchedule2,
-                                               [0.05],
-                                               Thirty360(Thirty360.BondBasis),
-                                               Following,
-                                               100.0, Date(5,February,2005))
+        fixedBondSchedule2 = ql.Schedule(
+            ql.Date(5, ql.February, 2005),
+            ql.Date(5, ql.February, 2019),
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBond2 = ql.FixedRateBond(
+            settlementDays,
+            self.faceAmount,
+            fixedBondSchedule2,
+            [0.05],
+            ql.Thirty360(ql.Thirty360.BondBasis),
+            ql.Following,
+            100.0,
+            ql.Date(5, ql.February, 2005),
+        )
 
         fixedBond2.setPricingEngine(bondEngine)
 
         fixedBondPrice2 = fixedBond2.cleanPrice()
-        fixedBondAssetSwap2 = AssetSwap(payFixedRate,
-                                      fixedBond2, fixedBondPrice2,
-                                      self.iborIndex, self.spread,
-                                      Schedule(),
-                                      self.iborIndex.dayCounter(),
-                                      parAssetSwap)
+        fixedBondAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond2,
+            fixedBondPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedBondAssetSwap2.setPricingEngine(swapEngine)
         fixedBondAssetSwapPrice2 = fixedBondAssetSwap2.fairCleanPrice()
-        error2 = abs(fixedBondAssetSwapPrice2-fixedBondPrice2)
+        error2 = abs(fixedBondAssetSwapPrice2 - fixedBondPrice2)
 
-        self.assertFalse(error2>tolerance,  
+        self.assertFalse(
+            error2 > tolerance,
             "wrong zero spread asset swap price for fixed bond:"
-            + "\n  bond's clean price:    " + str(fixedBondPrice2)
-            + "\n  asset swap fair price: " + str(fixedBondAssetSwapPrice2)
-            + "\n  error:                 " + str(error2)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  bond's clean price:    "
+            + str(fixedBondPrice2)
+            + "\n  asset swap fair price: "
+            + str(fixedBondAssetSwapPrice2)
+            + "\n  error:                 "
+            + str(error2)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## FRN Underlying bond (Isin: IT0003543847 ISPIM 0 09/29/13)
         ## maturity doesn't occur on a business day
 
-        floatingBondSchedule1 = Schedule(Date(29,September,2003),
-                                       Date(29,September,2013),
-                                       Period(Semiannual), bondCalendar,
-                                       Unadjusted, Unadjusted,
-                                       DateGeneration.Backward, False)
+        floatingBondSchedule1 = ql.Schedule(
+            ql.Date(29, ql.September, 2003),
+            ql.Date(29, ql.September, 2013),
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
 
-        floatingBond1 =FloatingRateBond(settlementDays, self.faceAmount,
-                                               floatingBondSchedule1,
-                                               self.iborIndex, Actual360(),
-                                               Following, fixingDays,
-                                               [1],
-                                               [0.0056],
-                                               [],
-                                               [],
-                                               inArrears,
-                                               100.0, Date(29,September,2003))
+        floatingBond1 = ql.FloatingRateBond(
+            settlementDays,
+            self.faceAmount,
+            floatingBondSchedule1,
+            self.iborIndex,
+            ql.Actual360(),
+            ql.Following,
+            fixingDays,
+            [1],
+            [0.0056],
+            [],
+            [],
+            inArrears,
+            100.0,
+            ql.Date(29, ql.September, 2003),
+        )
 
         floatingBond1.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond1.cashflows(), self.pricer)
-        self.iborIndex.addFixing(Date(27,March,2007), 0.0402)
+        ql.setCouponPricer(floatingBond1.cashflows(), self.pricer)
+        self.iborIndex.addFixing(ql.Date(27, ql.March, 2007), 0.0402)
         floatingBondPrice1 = floatingBond1.cleanPrice()
-        floatingBondAssetSwap1 = AssetSwap(payFixedRate,
-                                         floatingBond1, floatingBondPrice1,
-                                         self.iborIndex, self.spread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         parAssetSwap)
+        floatingBondAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond1,
+            floatingBondPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingBondAssetSwap1.setPricingEngine(swapEngine)
         floatingBondAssetSwapPrice1 = floatingBondAssetSwap1.fairCleanPrice()
-        error3 = abs(floatingBondAssetSwapPrice1-floatingBondPrice1)
+        error3 = abs(floatingBondAssetSwapPrice1 - floatingBondPrice1)
 
-        self.assertFalse(error3>tolerance, 
+        self.assertFalse(
+            error3 > tolerance,
             "wrong zero spread asset swap price for floater:"
-            + "\n  bond's clean price:    " + str(floatingBondPrice1)
-            + "\n  asset swap fair price: " + str(floatingBondAssetSwapPrice1)
-            + "\n  error:                 " + str(error3)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  bond's clean price:    "
+            + str(floatingBondPrice1)
+            + "\n  asset swap fair price: "
+            + str(floatingBondAssetSwapPrice1)
+            + "\n  error:                 "
+            + str(error3)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## FRN Underlying bond (Isin: XS0090566539 COE 0 09/24/18)
         ## maturity occurs on a business day
 
-        floatingBondSchedule2 = Schedule(Date(24,September,2004),
-                                       Date(24,September,2018),
-                                       Period(Semiannual), bondCalendar,
-                                       ModifiedFollowing, ModifiedFollowing,
-                                       DateGeneration.Backward, False)
-        floatingBond2 = FloatingRateBond(settlementDays, self.faceAmount,
-                                               floatingBondSchedule2,
-                                               self.iborIndex, Actual360(),
-                                               ModifiedFollowing, fixingDays,
-                                               [1],
-                                               [0.0025],
-                                               [],
-                                               [],
-                                               inArrears,
-                                               100.0, Date(24,September,2004))
+        floatingBondSchedule2 = ql.Schedule(
+            ql.Date(24, ql.September, 2004),
+            ql.Date(24, ql.September, 2018),
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.ModifiedFollowing,
+            ql.ModifiedFollowing,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        floatingBond2 = ql.FloatingRateBond(
+            settlementDays,
+            self.faceAmount,
+            floatingBondSchedule2,
+            self.iborIndex,
+            ql.Actual360(),
+            ql.ModifiedFollowing,
+            fixingDays,
+            [1],
+            [0.0025],
+            [],
+            [],
+            inArrears,
+            100.0,
+            ql.Date(24, ql.September, 2004),
+        )
 
         floatingBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond2.cashflows(), self.pricer)
-        self.iborIndex.addFixing(Date(22,March,2007), 0.04013)
-        currentCoupon=0.04013+0.0025
-        floatingCurrentCoupon= floatingBond2.nextCouponRate()
-        error4= abs(floatingCurrentCoupon-currentCoupon)
-        self.assertFalse(error4>tolerance, 
+        ql.setCouponPricer(floatingBond2.cashflows(), self.pricer)
+        self.iborIndex.addFixing(ql.Date(22, ql.March, 2007), 0.04013)
+        currentCoupon = 0.04013 + 0.0025
+        floatingCurrentCoupon = floatingBond2.nextCouponRate()
+        error4 = abs(floatingCurrentCoupon - currentCoupon)
+        self.assertFalse(
+            error4 > tolerance,
             "wrong current coupon is returned for floater bond:"
-            + "\n  bond's calculated current coupon:      " + str(currentCoupon)
-            + "\n  current coupon asked to the bond: " + str(floatingCurrentCoupon)
-            + "\n  error:                 " + str(error4)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  bond's calculated current coupon:      "
+            + str(currentCoupon)
+            + "\n  current coupon asked to the bond: "
+            + str(floatingCurrentCoupon)
+            + "\n  error:                 "
+            + str(error4)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         floatingBondPrice2 = floatingBond2.cleanPrice()
-        floatingBondAssetSwap2 = AssetSwap(payFixedRate,
-                                         floatingBond2, floatingBondPrice2,
-                                         self.iborIndex, self.spread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         parAssetSwap)
+        floatingBondAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond2,
+            floatingBondPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingBondAssetSwap2.setPricingEngine(swapEngine)
         floatingBondAssetSwapPrice2 = floatingBondAssetSwap2.fairCleanPrice()
-        error5 = abs(floatingBondAssetSwapPrice2-floatingBondPrice2)
+        error5 = abs(floatingBondAssetSwapPrice2 - floatingBondPrice2)
 
-        self.assertFalse(error5>tolerance, 
+        self.assertFalse(
+            error5 > tolerance,
             "wrong zero spread asset swap price for floater:"
-            + "\n  bond's clean price:    " + str(floatingBondPrice2)
-            + "\n  asset swap fair price: " + str(floatingBondAssetSwapPrice2)
-            + "\n  error:                 " + str(error5)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  bond's clean price:    "
+            + str(floatingBondPrice2)
+            + "\n  asset swap fair price: "
+            + str(floatingBondAssetSwapPrice2)
+            + "\n  error:                 "
+            + str(error5)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## CMS Underlying bond (Isin: XS0228052402 CRDIT 0 8/22/20)
         ## maturity doesn't occur on a business day
 
-        cmsBondSchedule1 = Schedule(Date(22,August,2005),
-                                  Date(22,August,2020),
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBond1 = CmsRateBond(settlementDays, self.faceAmount,
-                                              cmsBondSchedule1,
-                                              self.swapIndex, Thirty360(),
-                                              Following, fixingDays,
-                                              [1.0],
-                                              [0.0],
-                                              [0.055],
-                                              [0.025],
-                                              inArrears,
-                                              100.0, Date(22,August,2005))
+        cmsBondSchedule1 = ql.Schedule(
+            ql.Date(22, ql.August, 2005),
+            ql.Date(22, ql.August, 2020),
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBond1 = ql.CmsRateBond(
+            settlementDays,
+            self.faceAmount,
+            cmsBondSchedule1,
+            self.swapIndex,
+            ql.Thirty360(),
+            ql.Following,
+            fixingDays,
+            [1.0],
+            [0.0],
+            [0.055],
+            [0.025],
+            inArrears,
+            100.0,
+            ql.Date(22, ql.August, 2005),
+        )
 
         cmsBond1.setPricingEngine(bondEngine)
 
-        setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(18,August,2006), 0.04158)
+        ql.setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(18, ql.August, 2006), 0.04158)
         cmsBondPrice1 = cmsBond1.cleanPrice()
-        cmsBondAssetSwap1 = AssetSwap(payFixedRate,
-                                    cmsBond1, cmsBondPrice1,
-                                    self.iborIndex, self.spread,
-                                    Schedule(),
-                                    self.iborIndex.dayCounter(),
-                                    parAssetSwap)
+        cmsBondAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond1,
+            cmsBondPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsBondAssetSwap1.setPricingEngine(swapEngine)
         cmsBondAssetSwapPrice1 = cmsBondAssetSwap1.fairCleanPrice()
-        error6 = abs(cmsBondAssetSwapPrice1-cmsBondPrice1)
+        error6 = abs(cmsBondAssetSwapPrice1 - cmsBondPrice1)
 
-        self.assertFalse(error6>tolerance, 
+        self.assertFalse(
+            error6 > tolerance,
             "wrong zero spread asset swap price for cms bond:"
-            + "\n  bond's clean price:    " + str(cmsBondPrice1)
-            + "\n  asset swap fair price: " + str(cmsBondAssetSwapPrice1)
-            + "\n  error:                 " + str(error6)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  bond's clean price:    "
+            + str(cmsBondPrice1)
+            + "\n  asset swap fair price: "
+            + str(cmsBondAssetSwapPrice1)
+            + "\n  error:                 "
+            + str(error6)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
-         ## CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
-         ## maturity occurs on a business day
+        ## CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
+        ## maturity occurs on a business day
 
-        cmsBondSchedule2 =  Schedule(Date(6,May,2005),
-                                  Date(6,May,2015),
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBond2 = CmsRateBond(settlementDays, self.faceAmount, cmsBondSchedule2,
-                        self.swapIndex, Thirty360(),
-                        Following, fixingDays,
-                        [0.84], [0.0],
-                        [], [],
-                        inArrears,
-                        100.0, Date(6,May,2005))
+        cmsBondSchedule2 = ql.Schedule(
+            ql.Date(6, ql.May, 2005),
+            ql.Date(6, ql.May, 2015),
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBond2 = ql.CmsRateBond(
+            settlementDays,
+            self.faceAmount,
+            cmsBondSchedule2,
+            self.swapIndex,
+            ql.Thirty360(),
+            ql.Following,
+            fixingDays,
+            [0.84],
+            [0.0],
+            [],
+            [],
+            inArrears,
+            100.0,
+            ql.Date(6, ql.May, 2005),
+        )
 
         cmsBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(4,May,2006), 0.04217)
+        ql.setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(4, ql.May, 2006), 0.04217)
         cmsBondPrice2 = cmsBond2.cleanPrice()
-        cmsBondAssetSwap2 = AssetSwap(payFixedRate,
-                                    cmsBond2, cmsBondPrice2,
-                                    self.iborIndex, self.spread,
-                                    Schedule(),
-                                    self.iborIndex.dayCounter(),
-                                    parAssetSwap)
+        cmsBondAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond2,
+            cmsBondPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsBondAssetSwap2.setPricingEngine(swapEngine)
         cmsBondAssetSwapPrice2 = cmsBondAssetSwap2.fairCleanPrice()
-        error7 = abs(cmsBondAssetSwapPrice2-cmsBondPrice2)
+        error7 = abs(cmsBondAssetSwapPrice2 - cmsBondPrice2)
 
-        self.assertFalse(error7>tolerance, 
+        self.assertFalse(
+            error7 > tolerance,
             "wrong zero spread asset swap price for cms bond:"
-            + "\n  bond's clean price:    " + str(cmsBondPrice2)
-            + "\n  asset swap fair price: " + str(cmsBondAssetSwapPrice2)
-            + "\n  error:                 " + str(error7)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  bond's clean price:    "
+            + str(cmsBondPrice2)
+            + "\n  asset swap fair price: "
+            + str(cmsBondAssetSwapPrice2)
+            + "\n  error:                 "
+            + str(error7)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## Zero Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
         ## maturity doesn't occur on a business day
 
-        zeroCpnBond1 = ZeroCouponBond(settlementDays, bondCalendar, self.faceAmount,
-                           Date(20,December,2015),
-                           Following,
-                           100.0, Date(19,December,1985))
+        zeroCpnBond1 = ql.ZeroCouponBond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            ql.Date(20, ql.December, 2015),
+            ql.Following,
+            100.0,
+            ql.Date(19, ql.December, 1985),
+        )
 
         zeroCpnBond1.setPricingEngine(bondEngine)
 
         zeroCpnBondPrice1 = zeroCpnBond1.cleanPrice()
-        zeroCpnAssetSwap1 = AssetSwap(payFixedRate,
-                                    zeroCpnBond1, zeroCpnBondPrice1,
-                                    self.iborIndex, self.spread,
-                                    Schedule(),
-                                    self.iborIndex.dayCounter(),
-                                    parAssetSwap)
+        zeroCpnAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond1,
+            zeroCpnBondPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnAssetSwap1.setPricingEngine(swapEngine)
         zeroCpnBondAssetSwapPrice1 = zeroCpnAssetSwap1.fairCleanPrice()
-        error8 = abs(cmsBondAssetSwapPrice1-cmsBondPrice1)
+        error8 = abs(cmsBondAssetSwapPrice1 - cmsBondPrice1)
 
-        self.assertFalse(error8>tolerance, 
+        self.assertFalse(
+            error8 > tolerance,
             "wrong zero spread asset swap price for zero cpn bond:"
-            + "\n  bond's clean price:    " + str(zeroCpnBondPrice1)
-            + "\n  asset swap fair price: " + str(zeroCpnBondAssetSwapPrice1)
-            + "\n  error:                 " + str(error8)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  bond's clean price:    "
+            + str(zeroCpnBondPrice1)
+            + "\n  asset swap fair price: "
+            + str(zeroCpnBondAssetSwapPrice1)
+            + "\n  error:                 "
+            + str(error8)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
         ## maturity occurs on a business day
 
-        zeroCpnBond2 = ZeroCouponBond(settlementDays, bondCalendar, self.faceAmount,
-                           Date(17,February,2028),
-                           Following,
-                           100.0, Date(17,February,1998))
+        zeroCpnBond2 = ql.ZeroCouponBond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            ql.Date(17, ql.February, 2028),
+            ql.Following,
+            100.0,
+            ql.Date(17, ql.February, 1998),
+        )
 
         zeroCpnBond2.setPricingEngine(bondEngine)
 
         zeroCpnBondPrice2 = zeroCpnBond2.cleanPrice()
-        zeroCpnAssetSwap2 = AssetSwap(payFixedRate,
-                                    zeroCpnBond2, zeroCpnBondPrice2,
-                                    self.iborIndex, self.spread,
-                                    Schedule(),
-                                    self.iborIndex.dayCounter(),
-                                    parAssetSwap)
+        zeroCpnAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond2,
+            zeroCpnBondPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnAssetSwap2.setPricingEngine(swapEngine)
         zeroCpnBondAssetSwapPrice2 = zeroCpnAssetSwap2.fairCleanPrice()
-        error9 = abs(cmsBondAssetSwapPrice2-cmsBondPrice2)
+        error9 = abs(cmsBondAssetSwapPrice2 - cmsBondPrice2)
 
-        self.assertFalse(error9>tolerance, 
+        self.assertFalse(
+            error9 > tolerance,
             "wrong zero spread asset swap price for zero cpn bond:"
-            + "\n  bond's clean price:      " + str(zeroCpnBondPrice2)
-            + "\n  asset swap fair price:   " + str(zeroCpnBondAssetSwapPrice2)
-            + "\n  error:                   " + str(error9)
-            + "\n  tolerance:               " + str(tolerance))
-        
+            + "\n  bond's clean price:      "
+            + str(zeroCpnBondPrice2)
+            + "\n  asset swap fair price:   "
+            + str(zeroCpnBondAssetSwapPrice2)
+            + "\n  error:                   "
+            + str(error9)
+            + "\n  tolerance:               "
+            + str(tolerance),
+        )
 
-
-    def testMarketASWSpread(self) :
+    def testMarketASWSpread(self):
         """Testing relationship between market asset swap and par asset swap..."""
-        bondCalendar = TARGET()
+        bondCalendar = ql.TARGET()
         settlementDays = 3
         fixingDays = 2
         payFixedRate = True
@@ -722,384 +1054,568 @@ class AssetSwapTest(unittest.TestCase):
         ## Fixed Underlying bond (Isin: DE0001135275 DBR 4 01/04/37)
         ## maturity doesn't occur on a business day
 
-        fixedBondSchedule1 = Schedule (Date(4,January,2005),
-                                    Date(4,January,2037),
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBond1 = FixedRateBond(settlementDays, self.faceAmount, fixedBondSchedule1,
-                          [0.04],
-                          ActualActual(ActualActual.ISDA), Following,
-                          100.0, Date(4,January,2005))
+        fixedBondSchedule1 = ql.Schedule(
+            ql.Date(4, ql.January, 2005),
+            ql.Date(4, ql.January, 2037),
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBond1 = ql.FixedRateBond(
+            settlementDays,
+            self.faceAmount,
+            fixedBondSchedule1,
+            [0.04],
+            ql.ActualActual(ql.ActualActual.ISDA),
+            ql.Following,
+            100.0,
+            ql.Date(4, ql.January, 2005),
+        )
 
-        bondEngine = DiscountingBondEngine(self.termStructure)
-        swapEngine = DiscountingSwapEngine(self.termStructure,False)
+        bondEngine = ql.DiscountingBondEngine(self.termStructure)
+        swapEngine = ql.DiscountingSwapEngine(self.termStructure, False)
         fixedBond1.setPricingEngine(bondEngine)
 
         fixedBondMktPrice1 = 89.22  ## market price observed on 7th June 2007
-        fixedBondMktFullPrice1=fixedBondMktPrice1+fixedBond1.accruedAmount()
-        fixedBondParAssetSwap1 = AssetSwap(payFixedRate,
-                                         fixedBond1, fixedBondMktPrice1,
-                                         self.iborIndex, self.spread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         parAssetSwap)
+        fixedBondMktFullPrice1 = fixedBondMktPrice1 + fixedBond1.accruedAmount()
+        fixedBondParAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond1,
+            fixedBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedBondParAssetSwap1.setPricingEngine(swapEngine)
         fixedBondParAssetSwapSpread1 = fixedBondParAssetSwap1.fairSpread()
-        fixedBondMktAssetSwap1 = AssetSwap(payFixedRate,
-                                         fixedBond1, fixedBondMktPrice1,
-                                         self.iborIndex, self.spread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         mktAssetSwap)
+        fixedBondMktAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond1,
+            fixedBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         fixedBondMktAssetSwap1.setPricingEngine(swapEngine)
         fixedBondMktAssetSwapSpread1 = fixedBondMktAssetSwap1.fairSpread()
 
         tolerance = 1.0e-13
-        error1 = abs(fixedBondMktAssetSwapSpread1-
-                      100*fixedBondParAssetSwapSpread1/fixedBondMktFullPrice1)
+        error1 = abs(fixedBondMktAssetSwapSpread1 - 100 * fixedBondParAssetSwapSpread1 / fixedBondMktFullPrice1)
 
-        self.assertFalse (error1>tolerance, 
+        self.assertFalse(
+            error1 > tolerance,
             "wrong asset swap spreads for fixed bond:"
-            + "\n  market ASW spread: " + str(fixedBondMktAssetSwapSpread1)
-            + "\n  par ASW spread:    " + str(fixedBondParAssetSwapSpread1)
-            + "\n  error:             " + str(error1)
-            + "\n  tolerance:         " + str(tolerance))
-        
+            + "\n  market ASW spread: "
+            + str(fixedBondMktAssetSwapSpread1)
+            + "\n  par ASW spread:    "
+            + str(fixedBondParAssetSwapSpread1)
+            + "\n  error:             "
+            + str(error1)
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
 
         ## Fixed Underlying bond (Isin: IT0006527060 IBRD 5 02/05/19)
         ## maturity occurs on a business day
 
-        fixedBondSchedule2 = Schedule(Date(5,February,2005),
-                                    Date(5,February,2019),
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBond2 =FixedRateBond(settlementDays, self.faceAmount, fixedBondSchedule2,
-                          [0.05],
-                          Thirty360(Thirty360.BondBasis), Following,
-                          100.0, Date(5,February,2005))
+        fixedBondSchedule2 = ql.Schedule(
+            ql.Date(5, ql.February, 2005),
+            ql.Date(5, ql.February, 2019),
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBond2 = ql.FixedRateBond(
+            settlementDays,
+            self.faceAmount,
+            fixedBondSchedule2,
+            [0.05],
+            ql.Thirty360(ql.Thirty360.BondBasis),
+            ql.Following,
+            100.0,
+            ql.Date(5, ql.February, 2005),
+        )
 
         fixedBond2.setPricingEngine(bondEngine)
 
         fixedBondMktPrice2 = 99.98  ## market price observed on 7th June 2007
-        fixedBondMktFullPrice2 = fixedBondMktPrice2+fixedBond2.accruedAmount()
-        fixedBondParAssetSwap2 = AssetSwap (payFixedRate,
-                                         fixedBond2, fixedBondMktPrice2,
-                                         self.iborIndex, self.spread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         parAssetSwap)
+        fixedBondMktFullPrice2 = fixedBondMktPrice2 + fixedBond2.accruedAmount()
+        fixedBondParAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond2,
+            fixedBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedBondParAssetSwap2.setPricingEngine(swapEngine)
         fixedBondParAssetSwapSpread2 = fixedBondParAssetSwap2.fairSpread()
-        fixedBondMktAssetSwap2 = AssetSwap(payFixedRate,
-                                         fixedBond2, fixedBondMktPrice2,
-                                         self.iborIndex, self.spread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         mktAssetSwap)
+        fixedBondMktAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond2,
+            fixedBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         fixedBondMktAssetSwap2.setPricingEngine(swapEngine)
         fixedBondMktAssetSwapSpread2 = fixedBondMktAssetSwap2.fairSpread()
-        error2 = abs(fixedBondMktAssetSwapSpread2-
-                      100*fixedBondParAssetSwapSpread2/fixedBondMktFullPrice2)
+        error2 = abs(fixedBondMktAssetSwapSpread2 - 100 * fixedBondParAssetSwapSpread2 / fixedBondMktFullPrice2)
 
-        self.assertFalse(error2>tolerance,
+        self.assertFalse(
+            error2 > tolerance,
             "wrong asset swap spreads for fixed bond:"
-            + "\n  market ASW spread: " + str(fixedBondMktAssetSwapSpread2)
-            + "\n  par ASW spread:    " + str(fixedBondParAssetSwapSpread2)
-            + "\n  error:             " + str(error2)
-            + "\n  tolerance:         " + str(tolerance))
-        
+            + "\n  market ASW spread: "
+            + str(fixedBondMktAssetSwapSpread2)
+            + "\n  par ASW spread:    "
+            + str(fixedBondParAssetSwapSpread2)
+            + "\n  error:             "
+            + str(error2)
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
 
         ## FRN Underlying bond (Isin: IT0003543847 ISPIM 0 09/29/13)
         ## maturity doesn't occur on a business day
 
-        floatingBondSchedule1 = Schedule(Date(29,September,2003),
-                                       Date(29,September,2013),
-                                       Period(Semiannual), bondCalendar,
-                                       Unadjusted, Unadjusted,
-                                       DateGeneration.Backward, False)
+        floatingBondSchedule1 = ql.Schedule(
+            ql.Date(29, ql.September, 2003),
+            ql.Date(29, ql.September, 2013),
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
 
-        floatingBond1 = FloatingRateBond(settlementDays, self.faceAmount,
-                             floatingBondSchedule1,
-                             self.iborIndex, Actual360(),
-                             Following, fixingDays,
-                             [1], [0.0056],
-                             [],[],
-                             inArrears,
-                             100.0, Date(29,September,2003))
+        floatingBond1 = ql.FloatingRateBond(
+            settlementDays,
+            self.faceAmount,
+            floatingBondSchedule1,
+            self.iborIndex,
+            ql.Actual360(),
+            ql.Following,
+            fixingDays,
+            [1],
+            [0.0056],
+            [],
+            [],
+            inArrears,
+            100.0,
+            ql.Date(29, ql.September, 2003),
+        )
 
         floatingBond1.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond1.cashflows(), self.pricer)
-        self.iborIndex.addFixing(Date(27,March,2007), 0.0402)
+        ql.setCouponPricer(floatingBond1.cashflows(), self.pricer)
+        self.iborIndex.addFixing(ql.Date(27, ql.March, 2007), 0.0402)
         ## market price observed on 7th June 2007
-        floatingBondMktPrice1 = 101.64 
-        floatingBondMktFullPrice1 = floatingBondMktPrice1+floatingBond1.accruedAmount()
-        floatingBondParAssetSwap1 = AssetSwap(payFixedRate,
-                                            floatingBond1, floatingBondMktPrice1,
-                                            self.iborIndex, self.spread,
-                                            Schedule(),
-                                            self.iborIndex.dayCounter(),
-                                            parAssetSwap)
+        floatingBondMktPrice1 = 101.64
+        floatingBondMktFullPrice1 = floatingBondMktPrice1 + floatingBond1.accruedAmount()
+        floatingBondParAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond1,
+            floatingBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingBondParAssetSwap1.setPricingEngine(swapEngine)
         floatingBondParAssetSwapSpread1 = floatingBondParAssetSwap1.fairSpread()
-        floatingBondMktAssetSwap1 = AssetSwap(payFixedRate,
-                                            floatingBond1, floatingBondMktPrice1,
-                                            self.iborIndex, self.spread,
-                                            Schedule(),
-                                            self.iborIndex.dayCounter(),
-                                            mktAssetSwap)
+        floatingBondMktAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond1,
+            floatingBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         floatingBondMktAssetSwap1.setPricingEngine(swapEngine)
         floatingBondMktAssetSwapSpread1 = floatingBondMktAssetSwap1.fairSpread()
-        error3 =  abs(floatingBondMktAssetSwapSpread1-
-                      100*floatingBondParAssetSwapSpread1/floatingBondMktFullPrice1)
+        error3 = abs(
+            floatingBondMktAssetSwapSpread1 - 100 * floatingBondParAssetSwapSpread1 / floatingBondMktFullPrice1
+        )
 
-        self.assertFalse(error3>tolerance, 
+        self.assertFalse(
+            error3 > tolerance,
             "wrong asset swap spreads for floating bond:"
-            + "\n  market ASW spread: " + str(floatingBondMktAssetSwapSpread1)
-            + "\n  par ASW spread:    " + str(floatingBondParAssetSwapSpread1)
-            + "\n  error:             " + str(error3)
-            + "\n  tolerance:         " + str(tolerance))
-        
+            + "\n  market ASW spread: "
+            + str(floatingBondMktAssetSwapSpread1)
+            + "\n  par ASW spread:    "
+            + str(floatingBondParAssetSwapSpread1)
+            + "\n  error:             "
+            + str(error3)
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
 
         ## FRN Underlying bond (Isin: XS0090566539 COE 0 09/24/18)
         ## maturity occurs on a business day
 
-        floatingBondSchedule2 = Schedule (Date(24,September,2004),
-                                       Date(24,September,2018),
-                                       Period(Semiannual), bondCalendar,
-                                       ModifiedFollowing, ModifiedFollowing,
-                                       DateGeneration.Backward, False)
-        floatingBond2  = FloatingRateBond(settlementDays, self.faceAmount,
-                             floatingBondSchedule2,
-                             self.iborIndex, Actual360(),
-                             ModifiedFollowing, fixingDays,
-                             [1], [0.0025],
-                             [], [],
-                             inArrears,
-                             100.0, Date(24,September,2004))
+        floatingBondSchedule2 = ql.Schedule(
+            ql.Date(24, ql.September, 2004),
+            ql.Date(24, ql.September, 2018),
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.ModifiedFollowing,
+            ql.ModifiedFollowing,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        floatingBond2 = ql.FloatingRateBond(
+            settlementDays,
+            self.faceAmount,
+            floatingBondSchedule2,
+            self.iborIndex,
+            ql.Actual360(),
+            ql.ModifiedFollowing,
+            fixingDays,
+            [1],
+            [0.0025],
+            [],
+            [],
+            inArrears,
+            100.0,
+            ql.Date(24, ql.September, 2004),
+        )
 
         floatingBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond2.cashflows(), self.pricer)
-        self.iborIndex.addFixing(Date(22,March,2007), 0.04013)
+        ql.setCouponPricer(floatingBond2.cashflows(), self.pricer)
+        self.iborIndex.addFixing(ql.Date(22, ql.March, 2007), 0.04013)
         ## market price observed on 7th June 2007
-        floatingBondMktPrice2 = 101.248 
-        floatingBondMktFullPrice2 = floatingBondMktPrice2+floatingBond2.accruedAmount()
-        floatingBondParAssetSwap2 = AssetSwap (payFixedRate,
-                                            floatingBond2, floatingBondMktPrice2,
-                                            self.iborIndex, self.spread,
-                                            Schedule(),
-                                            self.iborIndex.dayCounter(),
-                                            parAssetSwap)
+        floatingBondMktPrice2 = 101.248
+        floatingBondMktFullPrice2 = floatingBondMktPrice2 + floatingBond2.accruedAmount()
+        floatingBondParAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond2,
+            floatingBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingBondParAssetSwap2.setPricingEngine(swapEngine)
         floatingBondParAssetSwapSpread2 = floatingBondParAssetSwap2.fairSpread()
-        floatingBondMktAssetSwap2 = AssetSwap(payFixedRate,
-                                            floatingBond2, floatingBondMktPrice2,
-                                            self.iborIndex, self.spread,
-                                            Schedule(),
-                                            self.iborIndex.dayCounter(),
-                                            mktAssetSwap)
+        floatingBondMktAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond2,
+            floatingBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         floatingBondMktAssetSwap2.setPricingEngine(swapEngine)
         floatingBondMktAssetSwapSpread2 = floatingBondMktAssetSwap2.fairSpread()
-        error4 = abs(floatingBondMktAssetSwapSpread2-
-                      100*floatingBondParAssetSwapSpread2/floatingBondMktFullPrice2)
+        error4 = abs(
+            floatingBondMktAssetSwapSpread2 - 100 * floatingBondParAssetSwapSpread2 / floatingBondMktFullPrice2
+        )
 
-        self.assertFalse(error4>tolerance , 
+        self.assertFalse(
+            error4 > tolerance,
             "wrong asset swap spreads for floating bond:"
-            + "\n  market ASW spread: " + str(floatingBondMktAssetSwapSpread2)
-            + "\n  par ASW spread:    " + str(floatingBondParAssetSwapSpread2)
-            + "\n  error:             " + str(error4)
-            + "\n  tolerance:         " + str(tolerance))
-        
+            + "\n  market ASW spread: "
+            + str(floatingBondMktAssetSwapSpread2)
+            + "\n  par ASW spread:    "
+            + str(floatingBondParAssetSwapSpread2)
+            + "\n  error:             "
+            + str(error4)
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
 
         ## CMS Underlying bond (Isin: XS0228052402 CRDIT 0 8/22/20)
         ## maturity doesn't occur on a business day
 
-        cmsBondSchedule1 = Schedule(Date(22,August,2005),
-                                  Date(22,August,2020),
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBond1 = CmsRateBond(settlementDays, self.faceAmount, cmsBondSchedule1,
-                        self.swapIndex, Thirty360(),
-                        Following, fixingDays,
-                        [1,1.0], [0.0],
-                        [0.055], [0.025],
-                        inArrears,
-                        100.0, Date(22,August,2005))
+        cmsBondSchedule1 = ql.Schedule(
+            ql.Date(22, ql.August, 2005),
+            ql.Date(22, ql.August, 2020),
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBond1 = ql.CmsRateBond(
+            settlementDays,
+            self.faceAmount,
+            cmsBondSchedule1,
+            self.swapIndex,
+            ql.Thirty360(),
+            ql.Following,
+            fixingDays,
+            [1, 1.0],
+            [0.0],
+            [0.055],
+            [0.025],
+            inArrears,
+            100.0,
+            ql.Date(22, ql.August, 2005),
+        )
 
         cmsBond1.setPricingEngine(bondEngine)
 
-        setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(18,August,2006), 0.04158)
+        ql.setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(18, ql.August, 2006), 0.04158)
         cmsBondMktPrice1 = 88.45  ## market price observed on 7th June 2007
-        cmsBondMktFullPrice1 = cmsBondMktPrice1+cmsBond1.accruedAmount()
-        cmsBondParAssetSwap1 = AssetSwap(payFixedRate,
-                                       cmsBond1, cmsBondMktPrice1,
-                                       self.iborIndex, self.spread,
-                                       Schedule(),
-                                       self.iborIndex.dayCounter(),
-                                       parAssetSwap)
+        cmsBondMktFullPrice1 = cmsBondMktPrice1 + cmsBond1.accruedAmount()
+        cmsBondParAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond1,
+            cmsBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsBondParAssetSwap1.setPricingEngine(swapEngine)
         cmsBondParAssetSwapSpread1 = cmsBondParAssetSwap1.fairSpread()
-        cmsBondMktAssetSwap1 = AssetSwap(payFixedRate,
-                                       cmsBond1, cmsBondMktPrice1,
-                                       self.iborIndex, self.spread,
-                                       Schedule(),
-                                       self.iborIndex.dayCounter(),
-                                       mktAssetSwap)
+        cmsBondMktAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond1,
+            cmsBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         cmsBondMktAssetSwap1.setPricingEngine(swapEngine)
         cmsBondMktAssetSwapSpread1 = cmsBondMktAssetSwap1.fairSpread()
-        error5 = abs(cmsBondMktAssetSwapSpread1-
-                      100*cmsBondParAssetSwapSpread1/cmsBondMktFullPrice1)
+        error5 = abs(cmsBondMktAssetSwapSpread1 - 100 * cmsBondParAssetSwapSpread1 / cmsBondMktFullPrice1)
 
-        self.assertFalse(error5>tolerance, 
+        self.assertFalse(
+            error5 > tolerance,
             "wrong asset swap spreads for cms bond:"
-            + "\n  market ASW spread: " + str(cmsBondMktAssetSwapSpread1)
-            + "\n  par ASW spread:    " + str(cmsBondParAssetSwapSpread1)
-            + "\n  error:             " + str(error5)
-            + "\n  tolerance:         " + str(tolerance))
-        
+            + "\n  market ASW spread: "
+            + str(cmsBondMktAssetSwapSpread1)
+            + "\n  par ASW spread:    "
+            + str(cmsBondParAssetSwapSpread1)
+            + "\n  error:             "
+            + str(error5)
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
 
-         ## CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
-         ## maturity occurs on a business day
+        ## CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
+        ## maturity occurs on a business day
 
-        cmsBondSchedule2 = Schedule(Date(6,May,2005),
-                                  Date(6,May,2015),
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBond2 = CmsRateBond(settlementDays, self.faceAmount, cmsBondSchedule2,
-                        self.swapIndex, Thirty360(),
-                        Following, fixingDays,
-                        [0.84], [0.0],
-                        [], [],
-                        inArrears,
-                        100.0, Date(6,May,2005))
+        cmsBondSchedule2 = ql.Schedule(
+            ql.Date(6, ql.May, 2005),
+            ql.Date(6, ql.May, 2015),
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBond2 = ql.CmsRateBond(
+            settlementDays,
+            self.faceAmount,
+            cmsBondSchedule2,
+            self.swapIndex,
+            ql.Thirty360(),
+            ql.Following,
+            fixingDays,
+            [0.84],
+            [0.0],
+            [],
+            [],
+            inArrears,
+            100.0,
+            ql.Date(6, ql.May, 2005),
+        )
 
         cmsBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(4,May,2006), 0.04217)
+        ql.setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(4, ql.May, 2006), 0.04217)
         cmsBondMktPrice2 = 94.08  ## market price observed on 7th June 2007
-        cmsBondMktFullPrice2 = cmsBondMktPrice2+cmsBond2.accruedAmount()
-        cmsBondParAssetSwap2 = AssetSwap(payFixedRate,
-                                       cmsBond2, cmsBondMktPrice2,
-                                       self.iborIndex, self.spread,
-                                       Schedule(),
-                                       self.iborIndex.dayCounter(),
-                                       parAssetSwap)
+        cmsBondMktFullPrice2 = cmsBondMktPrice2 + cmsBond2.accruedAmount()
+        cmsBondParAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond2,
+            cmsBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsBondParAssetSwap2.setPricingEngine(swapEngine)
         cmsBondParAssetSwapSpread2 = cmsBondParAssetSwap2.fairSpread()
-        cmsBondMktAssetSwap2 = AssetSwap(payFixedRate,
-                                       cmsBond2, cmsBondMktPrice2,
-                                       self.iborIndex, self.spread,
-                                       Schedule(),
-                                       self.iborIndex.dayCounter(),
-                                       mktAssetSwap)
+        cmsBondMktAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond2,
+            cmsBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         cmsBondMktAssetSwap2.setPricingEngine(swapEngine)
         cmsBondMktAssetSwapSpread2 = cmsBondMktAssetSwap2.fairSpread()
-        error6 = abs(cmsBondMktAssetSwapSpread2-
-                      100*cmsBondParAssetSwapSpread2/cmsBondMktFullPrice2)
+        error6 = abs(cmsBondMktAssetSwapSpread2 - 100 * cmsBondParAssetSwapSpread2 / cmsBondMktFullPrice2)
 
-        self.assertFalse(error6>tolerance,  
+        self.assertFalse(
+            error6 > tolerance,
             "wrong asset swap spreads for cms bond:"
-            + "\n  market ASW spread: " + str(cmsBondMktAssetSwapSpread2)
-            + "\n  par ASW spread:    " + str(cmsBondParAssetSwapSpread2)
-            + "\n  error:             " + str(error6)
-            + "\n  tolerance:         " + str(tolerance))
-        
+            + "\n  market ASW spread: "
+            + str(cmsBondMktAssetSwapSpread2)
+            + "\n  par ASW spread:    "
+            + str(cmsBondParAssetSwapSpread2)
+            + "\n  error:             "
+            + str(error6)
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
 
         ## Zero Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
         ## maturity doesn't occur on a business day
 
-        zeroCpnBond1 = ZeroCouponBond(settlementDays, bondCalendar, self.faceAmount,
-                           Date(20,December,2015),
-                           Following,
-                           100.0, Date(19,December,1985))
+        zeroCpnBond1 = ql.ZeroCouponBond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            ql.Date(20, ql.December, 2015),
+            ql.Following,
+            100.0,
+            ql.Date(19, ql.December, 1985),
+        )
 
         zeroCpnBond1.setPricingEngine(bondEngine)
 
         ## market price observed on 12th June 2007
-        zeroCpnBondMktPrice1 = 70.436 
-        zeroCpnBondMktFullPrice1 = zeroCpnBondMktPrice1+zeroCpnBond1.accruedAmount()
-        zeroCpnBondParAssetSwap1 = AssetSwap(payFixedRate,zeroCpnBond1,
-                                           zeroCpnBondMktPrice1,
-                                           self.iborIndex, self.spread,
-                                           Schedule(),
-                                           self.iborIndex.dayCounter(),
-                                           parAssetSwap)
+        zeroCpnBondMktPrice1 = 70.436
+        zeroCpnBondMktFullPrice1 = zeroCpnBondMktPrice1 + zeroCpnBond1.accruedAmount()
+        zeroCpnBondParAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond1,
+            zeroCpnBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnBondParAssetSwap1.setPricingEngine(swapEngine)
         zeroCpnBondParAssetSwapSpread1 = zeroCpnBondParAssetSwap1.fairSpread()
-        zeroCpnBondMktAssetSwap1 = AssetSwap(payFixedRate,zeroCpnBond1,
-                                           zeroCpnBondMktPrice1,
-                                           self.iborIndex, self.spread,
-                                           Schedule(),
-                                           self.iborIndex.dayCounter(),
-                                           mktAssetSwap)
+        zeroCpnBondMktAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond1,
+            zeroCpnBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         zeroCpnBondMktAssetSwap1.setPricingEngine(swapEngine)
         zeroCpnBondMktAssetSwapSpread1 = zeroCpnBondMktAssetSwap1.fairSpread()
-        error7 = abs(zeroCpnBondMktAssetSwapSpread1-
-                      100*zeroCpnBondParAssetSwapSpread1/zeroCpnBondMktFullPrice1)
+        error7 = abs(zeroCpnBondMktAssetSwapSpread1 - 100 * zeroCpnBondParAssetSwapSpread1 / zeroCpnBondMktFullPrice1)
 
-        self.assertFalse(error7>tolerance, 
+        self.assertFalse(
+            error7 > tolerance,
             "wrong asset swap spreads for zero cpn bond:"
-            + "\n  market ASW spread: " + str(zeroCpnBondMktAssetSwapSpread1)
-            + "\n  par ASW spread:    " + str(zeroCpnBondParAssetSwapSpread1)
-            + "\n  error:             " + str(error7)
-            + "\n  tolerance:         " + str(tolerance))
-        
+            + "\n  market ASW spread: "
+            + str(zeroCpnBondMktAssetSwapSpread1)
+            + "\n  par ASW spread:    "
+            + str(zeroCpnBondParAssetSwapSpread1)
+            + "\n  error:             "
+            + str(error7)
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
 
         ## Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
         ## maturity occurs on a business day
 
-        zeroCpnBond2 =ZeroCouponBond(settlementDays, bondCalendar, self.faceAmount,
-                           Date(17,February,2028),
-                           Following,
-                           100.0, Date(17,February,1998))
+        zeroCpnBond2 = ql.ZeroCouponBond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            ql.Date(17, ql.February, 2028),
+            ql.Following,
+            100.0,
+            ql.Date(17, ql.February, 1998),
+        )
 
         zeroCpnBond2.setPricingEngine(bondEngine)
 
         ## zeroCpnBondPrice2 = zeroCpnBond2.cleanPrice()
 
         ## market price observed on 12th June 2007
-        zeroCpnBondMktPrice2 = 35.160 
-        zeroCpnBondMktFullPrice2 = zeroCpnBondMktPrice2+zeroCpnBond2.accruedAmount()
-        zeroCpnBondParAssetSwap2 = AssetSwap(payFixedRate,zeroCpnBond2,
-                                           zeroCpnBondMktPrice2,
-                                           self.iborIndex, self.spread,
-                                           Schedule(),
-                                           self.iborIndex.dayCounter(),
-                                           parAssetSwap)
+        zeroCpnBondMktPrice2 = 35.160
+        zeroCpnBondMktFullPrice2 = zeroCpnBondMktPrice2 + zeroCpnBond2.accruedAmount()
+        zeroCpnBondParAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond2,
+            zeroCpnBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnBondParAssetSwap2.setPricingEngine(swapEngine)
         zeroCpnBondParAssetSwapSpread2 = zeroCpnBondParAssetSwap2.fairSpread()
-        zeroCpnBondMktAssetSwap2 = AssetSwap(payFixedRate,zeroCpnBond2,
-                                           zeroCpnBondMktPrice2,
-                                           self.iborIndex, self.spread,
-                                           Schedule(),
-                                           self.iborIndex.dayCounter(),
-                                           mktAssetSwap)
+        zeroCpnBondMktAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond2,
+            zeroCpnBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         zeroCpnBondMktAssetSwap2.setPricingEngine(swapEngine)
         zeroCpnBondMktAssetSwapSpread2 = zeroCpnBondMktAssetSwap2.fairSpread()
-        error8 = abs(zeroCpnBondMktAssetSwapSpread2-
-                      100*zeroCpnBondParAssetSwapSpread2/zeroCpnBondMktFullPrice2)
+        error8 = abs(zeroCpnBondMktAssetSwapSpread2 - 100 * zeroCpnBondParAssetSwapSpread2 / zeroCpnBondMktFullPrice2)
 
-        self.assertFalse(error8>tolerance, 
+        self.assertFalse(
+            error8 > tolerance,
             "wrong asset swap spreads for zero cpn bond:"
-            + "\n  market ASW spread: " + str(zeroCpnBondMktAssetSwapSpread2)
-            + "\n  par ASW spread:    " + str(zeroCpnBondParAssetSwapSpread2)
-            + "\n  error:             " + str(error8)
-            + "\n  tolerance:         " + str(tolerance))
-        
+            + "\n  market ASW spread: "
+            + str(zeroCpnBondMktAssetSwapSpread2)
+            + "\n  par ASW spread:    "
+            + str(zeroCpnBondParAssetSwapSpread2)
+            + "\n  error:             "
+            + str(error8)
+            + "\n  tolerance:         "
+            + str(tolerance),
+        )
 
-
-
-    def testZSpread(self) :
+    def testZSpread(self):
         """Testing clean and dirty price with null Z-spread against theoretical prices..."""
-        
-        bondCalendar = TARGET()
+
+        bondCalendar = ql.TARGET()
         settlementDays = 3
         fixingDays = 2
         inArrears = False
@@ -1107,282 +1623,445 @@ class AssetSwapTest(unittest.TestCase):
         ## Fixed bond (Isin: DE0001135275 DBR 4 01/04/37)
         ## maturity doesn't occur on a business day
 
-        fixedBondSchedule1 = Schedule(Date(4,January,2005),
-                                    Date(4,January,2037),
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBond1 = FixedRateBond(settlementDays, self.faceAmount, fixedBondSchedule1,
-                          [0.04],
-                          ActualActual(ActualActual.ISDA), Following,
-                          100.0, Date(4,January,2005))
+        fixedBondSchedule1 = ql.Schedule(
+            ql.Date(4, ql.January, 2005),
+            ql.Date(4, ql.January, 2037),
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBond1 = ql.FixedRateBond(
+            settlementDays,
+            self.faceAmount,
+            fixedBondSchedule1,
+            [0.04],
+            ql.ActualActual(ql.ActualActual.ISDA),
+            ql.Following,
+            100.0,
+            ql.Date(4, ql.January, 2005),
+        )
 
-        bondEngine = DiscountingBondEngine(self.termStructure)
+        bondEngine = ql.DiscountingBondEngine(self.termStructure)
         fixedBond1.setPricingEngine(bondEngine)
 
         fixedBondImpliedValue1 = fixedBond1.cleanPrice()
-        fixedBondSettlementDate1= fixedBond1.settlementDate()
+        fixedBondSettlementDate1 = fixedBond1.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YC...
-        fixedBondCleanPrice1 = cleanPriceFromZSpread(fixedBond1,self.yieldCurve, self.spread,
-             Actual365Fixed(), self.compounding, Annual,
-             fixedBondSettlementDate1)
+        fixedBondCleanPrice1 = ql.cleanPriceFromZSpread(
+            fixedBond1,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Annual,
+            fixedBondSettlementDate1,
+        )
 
         tolerance = 1.0e-13
-        error1 = abs(fixedBondImpliedValue1-fixedBondCleanPrice1)
-        self.assertFalse(error1>tolerance, 
+        error1 = abs(fixedBondImpliedValue1 - fixedBondCleanPrice1)
+        self.assertFalse(
+            error1 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  market asset swap spread: " + str(fixedBondImpliedValue1)
-            + "\n  par asset swap spread: " + str(fixedBondCleanPrice1)
-            + "\n  error:                 " + str(error1)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  market asset swap spread: "
+            + str(fixedBondImpliedValue1)
+            + "\n  par asset swap spread: "
+            + str(fixedBondCleanPrice1)
+            + "\n  error:                 "
+            + str(error1)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
         ## Fixed bond (Isin: IT0006527060 IBRD 5 02/05/19)
         ## maturity occurs on a business day
 
-        fixedBondSchedule2 = Schedule (Date(5,February,2005),
-                                    Date(5,February,2019),
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBond2 = FixedRateBond(settlementDays, self.faceAmount, fixedBondSchedule2,
-                          [0.05],
-                          Thirty360(Thirty360.BondBasis), Following,
-                          100.0, Date(5,February,2005))
+        fixedBondSchedule2 = ql.Schedule(
+            ql.Date(5, ql.February, 2005),
+            ql.Date(5, ql.February, 2019),
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBond2 = ql.FixedRateBond(
+            settlementDays,
+            self.faceAmount,
+            fixedBondSchedule2,
+            [0.05],
+            ql.Thirty360(ql.Thirty360.BondBasis),
+            ql.Following,
+            100.0,
+            ql.Date(5, ql.February, 2005),
+        )
 
         fixedBond2.setPricingEngine(bondEngine)
 
         fixedBondImpliedValue2 = fixedBond2.cleanPrice()
-        fixedBondSettlementDate2= fixedBond2.settlementDate()
+        fixedBondSettlementDate2 = fixedBond2.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YieldCurve
-        fixedBondCleanPrice2 = cleanPriceFromZSpread(
-             fixedBond2, self.yieldCurve, self.spread,
-             Actual365Fixed(), self.compounding, Annual,
-             fixedBondSettlementDate2)
-        error3 = abs(fixedBondImpliedValue2-fixedBondCleanPrice2)
-        self.assertFalse(error3>tolerance, 
+        fixedBondCleanPrice2 = ql.cleanPriceFromZSpread(
+            fixedBond2,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Annual,
+            fixedBondSettlementDate2,
+        )
+        error3 = abs(fixedBondImpliedValue2 - fixedBondCleanPrice2)
+        self.assertFalse(
+            error3 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  market asset swap spread: " + str(fixedBondImpliedValue2)
-            + "\n  par asset swap spread: " + str(fixedBondCleanPrice2)
-            + "\n  error:                 " + str(error3)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  market asset swap spread: "
+            + str(fixedBondImpliedValue2)
+            + "\n  par asset swap spread: "
+            + str(fixedBondCleanPrice2)
+            + "\n  error:                 "
+            + str(error3)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## FRN bond (Isin: IT0003543847 ISPIM 0 09/29/13)
         ## maturity doesn't occur on a business day
 
-        floatingBondSchedule1 = Schedule(Date(29,September,2003),
-                                       Date(29,September,2013),
-                                       Period(Semiannual), bondCalendar,
-                                       Unadjusted, Unadjusted,
-                                       DateGeneration.Backward, False)
+        floatingBondSchedule1 = ql.Schedule(
+            ql.Date(29, ql.September, 2003),
+            ql.Date(29, ql.September, 2013),
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
 
-        floatingBond1 = FloatingRateBond(settlementDays, self.faceAmount,
-                             floatingBondSchedule1,
-                             self.iborIndex, Actual360(),
-                             Following, fixingDays,
-                             [1], [0.0056],
-                             [], [],
-                             inArrears,
-                             100.0, Date(29,September,2003))
+        floatingBond1 = ql.FloatingRateBond(
+            settlementDays,
+            self.faceAmount,
+            floatingBondSchedule1,
+            self.iborIndex,
+            ql.Actual360(),
+            ql.Following,
+            fixingDays,
+            [1],
+            [0.0056],
+            [],
+            [],
+            inArrears,
+            100.0,
+            ql.Date(29, ql.September, 2003),
+        )
 
         floatingBond1.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond1.cashflows(), self.pricer)
-        self.iborIndex.addFixing(Date(27,March,2007), 0.0402)
+        ql.setCouponPricer(floatingBond1.cashflows(), self.pricer)
+        self.iborIndex.addFixing(ql.Date(27, ql.March, 2007), 0.0402)
         floatingBondImpliedValue1 = floatingBond1.cleanPrice()
-        floatingBondSettlementDate1= floatingBond1.settlementDate()
+        floatingBondSettlementDate1 = floatingBond1.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YieldCurve
-        floatingBondCleanPrice1 = cleanPriceFromZSpread(
-            floatingBond1, self.yieldCurve, self.spread,
-            Actual365Fixed(), self.compounding, Semiannual,
-            fixedBondSettlementDate1)
-        error5 = abs(floatingBondImpliedValue1-floatingBondCleanPrice1)
-        self.assertFalse(error5>tolerance,  
+        floatingBondCleanPrice1 = ql.cleanPriceFromZSpread(
+            floatingBond1,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Semiannual,
+            floatingBondSettlementDate1,
+        )
+        error5 = abs(floatingBondImpliedValue1 - floatingBondCleanPrice1)
+        self.assertFalse(
+            error5 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  market asset swap spread: " + str(floatingBondImpliedValue1)
-            + "\n  par asset swap spread: " + str(floatingBondCleanPrice1)
-            + "\n  error:                 " + str(error5)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  market asset swap spread: "
+            + str(floatingBondImpliedValue1)
+            + "\n  par asset swap spread: "
+            + str(floatingBondCleanPrice1)
+            + "\n  error:                 "
+            + str(error5)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## FRN bond (Isin: XS0090566539 COE 0 09/24/18)
         ## maturity occurs on a business day
 
-        floatingBondSchedule2 = Schedule(Date(24,September,2004),
-                                       Date(24,September,2018),
-                                       Period(Semiannual), bondCalendar,
-                                       ModifiedFollowing, ModifiedFollowing,
-                                       DateGeneration.Backward, False)
-        floatingBond2 = FloatingRateBond(settlementDays, self.faceAmount,
-                             floatingBondSchedule2,
-                             self.iborIndex, Actual360(),
-                             ModifiedFollowing, fixingDays,
-                             [1], [0.0025],
-                             [], [],
-                             inArrears,
-                             100.0, Date(24,September,2004))
+        floatingBondSchedule2 = ql.Schedule(
+            ql.Date(24, ql.September, 2004),
+            ql.Date(24, ql.September, 2018),
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.ModifiedFollowing,
+            ql.ModifiedFollowing,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        floatingBond2 = ql.FloatingRateBond(
+            settlementDays,
+            self.faceAmount,
+            floatingBondSchedule2,
+            self.iborIndex,
+            ql.Actual360(),
+            ql.ModifiedFollowing,
+            fixingDays,
+            [1],
+            [0.0025],
+            [],
+            [],
+            inArrears,
+            100.0,
+            ql.Date(24, ql.September, 2004),
+        )
 
         floatingBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond2.cashflows(), self.pricer)
-        self.iborIndex.addFixing(Date(22,March,2007), 0.04013)
+        ql.setCouponPricer(floatingBond2.cashflows(), self.pricer)
+        self.iborIndex.addFixing(ql.Date(22, ql.March, 2007), 0.04013)
         floatingBondImpliedValue2 = floatingBond2.cleanPrice()
-        floatingBondSettlementDate2= floatingBond2.settlementDate()
+        floatingBondSettlementDate2 = floatingBond2.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YieldCurve
-        floatingBondCleanPrice2 = cleanPriceFromZSpread(
-            floatingBond2, self.yieldCurve,
-            self.spread, Actual365Fixed(), self.compounding, Semiannual,
-            fixedBondSettlementDate1)
-        error7 = abs(floatingBondImpliedValue2-floatingBondCleanPrice2)
-        self.assertFalse(error7>tolerance, 
+        floatingBondCleanPrice2 = ql.cleanPriceFromZSpread(
+            floatingBond2,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Semiannual,
+            floatingBondSettlementDate2,
+        )
+        error7 = abs(floatingBondImpliedValue2 - floatingBondCleanPrice2)
+        self.assertFalse(
+            error7 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  market asset swap spread: " + str(floatingBondImpliedValue2)
-            + "\n  par asset swap spread: " + str(floatingBondCleanPrice2)
-            + "\n  error:                 " + str(error7)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  market asset swap spread: "
+            + str(floatingBondImpliedValue2)
+            + "\n  par asset swap spread: "
+            + str(floatingBondCleanPrice2)
+            + "\n  error:                 "
+            + str(error7)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         #### CMS bond (Isin: XS0228052402 CRDIT 0 8/22/20)
         #### maturity doesn't occur on a business day
 
-        cmsBondSchedule1 = Schedule(Date(22,August,2005),
-                                  Date(22,August,2020),
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBond1 = CmsRateBond(settlementDays, self.faceAmount, cmsBondSchedule1,
-                        self.swapIndex, Thirty360(),
-                        Following, fixingDays,
-                        [1.0], [0.0],
-                        [0.055], [0.025],
-                        inArrears,
-                        100.0, Date(22,August,2005))
+        cmsBondSchedule1 = ql.Schedule(
+            ql.Date(22, ql.August, 2005),
+            ql.Date(22, ql.August, 2020),
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBond1 = ql.CmsRateBond(
+            settlementDays,
+            self.faceAmount,
+            cmsBondSchedule1,
+            self.swapIndex,
+            ql.Thirty360(),
+            ql.Following,
+            fixingDays,
+            [1.0],
+            [0.0],
+            [0.055],
+            [0.025],
+            inArrears,
+            100.0,
+            ql.Date(22, ql.August, 2005),
+        )
 
         cmsBond1.setPricingEngine(bondEngine)
 
-        setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(18,August,2006), 0.04158)
+        ql.setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(18, ql.August, 2006), 0.04158)
         cmsBondImpliedValue1 = cmsBond1.cleanPrice()
-        cmsBondSettlementDate1= cmsBond1.settlementDate()
+        cmsBondSettlementDate1 = cmsBond1.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YieldCurve
-        cmsBondCleanPrice1 = cleanPriceFromZSpread(
-            cmsBond1, self.yieldCurve, self.spread,
-            Actual365Fixed(), self.compounding, Annual,
-            cmsBondSettlementDate1)
-        error9 = abs(cmsBondImpliedValue1-cmsBondCleanPrice1)
-        self.assertFalse(error9>tolerance, 
+        cmsBondCleanPrice1 = ql.cleanPriceFromZSpread(
+            cmsBond1,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Annual,
+            cmsBondSettlementDate1,
+        )
+        error9 = abs(cmsBondImpliedValue1 - cmsBondCleanPrice1)
+        self.assertFalse(
+            error9 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  market asset swap spread: " + str(cmsBondImpliedValue1)
-            + "\n  par asset swap spread: " + str(cmsBondCleanPrice1)
-            + "\n  error:                 " + str(error9)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  market asset swap spread: "
+            + str(cmsBondImpliedValue1)
+            + "\n  par asset swap spread: "
+            + str(cmsBondCleanPrice1)
+            + "\n  error:                 "
+            + str(error9)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## CMS bond (Isin: XS0218766664 ISPIM 0 5/6/15)
         ## maturity occurs on a business day
 
-        cmsBondSchedule2 = Schedule(Date(6,May,2005),
-                                  Date(6,May,2015),
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBond2 = CmsRateBond(settlementDays, self.faceAmount, cmsBondSchedule2,
-                        self.swapIndex, Thirty360(),
-                        Following, fixingDays,
-                        [0.84], [0.0],
-                        [], [],
-                        inArrears,
-                        100.0, Date(6,May,2005))
+        cmsBondSchedule2 = ql.Schedule(
+            ql.Date(6, ql.May, 2005),
+            ql.Date(6, ql.May, 2015),
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBond2 = ql.CmsRateBond(
+            settlementDays,
+            self.faceAmount,
+            cmsBondSchedule2,
+            self.swapIndex,
+            ql.Thirty360(),
+            ql.Following,
+            fixingDays,
+            [0.84],
+            [0.0],
+            [],
+            [],
+            inArrears,
+            100.0,
+            ql.Date(6, ql.May, 2005),
+        )
 
         cmsBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(4,May,2006), 0.04217)
+        ql.setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(4, ql.May, 2006), 0.04217)
         cmsBondImpliedValue2 = cmsBond2.cleanPrice()
-        cmsBondSettlementDate2= cmsBond2.settlementDate()
+        cmsBondSettlementDate2 = cmsBond2.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YieldCurve
-        cmsBondCleanPrice2 = cleanPriceFromZSpread(
-             cmsBond2, self.yieldCurve, self.spread,
-             Actual365Fixed(), self.compounding, Annual,
-             cmsBondSettlementDate2)
-        error11 = abs(cmsBondImpliedValue2-cmsBondCleanPrice2)
-        self.assertFalse(error11>tolerance, 
+        cmsBondCleanPrice2 = ql.cleanPriceFromZSpread(
+            cmsBond2,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Annual,
+            cmsBondSettlementDate2,
+        )
+        error11 = abs(cmsBondImpliedValue2 - cmsBondCleanPrice2)
+        self.assertFalse(
+            error11 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  market asset swap spread: " + str(cmsBondImpliedValue2)
-            + "\n  par asset swap spread: " + str(cmsBondCleanPrice2)
-            + "\n  error:                 " + str(error11)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  market asset swap spread: "
+            + str(cmsBondImpliedValue2)
+            + "\n  par asset swap spread: "
+            + str(cmsBondCleanPrice2)
+            + "\n  error:                 "
+            + str(error11)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## Zero-Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
         ## maturity doesn't occur on a business day
 
-        zeroCpnBond1 = ZeroCouponBond(settlementDays, bondCalendar, self.faceAmount,
-                           Date(20,December,2015),
-                           Following,
-                           100.0, Date(19,December,1985))
+        zeroCpnBond1 = ql.ZeroCouponBond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            ql.Date(20, ql.December, 2015),
+            ql.Following,
+            100.0,
+            ql.Date(19, ql.December, 1985),
+        )
 
         zeroCpnBond1.setPricingEngine(bondEngine)
 
         zeroCpnBondImpliedValue1 = zeroCpnBond1.cleanPrice()
-        zeroCpnBondSettlementDate1= zeroCpnBond1.settlementDate()
+        zeroCpnBondSettlementDate1 = zeroCpnBond1.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YieldCurve
-        zeroCpnBondCleanPrice1 = cleanPriceFromZSpread(zeroCpnBond1,
-                                  self.yieldCurve,
-                                  self.spread,
-                                  Actual365Fixed(),
-                                  self.compounding, Annual,
-                                  zeroCpnBondSettlementDate1)
-        error13 = abs(zeroCpnBondImpliedValue1-zeroCpnBondCleanPrice1)
-        self.assertFalse(error13>tolerance, 
+        zeroCpnBondCleanPrice1 = ql.cleanPriceFromZSpread(
+            zeroCpnBond1,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Annual,
+            zeroCpnBondSettlementDate1,
+        )
+        error13 = abs(zeroCpnBondImpliedValue1 - zeroCpnBondCleanPrice1)
+        self.assertFalse(
+            error13 > tolerance,
             "wrong clean price for zero coupon bond:"
-            + "\n  zero cpn implied value: " + str(zeroCpnBondImpliedValue1)
-            + "\n  zero cpn price: " + str(zeroCpnBondCleanPrice1)
-            + "\n  error:                 " + str(error13)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  zero cpn implied value: "
+            + str(zeroCpnBondImpliedValue1)
+            + "\n  zero cpn price: "
+            + str(zeroCpnBondCleanPrice1)
+            + "\n  error:                 "
+            + str(error13)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
         ## maturity doesn't occur on a business day
 
-        zeroCpnBond2 = ZeroCouponBond(settlementDays, bondCalendar, self.faceAmount,
-                           Date(17,February,2028),
-                           Following,
-                           100.0, Date(17,February,1998))
+        zeroCpnBond2 = ql.ZeroCouponBond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            ql.Date(17, ql.February, 2028),
+            ql.Following,
+            100.0,
+            ql.Date(17, ql.February, 1998),
+        )
 
         zeroCpnBond2.setPricingEngine(bondEngine)
 
         zeroCpnBondImpliedValue2 = zeroCpnBond2.cleanPrice()
-        zeroCpnBondSettlementDate2= zeroCpnBond2.settlementDate()
+        zeroCpnBondSettlementDate2 = zeroCpnBond2.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YieldCurve
-        zeroCpnBondCleanPrice2 = cleanPriceFromZSpread(zeroCpnBond2,
-                                  self.yieldCurve,
-                                  self.spread,
-                                  Actual365Fixed(),
-                                  self.compounding, Annual,
-                                  zeroCpnBondSettlementDate2)
-        error15 = abs(zeroCpnBondImpliedValue2-zeroCpnBondCleanPrice2)
-        self.assertFalse(error15>tolerance,
+        zeroCpnBondCleanPrice2 = ql.cleanPriceFromZSpread(
+            zeroCpnBond2,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Annual,
+            zeroCpnBondSettlementDate2,
+        )
+        error15 = abs(zeroCpnBondImpliedValue2 - zeroCpnBondCleanPrice2)
+        self.assertFalse(
+            error15 > tolerance,
             "wrong clean price for zero coupon bond:"
-            + "\n  zero cpn implied value: " + str(zeroCpnBondImpliedValue2)
-            + "\n  zero cpn price: " + str(zeroCpnBondCleanPrice2)
-            + "\n  error:                 " + str(error15)
-            + "\n  tolerance:             " + str(tolerance))
-        
-
+            + "\n  zero cpn implied value: "
+            + str(zeroCpnBondImpliedValue2)
+            + "\n  zero cpn price: "
+            + str(zeroCpnBondCleanPrice2)
+            + "\n  error:                 "
+            + str(error15)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
     def testGenericBondImplied(self):
         """Testing implied generic-bond value against asset-swap fair price with null spread..."""
 
-        bondCalendar = TARGET()
+        bondCalendar = ql.TARGET()
         settlementDays = 3
         fixingDays = 2
         payFixedRate = True
@@ -1391,314 +2070,504 @@ class AssetSwapTest(unittest.TestCase):
 
         ## Fixed Underlying bond (Isin: DE0001135275 DBR 4 01/04/37)
         ## maturity doesn't occur on a business day
-        fixedBondStartDate1 = Date(4,January,2005)
-        fixedBondMaturityDate1 = Date(4,January,2037)
-        fixedBondSchedule1 = Schedule(fixedBondStartDate1,
-                                    fixedBondMaturityDate1,
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBondLeg1 = list(FixedRateLeg(fixedBondSchedule1,
-                        ActualActual(ActualActual.ISDA),
-                        [self.faceAmount],
-                        [0.04]))
-        fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1,
-                                                        Following)
-        fixedBondLeg1.append(SimpleCashFlow(100.0, fixedbondRedemption1))
-        fixedBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 fixedBondMaturityDate1, fixedBondStartDate1,
-                 tuple(fixedBondLeg1))
-        bondEngine = DiscountingBondEngine(self.termStructure)
-        swapEngine = DiscountingSwapEngine(self.termStructure,True)
+        fixedBondStartDate1 = ql.Date(4, ql.January, 2005)
+        fixedBondMaturityDate1 = ql.Date(4, ql.January, 2037)
+        fixedBondSchedule1 = ql.Schedule(
+            fixedBondStartDate1,
+            fixedBondMaturityDate1,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBondLeg1 = list(
+            ql.FixedRateLeg(fixedBondSchedule1, ql.ActualActual(ql.ActualActual.ISDA), [self.faceAmount], [0.04])
+        )
+        fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1, ql.Following)
+        fixedBondLeg1.append(ql.SimpleCashFlow(100.0, fixedbondRedemption1))
+        fixedBond1 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            fixedBondMaturityDate1,
+            fixedBondStartDate1,
+            tuple(fixedBondLeg1),
+        )
+        bondEngine = ql.DiscountingBondEngine(self.termStructure)
+        swapEngine = ql.DiscountingSwapEngine(self.termStructure, True)
         fixedBond1.setPricingEngine(bondEngine)
 
         fixedBondPrice1 = fixedBond1.cleanPrice()
-        fixedBondAssetSwap1 = AssetSwap(payFixedRate,
-                                      fixedBond1, fixedBondPrice1,
-                                      self.iborIndex, self.spread,
-                                      Schedule(),
-                                      self.iborIndex.dayCounter(),
-                                      parAssetSwap)
+        fixedBondAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond1,
+            fixedBondPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedBondAssetSwap1.setPricingEngine(swapEngine)
         fixedBondAssetSwapPrice1 = fixedBondAssetSwap1.fairCleanPrice()
         tolerance = 1.0e-13
-        error1 = abs(fixedBondAssetSwapPrice1-fixedBondPrice1)
+        error1 = abs(fixedBondAssetSwapPrice1 - fixedBondPrice1)
 
-        self.assertFalse(error1>tolerance, 
+        self.assertFalse(
+            error1 > tolerance,
             "wrong zero spread asset swap price for fixed bond:"
-            + "\n  bond's clean price:    " + str(fixedBondPrice1)
-            + "\n  asset swap fair price: " + str(fixedBondAssetSwapPrice1)
-            + "\n  error:                 " + str(error1)
-            + "\n  tolerance:             " + str(tolerance))
-
+            + "\n  bond's clean price:    "
+            + str(fixedBondPrice1)
+            + "\n  asset swap fair price: "
+            + str(fixedBondAssetSwapPrice1)
+            + "\n  error:                 "
+            + str(error1)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## Fixed Underlying bond (Isin: IT0006527060 IBRD 5 02/05/19)
         ## maturity occurs on a business day
-        fixedBondStartDate2 = Date(5,February,2005)
-        fixedBondMaturityDate2 = Date(5,February,2019)
-        fixedBondSchedule2 = Schedule(fixedBondStartDate2,
-                                    fixedBondMaturityDate2,
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBondLeg2 = list(FixedRateLeg(fixedBondSchedule2,Thirty360(Thirty360.BondBasis),
-                                      [self.faceAmount],[0.05]))
-        fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2,Following)
-        fixedBondLeg2.append(SimpleCashFlow(100.0, fixedbondRedemption2))
-        fixedBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 fixedBondMaturityDate2, fixedBondStartDate2, tuple(fixedBondLeg2))
+        fixedBondStartDate2 = ql.Date(5, ql.February, 2005)
+        fixedBondMaturityDate2 = ql.Date(5, ql.February, 2019)
+        fixedBondSchedule2 = ql.Schedule(
+            fixedBondStartDate2,
+            fixedBondMaturityDate2,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBondLeg2 = list(
+            ql.FixedRateLeg(fixedBondSchedule2, ql.Thirty360(ql.Thirty360.BondBasis), [self.faceAmount], [0.05])
+        )
+        fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2, ql.Following)
+        fixedBondLeg2.append(ql.SimpleCashFlow(100.0, fixedbondRedemption2))
+        fixedBond2 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            fixedBondMaturityDate2,
+            fixedBondStartDate2,
+            tuple(fixedBondLeg2),
+        )
         fixedBond2.setPricingEngine(bondEngine)
 
         fixedBondPrice2 = fixedBond2.cleanPrice()
-        fixedBondAssetSwap2 = AssetSwap(payFixedRate,
-                                      fixedBond2, fixedBondPrice2,
-                                      self.iborIndex, self.spread,
-                                      Schedule(),
-                                      self.iborIndex.dayCounter(),
-                                      parAssetSwap)
+        fixedBondAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond2,
+            fixedBondPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedBondAssetSwap2.setPricingEngine(swapEngine)
         fixedBondAssetSwapPrice2 = fixedBondAssetSwap2.fairCleanPrice()
-        error2 = abs(fixedBondAssetSwapPrice2-fixedBondPrice2)
+        error2 = abs(fixedBondAssetSwapPrice2 - fixedBondPrice2)
 
-        self.assertFalse(error2>tolerance,
+        self.assertFalse(
+            error2 > tolerance,
             "wrong zero spread asset swap price for fixed bond:"
-            + "\n  bond's clean price:    " + str(fixedBondPrice2)
-            + "\n  asset swap fair price: " + str(fixedBondAssetSwapPrice2)
-            + "\n  error:                 " + str(error2)
-            + "\n  tolerance:             " + str(tolerance))
+            + "\n  bond's clean price:    "
+            + str(fixedBondPrice2)
+            + "\n  asset swap fair price: "
+            + str(fixedBondAssetSwapPrice2)
+            + "\n  error:                 "
+            + str(error2)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## FRN Underlying bond (Isin: IT0003543847 ISPIM 0 09/29/13)
         ## maturity doesn't occur on a business day
-        floatingBondStartDate1 = Date(29,September,2003)
-        floatingBondMaturityDate1 = Date(29,September,2013)
-        floatingBondSchedule1 = Schedule(floatingBondStartDate1,
-                                       floatingBondMaturityDate1,
-                                       Period(Semiannual), bondCalendar,
-                                       Unadjusted, Unadjusted,
-                                       DateGeneration.Backward, False)
-        floatingBondLeg1 = list(IborLeg([self.faceAmount],floatingBondSchedule1, self.iborIndex,
-                                       Actual360(),ModifiedFollowing, [fixingDays],[],[0.0056],[],[],inArrears))
-        floatingbondRedemption1 = bondCalendar.adjust(floatingBondMaturityDate1, Following)
-        floatingBondLeg1.append(SimpleCashFlow(100.0, floatingbondRedemption1))
-        floatingBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 floatingBondMaturityDate1, floatingBondStartDate1,
-                 tuple(floatingBondLeg1))
+        floatingBondStartDate1 = ql.Date(29, ql.September, 2003)
+        floatingBondMaturityDate1 = ql.Date(29, ql.September, 2013)
+        floatingBondSchedule1 = ql.Schedule(
+            floatingBondStartDate1,
+            floatingBondMaturityDate1,
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        floatingBondLeg1 = list(
+            ql.IborLeg(
+                [self.faceAmount],
+                floatingBondSchedule1,
+                self.iborIndex,
+                ql.Actual360(),
+                ql.ModifiedFollowing,
+                [fixingDays],
+                [],
+                [0.0056],
+                [],
+                [],
+                inArrears,
+            )
+        )
+        floatingbondRedemption1 = bondCalendar.adjust(floatingBondMaturityDate1, ql.Following)
+        floatingBondLeg1.append(ql.SimpleCashFlow(100.0, floatingbondRedemption1))
+        floatingBond1 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            floatingBondMaturityDate1,
+            floatingBondStartDate1,
+            tuple(floatingBondLeg1),
+        )
         floatingBond1.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond1.cashflows(), self.pricer)
-        self.iborIndex.addFixing(Date(27,March,2007), 0.0402)
+        ql.setCouponPricer(floatingBond1.cashflows(), self.pricer)
+        self.iborIndex.addFixing(ql.Date(27, ql.March, 2007), 0.0402)
         floatingBondPrice1 = floatingBond1.cleanPrice()
-        floatingBondAssetSwap1 = AssetSwap (payFixedRate,
-                                         floatingBond1, floatingBondPrice1,
-                                         self.iborIndex, self.spread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         parAssetSwap)
+        floatingBondAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond1,
+            floatingBondPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingBondAssetSwap1.setPricingEngine(swapEngine)
         floatingBondAssetSwapPrice1 = floatingBondAssetSwap1.fairCleanPrice()
-        error3 = abs(floatingBondAssetSwapPrice1-floatingBondPrice1)
+        error3 = abs(floatingBondAssetSwapPrice1 - floatingBondPrice1)
 
-        self.assertFalse(error3>tolerance, 
+        self.assertFalse(
+            error3 > tolerance,
             "wrong zero spread asset swap price for floater:"
-            + "\n  bond's clean price:    " + str(floatingBondPrice1)
-            + "\n  asset swap fair price: " + str(floatingBondAssetSwapPrice1)
-            + "\n  error:                 " + str(error3)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  bond's clean price:    "
+            + str(floatingBondPrice1)
+            + "\n  asset swap fair price: "
+            + str(floatingBondAssetSwapPrice1)
+            + "\n  error:                 "
+            + str(error3)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## FRN Underlying bond (Isin: XS0090566539 COE 0 09/24/18)
         ## maturity occurs on a business day
-        floatingBondStartDate2 = Date(24,September,2004)
-        floatingBondMaturityDate2 = Date(24,September,2018)
-        floatingBondSchedule2 =Schedule(floatingBondStartDate2,
-                                       floatingBondMaturityDate2,
-                                       Period(Semiannual), bondCalendar,
-                                       ModifiedFollowing, ModifiedFollowing,
-                                       DateGeneration.Backward, False)
-        floatingBondLeg2 = list(IborLeg([self.faceAmount],floatingBondSchedule2, self.iborIndex,
-                                        Actual360(),ModifiedFollowing,[fixingDays],[],[0.0025],[],[],inArrears))
-        floatingbondRedemption2 = bondCalendar.adjust(floatingBondMaturityDate2, ModifiedFollowing)
-        floatingBondLeg2.append(SimpleCashFlow(100.0, floatingbondRedemption2))
-        floatingBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 floatingBondMaturityDate2, floatingBondStartDate2,
-                 tuple(floatingBondLeg2))
+        floatingBondStartDate2 = ql.Date(24, ql.September, 2004)
+        floatingBondMaturityDate2 = ql.Date(24, ql.September, 2018)
+        floatingBondSchedule2 = ql.Schedule(
+            floatingBondStartDate2,
+            floatingBondMaturityDate2,
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.ModifiedFollowing,
+            ql.ModifiedFollowing,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        floatingBondLeg2 = list(
+            ql.IborLeg(
+                [self.faceAmount],
+                floatingBondSchedule2,
+                self.iborIndex,
+                ql.Actual360(),
+                ql.ModifiedFollowing,
+                [fixingDays],
+                [],
+                [0.0025],
+                [],
+                [],
+                inArrears,
+            )
+        )
+        floatingbondRedemption2 = bondCalendar.adjust(floatingBondMaturityDate2, ql.ModifiedFollowing)
+        floatingBondLeg2.append(ql.SimpleCashFlow(100.0, floatingbondRedemption2))
+        floatingBond2 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            floatingBondMaturityDate2,
+            floatingBondStartDate2,
+            tuple(floatingBondLeg2),
+        )
         floatingBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond2.cashflows(), self.pricer)
-        self.iborIndex.addFixing(Date(22,March,2007), 0.04013)
-        currentCoupon=0.04013+0.0025
-        floatingCurrentCoupon= floatingBond2.nextCouponRate()
-        error4= abs(floatingCurrentCoupon-currentCoupon)
-        self.assertFalse(error4>tolerance,
+        ql.setCouponPricer(floatingBond2.cashflows(), self.pricer)
+        self.iborIndex.addFixing(ql.Date(22, ql.March, 2007), 0.04013)
+        currentCoupon = 0.04013 + 0.0025
+        floatingCurrentCoupon = floatingBond2.nextCouponRate()
+        error4 = abs(floatingCurrentCoupon - currentCoupon)
+        self.assertFalse(
+            error4 > tolerance,
             "wrong current coupon is returned for floater bond:"
-            + "\n  bond's calculated current coupon:      " + str(currentCoupon)
-            + "\n  current coupon asked to the bond: " + str(floatingCurrentCoupon)
-            + "\n  error:                 " + str(error4)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  bond's calculated current coupon:      "
+            + str(currentCoupon)
+            + "\n  current coupon asked to the bond: "
+            + str(floatingCurrentCoupon)
+            + "\n  error:                 "
+            + str(error4)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         floatingBondPrice2 = floatingBond2.cleanPrice()
-        floatingBondAssetSwap2 = AssetSwap(payFixedRate,
-                                         floatingBond2, floatingBondPrice2,
-                                         self.iborIndex, self.spread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         parAssetSwap)
+        floatingBondAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond2,
+            floatingBondPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingBondAssetSwap2.setPricingEngine(swapEngine)
         floatingBondAssetSwapPrice2 = floatingBondAssetSwap2.fairCleanPrice()
-        error5 = abs(floatingBondAssetSwapPrice2-floatingBondPrice2)
+        error5 = abs(floatingBondAssetSwapPrice2 - floatingBondPrice2)
 
-        self.assertFalse(error5>tolerance, 
+        self.assertFalse(
+            error5 > tolerance,
             "wrong zero spread asset swap price for floater:"
-            + "\n  bond's clean price:    " + str(floatingBondPrice2)
-            + "\n  asset swap fair price: " + str(floatingBondAssetSwapPrice2)
-            + "\n  error:                 " + str(error5)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  bond's clean price:    "
+            + str(floatingBondPrice2)
+            + "\n  asset swap fair price: "
+            + str(floatingBondAssetSwapPrice2)
+            + "\n  error:                 "
+            + str(error5)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## CMS Underlying bond (Isin: XS0228052402 CRDIT 0 8/22/20)
         ## maturity doesn't occur on a business day
-     
-        cmsBondStartDate1 = Date(22,August,2005)
-        cmsBondMaturityDate1 = Date(22,August,2020)
-        cmsBondSchedule1 = Schedule(cmsBondStartDate1,
-                                  cmsBondMaturityDate1,
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBondLeg1 = list(CmsLeg([self.faceAmount],cmsBondSchedule1, self.swapIndex,
-                             Thirty360(),Following,[fixingDays],[],[0.055],[0.025],[],inArrears))
-        cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1, Following)
-        cmsBondLeg1.append(SimpleCashFlow(100.0, cmsbondRedemption1))
-        cmsBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 cmsBondMaturityDate1, cmsBondStartDate1, tuple(cmsBondLeg1))
+
+        cmsBondStartDate1 = ql.Date(22, ql.August, 2005)
+        cmsBondMaturityDate1 = ql.Date(22, ql.August, 2020)
+        cmsBondSchedule1 = ql.Schedule(
+            cmsBondStartDate1,
+            cmsBondMaturityDate1,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBondLeg1 = list(
+            ql.CmsLeg(
+                [self.faceAmount],
+                cmsBondSchedule1,
+                self.swapIndex,
+                ql.Thirty360(),
+                ql.Following,
+                [fixingDays],
+                [],
+                [0.055],
+                [0.025],
+                [],
+                inArrears,
+            )
+        )
+        cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1, ql.Following)
+        cmsBondLeg1.append(ql.SimpleCashFlow(100.0, cmsbondRedemption1))
+        cmsBond1 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, cmsBondMaturityDate1, cmsBondStartDate1, tuple(cmsBondLeg1)
+        )
         cmsBond1.setPricingEngine(bondEngine)
 
-        setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(18,August,2006), 0.04158)
+        ql.setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(18, ql.August, 2006), 0.04158)
         cmsBondPrice1 = cmsBond1.cleanPrice()
-        cmsBondAssetSwap1 = AssetSwap(payFixedRate,
-                                    cmsBond1, cmsBondPrice1,
-                                    self.iborIndex, self.spread,
-                                    Schedule(),
-                                    self.iborIndex.dayCounter(),
-                                    parAssetSwap)
+        cmsBondAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond1,
+            cmsBondPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsBondAssetSwap1.setPricingEngine(swapEngine)
         cmsBondAssetSwapPrice1 = cmsBondAssetSwap1.fairCleanPrice()
-        error6 = abs(cmsBondAssetSwapPrice1-cmsBondPrice1)
+        error6 = abs(cmsBondAssetSwapPrice1 - cmsBondPrice1)
 
-        self.assertFalse(error6>tolerance, 
+        self.assertFalse(
+            error6 > tolerance,
             "wrong zero spread asset swap price for cms bond:"
-            + "\n  bond's clean price:    " + str(cmsBondPrice1)
-            + "\n  asset swap fair price: " + str(cmsBondAssetSwapPrice1)
-            + "\n  error:                 " + str(error6)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  bond's clean price:    "
+            + str(cmsBondPrice1)
+            + "\n  asset swap fair price: "
+            + str(cmsBondAssetSwapPrice1)
+            + "\n  error:                 "
+            + str(error6)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
         ## maturity occurs on a business day
-        cmsBondStartDate2 = Date(6,May,2005)
-        cmsBondMaturityDate2 = Date(6,May,2015)
-        cmsBondSchedule2 = Schedule(cmsBondStartDate2,
-                                  cmsBondMaturityDate2,
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBondLeg2 = list(CmsLeg([self.faceAmount],cmsBondSchedule2, self.swapIndex,
-                                  Thirty360(),Following,[fixingDays],[0.84],[],[],[],inArrears))
-        cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2, Following)
-        cmsBondLeg2.append(SimpleCashFlow(100.0, cmsbondRedemption2))
-        cmsBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 cmsBondMaturityDate2, cmsBondStartDate2, tuple(cmsBondLeg2))
+        cmsBondStartDate2 = ql.Date(6, ql.May, 2005)
+        cmsBondMaturityDate2 = ql.Date(6, ql.May, 2015)
+        cmsBondSchedule2 = ql.Schedule(
+            cmsBondStartDate2,
+            cmsBondMaturityDate2,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBondLeg2 = list(
+            ql.CmsLeg(
+                [self.faceAmount],
+                cmsBondSchedule2,
+                self.swapIndex,
+                ql.Thirty360(),
+                ql.Following,
+                [fixingDays],
+                [0.84],
+                [],
+                [],
+                [],
+                inArrears,
+            )
+        )
+        cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2, ql.Following)
+        cmsBondLeg2.append(ql.SimpleCashFlow(100.0, cmsbondRedemption2))
+        cmsBond2 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, cmsBondMaturityDate2, cmsBondStartDate2, tuple(cmsBondLeg2)
+        )
         cmsBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(4,May,2006), 0.04217)
+        ql.setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(4, ql.May, 2006), 0.04217)
         cmsBondPrice2 = cmsBond2.cleanPrice()
-        cmsBondAssetSwap2 = AssetSwap(payFixedRate,
-                                    cmsBond2, cmsBondPrice2,
-                                    self.iborIndex, self.spread,
-                                    Schedule(),
-                                    self.iborIndex.dayCounter(),
-                                    parAssetSwap)
+        cmsBondAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond2,
+            cmsBondPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsBondAssetSwap2.setPricingEngine(swapEngine)
         cmsBondAssetSwapPrice2 = cmsBondAssetSwap2.fairCleanPrice()
-        error7 = abs(cmsBondAssetSwapPrice2-cmsBondPrice2)
+        error7 = abs(cmsBondAssetSwapPrice2 - cmsBondPrice2)
 
-        self.assertFalse(error7>tolerance, 
+        self.assertFalse(
+            error7 > tolerance,
             "wrong zero spread asset swap price for cms bond:"
-            + "\n  bond's clean price:    " + str(cmsBondPrice2)
-            + "\n  asset swap fair price: " + str(cmsBondAssetSwapPrice2)
-            + "\n  error:                 " + str(error7)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  bond's clean price:    "
+            + str(cmsBondPrice2)
+            + "\n  asset swap fair price: "
+            + str(cmsBondAssetSwapPrice2)
+            + "\n  error:                 "
+            + str(error7)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## Zero Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
         ## maturity doesn't occur on a business day
-        
-        zeroCpnBondStartDate1 = Date(19,December,1985)
-        zeroCpnBondMaturityDate1 = Date(20,December,2015)
-        zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1,
-                                                          Following)
-        zeroCpnBondLeg1 = Leg([SimpleCashFlow(100.0, zeroCpnBondRedemption1)])
-        zeroCpnBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1)
+
+        zeroCpnBondStartDate1 = ql.Date(19, ql.December, 1985)
+        zeroCpnBondMaturityDate1 = ql.Date(20, ql.December, 2015)
+        zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1, ql.Following)
+        zeroCpnBondLeg1 = ql.Leg([ql.SimpleCashFlow(100.0, zeroCpnBondRedemption1)])
+        zeroCpnBond1 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            zeroCpnBondMaturityDate1,
+            zeroCpnBondStartDate1,
+            zeroCpnBondLeg1,
+        )
         zeroCpnBond1.setPricingEngine(bondEngine)
 
         zeroCpnBondPrice1 = zeroCpnBond1.cleanPrice()
-        zeroCpnAssetSwap1 = AssetSwap (payFixedRate,
-                                    zeroCpnBond1, zeroCpnBondPrice1,
-                                    self.iborIndex, self.spread,
-                                    Schedule(),
-                                    self.iborIndex.dayCounter(),
-                                    parAssetSwap)
+        zeroCpnAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond1,
+            zeroCpnBondPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnAssetSwap1.setPricingEngine(swapEngine)
         zeroCpnBondAssetSwapPrice1 = zeroCpnAssetSwap1.fairCleanPrice()
-        error8 = abs(zeroCpnBondAssetSwapPrice1-zeroCpnBondPrice1)
+        error8 = abs(zeroCpnBondAssetSwapPrice1 - zeroCpnBondPrice1)
 
-        self.assertFalse(error8>tolerance, 
+        self.assertFalse(
+            error8 > tolerance,
             "wrong zero spread asset swap price for zero cpn bond:"
-            + "\n  bond's clean price:    " + str(zeroCpnBondPrice1)
-            + "\n  asset swap fair price: " + str(zeroCpnBondAssetSwapPrice1)
-            + "\n  error:                 " + str(error8)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  bond's clean price:    "
+            + str(zeroCpnBondPrice1)
+            + "\n  asset swap fair price: "
+            + str(zeroCpnBondAssetSwapPrice1)
+            + "\n  error:                 "
+            + str(error8)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
         ## maturity occurs on a business day
-        zeroCpnBondStartDate2 = Date(17,February,1998)
-        zeroCpnBondMaturityDate2 = Date(17,February,2028)
-        zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2,
-                                                          Following)
-        zeroCpnBondLeg2 = Leg([SimpleCashFlow(100.0, zerocpbondRedemption2)])
-        zeroCpnBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2)
+        zeroCpnBondStartDate2 = ql.Date(17, ql.February, 1998)
+        zeroCpnBondMaturityDate2 = ql.Date(17, ql.February, 2028)
+        zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2, ql.Following)
+        zeroCpnBondLeg2 = ql.Leg([ql.SimpleCashFlow(100.0, zerocpbondRedemption2)])
+        zeroCpnBond2 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            zeroCpnBondMaturityDate2,
+            zeroCpnBondStartDate2,
+            zeroCpnBondLeg2,
+        )
         zeroCpnBond2.setPricingEngine(bondEngine)
 
         zeroCpnBondPrice2 = zeroCpnBond2.cleanPrice()
-        zeroCpnAssetSwap2 = AssetSwap(payFixedRate,
-                                    zeroCpnBond2, zeroCpnBondPrice2,
-                                    self.iborIndex, self.spread,
-                                    Schedule(),
-                                    self.iborIndex.dayCounter(),
-                                    parAssetSwap)
+        zeroCpnAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond2,
+            zeroCpnBondPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnAssetSwap2.setPricingEngine(swapEngine)
         zeroCpnBondAssetSwapPrice2 = zeroCpnAssetSwap2.fairCleanPrice()
-        error9 = abs(cmsBondAssetSwapPrice2-cmsBondPrice2)
+        error9 = abs(cmsBondAssetSwapPrice2 - cmsBondPrice2)
 
-        self.assertFalse(error9>tolerance, 
+        self.assertFalse(
+            error9 > tolerance,
             "wrong zero spread asset swap price for zero cpn bond:"
-            + "\n  bond's clean price:    " + str(zeroCpnBondPrice2)
-            + "\n  asset swap fair price: " + str(zeroCpnBondAssetSwapPrice2)
-            + "\n  error:                 " + str(error9)
-            + "\n  tolerance:             " + str(tolerance))
-        
-
-
+            + "\n  bond's clean price:    "
+            + str(zeroCpnBondPrice2)
+            + "\n  asset swap fair price: "
+            + str(zeroCpnBondAssetSwapPrice2)
+            + "\n  error:                 "
+            + str(error9)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
     def testMASWWithGenericBond(self):
         """Testing market asset swap against par asset swap with generic bond..."""
-        bondCalendar = TARGET()
+        bondCalendar = ql.TARGET()
         settlementDays = 3
         fixingDays = 2
         payFixedRate = True
@@ -1709,385 +2578,598 @@ class AssetSwapTest(unittest.TestCase):
         ## Fixed Underlying bond (Isin: DE0001135275 DBR 4 01/04/37)
         ## maturity doesn't occur on a business day
 
-        fixedBondStartDate1 = Date(4,January,2005)
-        fixedBondMaturityDate1 = Date(4,January,2037)
-        fixedBondSchedule1 = Schedule(fixedBondStartDate1,
-                                    fixedBondMaturityDate1,
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBondLeg1 = list(FixedRateLeg(fixedBondSchedule1, ActualActual(ActualActual.ISDA), [self.faceAmount], [0.04]))
-        fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1, Following)
-        fixedBondLeg1.append(SimpleCashFlow(100.0, fixedbondRedemption1))
-        fixedBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 fixedBondMaturityDate1, fixedBondStartDate1,
-                 fixedBondLeg1)
-        bondEngine = DiscountingBondEngine(self.termStructure)
-        swapEngine = DiscountingSwapEngine(self.termStructure, False)
+        fixedBondStartDate1 = ql.Date(4, ql.January, 2005)
+        fixedBondMaturityDate1 = ql.Date(4, ql.January, 2037)
+        fixedBondSchedule1 = ql.Schedule(
+            fixedBondStartDate1,
+            fixedBondMaturityDate1,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBondLeg1 = list(
+            ql.FixedRateLeg(fixedBondSchedule1, ql.ActualActual(ql.ActualActual.ISDA), [self.faceAmount], [0.04])
+        )
+        fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1, ql.Following)
+        fixedBondLeg1.append(ql.SimpleCashFlow(100.0, fixedbondRedemption1))
+        fixedBond1 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, fixedBondMaturityDate1, fixedBondStartDate1, fixedBondLeg1
+        )
+        bondEngine = ql.DiscountingBondEngine(self.termStructure)
+        swapEngine = ql.DiscountingSwapEngine(self.termStructure, False)
         fixedBond1.setPricingEngine(bondEngine)
 
         fixedBondMktPrice1 = 89.22  ## market price observed on 7th June 2007
-        fixedBondMktFullPrice1=fixedBondMktPrice1+fixedBond1.accruedAmount()
-        fixedBondParAssetSwap1 = AssetSwap (payFixedRate,
-                                         fixedBond1, fixedBondMktPrice1,
-                                         self.iborIndex, self.spread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         parAssetSwap)
+        fixedBondMktFullPrice1 = fixedBondMktPrice1 + fixedBond1.accruedAmount()
+        fixedBondParAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond1,
+            fixedBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedBondParAssetSwap1.setPricingEngine(swapEngine)
         fixedBondParAssetSwapSpread1 = fixedBondParAssetSwap1.fairSpread()
-        fixedBondMktAssetSwap1 = AssetSwap(payFixedRate,
-                                         fixedBond1, fixedBondMktPrice1,
-                                         self.iborIndex, self.spread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         mktAssetSwap)
+        fixedBondMktAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond1,
+            fixedBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         fixedBondMktAssetSwap1.setPricingEngine(swapEngine)
         fixedBondMktAssetSwapSpread1 = fixedBondMktAssetSwap1.fairSpread()
 
         tolerance = 1.0e-13
-        error1 = abs(fixedBondMktAssetSwapSpread1-
-                      100*fixedBondParAssetSwapSpread1/fixedBondMktFullPrice1)
+        error1 = abs(fixedBondMktAssetSwapSpread1 - 100 * fixedBondParAssetSwapSpread1 / fixedBondMktFullPrice1)
 
-        self.assertFalse(error1>tolerance,
+        self.assertFalse(
+            error1 > tolerance,
             "wrong asset swap spreads for fixed bond:"
-            + "\n  market asset swap spread: " + str(fixedBondMktAssetSwapSpread1)
-            + "\n  par asset swap spread:    " + str(fixedBondParAssetSwapSpread1)
-            + "\n  error:                    " + str(error1)
-            + "\n  tolerance:                " + str(tolerance))
+            + "\n  market asset swap spread: "
+            + str(fixedBondMktAssetSwapSpread1)
+            + "\n  par asset swap spread:    "
+            + str(fixedBondParAssetSwapSpread1)
+            + "\n  error:                    "
+            + str(error1)
+            + "\n  tolerance:                "
+            + str(tolerance),
+        )
 
         ## Fixed Underlying bond (Isin: IT0006527060 IBRD 5 02/05/19)
         ## maturity occurs on a business day
 
-        fixedBondStartDate2 = Date(5,February,2005)
-        fixedBondMaturityDate2 = Date(5,February,2019)
-        fixedBondSchedule2 = Schedule(fixedBondStartDate2,
-                                    fixedBondMaturityDate2,
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBondLeg2 = list(FixedRateLeg(fixedBondSchedule2, Thirty360(Thirty360.BondBasis),[self.faceAmount],[0.05]))
-        fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2, Following)
-        fixedBondLeg2.append(SimpleCashFlow(100.0, fixedbondRedemption2))
-        fixedBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2)
+        fixedBondStartDate2 = ql.Date(5, ql.February, 2005)
+        fixedBondMaturityDate2 = ql.Date(5, ql.February, 2019)
+        fixedBondSchedule2 = ql.Schedule(
+            fixedBondStartDate2,
+            fixedBondMaturityDate2,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBondLeg2 = list(
+            ql.FixedRateLeg(fixedBondSchedule2, ql.Thirty360(ql.Thirty360.BondBasis), [self.faceAmount], [0.05])
+        )
+        fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2, ql.Following)
+        fixedBondLeg2.append(ql.SimpleCashFlow(100.0, fixedbondRedemption2))
+        fixedBond2 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2
+        )
         fixedBond2.setPricingEngine(bondEngine)
 
         fixedBondMktPrice2 = 99.98  ## market price observed on 7th June 2007
-        fixedBondMktFullPrice2 = fixedBondMktPrice2+fixedBond2.accruedAmount()
-        fixedBondParAssetSwap2 = AssetSwap(payFixedRate,
-                                         fixedBond2, fixedBondMktPrice2,
-                                         self.iborIndex, self.spread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         parAssetSwap)
+        fixedBondMktFullPrice2 = fixedBondMktPrice2 + fixedBond2.accruedAmount()
+        fixedBondParAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond2,
+            fixedBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedBondParAssetSwap2.setPricingEngine(swapEngine)
         fixedBondParAssetSwapSpread2 = fixedBondParAssetSwap2.fairSpread()
-        fixedBondMktAssetSwap2 = AssetSwap(payFixedRate,
-                                         fixedBond2, fixedBondMktPrice2,
-                                         self.iborIndex, self.spread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         mktAssetSwap)
+        fixedBondMktAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond2,
+            fixedBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         fixedBondMktAssetSwap2.setPricingEngine(swapEngine)
         fixedBondMktAssetSwapSpread2 = fixedBondMktAssetSwap2.fairSpread()
-        error2 = abs(fixedBondMktAssetSwapSpread2-
-                      100*fixedBondParAssetSwapSpread2/fixedBondMktFullPrice2)
+        error2 = abs(fixedBondMktAssetSwapSpread2 - 100 * fixedBondParAssetSwapSpread2 / fixedBondMktFullPrice2)
 
-        self.assertFalse(error2>tolerance,
+        self.assertFalse(
+            error2 > tolerance,
             "wrong asset swap spreads for fixed bond:"
-            + "\n  market asset swap spread: " + str(fixedBondMktAssetSwapSpread2)
-            + "\n  par asset swap spread:    " + str(fixedBondParAssetSwapSpread2)
-            + "\n  error:                    " + str(error2)
-            + "\n  tolerance:                " + str(tolerance))
+            + "\n  market asset swap spread: "
+            + str(fixedBondMktAssetSwapSpread2)
+            + "\n  par asset swap spread:    "
+            + str(fixedBondParAssetSwapSpread2)
+            + "\n  error:                    "
+            + str(error2)
+            + "\n  tolerance:                "
+            + str(tolerance),
+        )
 
         ## FRN Underlying bond (Isin: IT0003543847 ISPIM 0 09/29/13)
         ## maturity doesn't occur on a business day
 
-        floatingBondStartDate1 = Date(29,September,2003)
-        floatingBondMaturityDate1 = Date(29,September,2013)
-        floatingBondSchedule1 = Schedule(floatingBondStartDate1,
-                                       floatingBondMaturityDate1,
-                                       Period(Semiannual), bondCalendar,
-                                       Unadjusted, Unadjusted,
-                                       DateGeneration.Backward, False)
-        floatingBondLeg1 = list(IborLeg([self.faceAmount],floatingBondSchedule1, self.iborIndex,Actual360(),Following,
-                                   [fixingDays], [],[0.0056],[],[],inArrears))
-        floatingbondRedemption1 = bondCalendar.adjust(floatingBondMaturityDate1, Following)
-        floatingBondLeg1.append(SimpleCashFlow(100.0, floatingbondRedemption1))
-        floatingBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                        floatingBondMaturityDate1, floatingBondStartDate1,
-                        floatingBondLeg1)
+        floatingBondStartDate1 = ql.Date(29, ql.September, 2003)
+        floatingBondMaturityDate1 = ql.Date(29, ql.September, 2013)
+        floatingBondSchedule1 = ql.Schedule(
+            floatingBondStartDate1,
+            floatingBondMaturityDate1,
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        floatingBondLeg1 = list(
+            ql.IborLeg(
+                [self.faceAmount],
+                floatingBondSchedule1,
+                self.iborIndex,
+                ql.Actual360(),
+                ql.Following,
+                [fixingDays],
+                [],
+                [0.0056],
+                [],
+                [],
+                inArrears,
+            )
+        )
+        floatingbondRedemption1 = bondCalendar.adjust(floatingBondMaturityDate1, ql.Following)
+        floatingBondLeg1.append(ql.SimpleCashFlow(100.0, floatingbondRedemption1))
+        floatingBond1 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            floatingBondMaturityDate1,
+            floatingBondStartDate1,
+            floatingBondLeg1,
+        )
         floatingBond1.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond1.cashflows(), self.pricer)
-        self.iborIndex.addFixing(Date(27,March,2007), 0.0402)
+        ql.setCouponPricer(floatingBond1.cashflows(), self.pricer)
+        self.iborIndex.addFixing(ql.Date(27, ql.March, 2007), 0.0402)
         ## market price observed on 7th June 2007
-        floatingBondMktPrice1 = 101.64 
-        floatingBondMktFullPrice1 = floatingBondMktPrice1+floatingBond1.accruedAmount()
-        floatingBondParAssetSwap1 = AssetSwap(payFixedRate,
-                                            floatingBond1, floatingBondMktPrice1,
-                                            self.iborIndex, self.spread,
-                                            Schedule(),
-                                            self.iborIndex.dayCounter(),
-                                            parAssetSwap)
+        floatingBondMktPrice1 = 101.64
+        floatingBondMktFullPrice1 = floatingBondMktPrice1 + floatingBond1.accruedAmount()
+        floatingBondParAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond1,
+            floatingBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingBondParAssetSwap1.setPricingEngine(swapEngine)
         floatingBondParAssetSwapSpread1 = floatingBondParAssetSwap1.fairSpread()
-        floatingBondMktAssetSwap1 = AssetSwap(payFixedRate,
-                                            floatingBond1, floatingBondMktPrice1,
-                                            self.iborIndex, self.spread,
-                                            Schedule(),
-                                            self.iborIndex.dayCounter(),
-                                            mktAssetSwap)
+        floatingBondMktAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond1,
+            floatingBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         floatingBondMktAssetSwap1.setPricingEngine(swapEngine)
         floatingBondMktAssetSwapSpread1 = floatingBondMktAssetSwap1.fairSpread()
-        error3 = abs(floatingBondMktAssetSwapSpread1-
-                      100*floatingBondParAssetSwapSpread1/floatingBondMktFullPrice1)
+        error3 = abs(
+            floatingBondMktAssetSwapSpread1 - 100 * floatingBondParAssetSwapSpread1 / floatingBondMktFullPrice1
+        )
 
-        self.assertFalse(error3>tolerance,
-                "wrong asset swap spreads for floating bond:"
-                + "\n  market asset swap spread: " + str(floatingBondMktAssetSwapSpread1)
-                + "\n  par asset swap spread:    " + str(floatingBondParAssetSwapSpread1)
-                + "\n  error:                    " + str(error3)
-                + "\n  tolerance:                " + str(tolerance))
+        self.assertFalse(
+            error3 > tolerance,
+            "wrong asset swap spreads for floating bond:"
+            + "\n  market asset swap spread: "
+            + str(floatingBondMktAssetSwapSpread1)
+            + "\n  par asset swap spread:    "
+            + str(floatingBondParAssetSwapSpread1)
+            + "\n  error:                    "
+            + str(error3)
+            + "\n  tolerance:                "
+            + str(tolerance),
+        )
 
         ## FRN Underlying bond (Isin: XS0090566539 COE 0 09/24/18)
         ## maturity occurs on a business day
 
-        floatingBondStartDate2 = Date(24,September,2004)
-        floatingBondMaturityDate2 = Date(24,September,2018)
-        floatingBondSchedule2 = Schedule(floatingBondStartDate2,
-                                       floatingBondMaturityDate2,
-                                       Period(Semiannual), bondCalendar,
-                                       ModifiedFollowing, ModifiedFollowing,
-                                       DateGeneration.Backward, False)
-        floatingBondLeg2 = list(IborLeg([self.faceAmount],floatingBondSchedule2, self.iborIndex, Actual360(),
-                                   ModifiedFollowing, [fixingDays], [], [0.0025] , [],[], inArrears))
-        floatingbondRedemption2 = bondCalendar.adjust(floatingBondMaturityDate2, ModifiedFollowing)
-        floatingBondLeg2.append(SimpleCashFlow(100.0, floatingbondRedemption2))
-        floatingBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                         floatingBondMaturityDate2, floatingBondStartDate2,
-                         floatingBondLeg2)
+        floatingBondStartDate2 = ql.Date(24, ql.September, 2004)
+        floatingBondMaturityDate2 = ql.Date(24, ql.September, 2018)
+        floatingBondSchedule2 = ql.Schedule(
+            floatingBondStartDate2,
+            floatingBondMaturityDate2,
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.ModifiedFollowing,
+            ql.ModifiedFollowing,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        floatingBondLeg2 = list(
+            ql.IborLeg(
+                [self.faceAmount],
+                floatingBondSchedule2,
+                self.iborIndex,
+                ql.Actual360(),
+                ql.ModifiedFollowing,
+                [fixingDays],
+                [],
+                [0.0025],
+                [],
+                [],
+                inArrears,
+            )
+        )
+        floatingbondRedemption2 = bondCalendar.adjust(floatingBondMaturityDate2, ql.ModifiedFollowing)
+        floatingBondLeg2.append(ql.SimpleCashFlow(100.0, floatingbondRedemption2))
+        floatingBond2 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            floatingBondMaturityDate2,
+            floatingBondStartDate2,
+            floatingBondLeg2,
+        )
         floatingBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond2.cashflows(), self.pricer)
-        self.iborIndex.addFixing(Date(22,March,2007), 0.04013)
+        ql.setCouponPricer(floatingBond2.cashflows(), self.pricer)
+        self.iborIndex.addFixing(ql.Date(22, ql.March, 2007), 0.04013)
         ## market price observed on 7th June 2007
-        floatingBondMktPrice2 = 101.248 
-        floatingBondMktFullPrice2 = floatingBondMktPrice2+floatingBond2.accruedAmount()
-        floatingBondParAssetSwap2 = AssetSwap(payFixedRate,
-                                            floatingBond2, floatingBondMktPrice2,
-                                            self.iborIndex, self.spread,
-                                            Schedule(),
-                                            self.iborIndex.dayCounter(),
-                                            parAssetSwap)
+        floatingBondMktPrice2 = 101.248
+        floatingBondMktFullPrice2 = floatingBondMktPrice2 + floatingBond2.accruedAmount()
+        floatingBondParAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond2,
+            floatingBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingBondParAssetSwap2.setPricingEngine(swapEngine)
         floatingBondParAssetSwapSpread2 = floatingBondParAssetSwap2.fairSpread()
-        floatingBondMktAssetSwap2 = AssetSwap(payFixedRate,
-                                            floatingBond2, floatingBondMktPrice2,
-                                            self.iborIndex, self.spread,
-                                            Schedule(),
-                                            self.iborIndex.dayCounter(),
-                                            mktAssetSwap)
+        floatingBondMktAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond2,
+            floatingBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         floatingBondMktAssetSwap2.setPricingEngine(swapEngine)
         floatingBondMktAssetSwapSpread2 = floatingBondMktAssetSwap2.fairSpread()
-        error4 = abs(floatingBondMktAssetSwapSpread2-
-                      100*floatingBondParAssetSwapSpread2/floatingBondMktFullPrice2)
+        error4 = abs(
+            floatingBondMktAssetSwapSpread2 - 100 * floatingBondParAssetSwapSpread2 / floatingBondMktFullPrice2
+        )
 
-        self.assertFalse(error4>tolerance,
+        self.assertFalse(
+            error4 > tolerance,
             "wrong asset swap spreads for floating bond:"
-            + "\n  market asset swap spread: " + str(floatingBondMktAssetSwapSpread2)
-            + "\n  par asset swap spread:    " + str(floatingBondParAssetSwapSpread2)
-            + "\n  error:                    " + str(error4)
-            + "\n  tolerance:                " + str(tolerance))
+            + "\n  market asset swap spread: "
+            + str(floatingBondMktAssetSwapSpread2)
+            + "\n  par asset swap spread:    "
+            + str(floatingBondParAssetSwapSpread2)
+            + "\n  error:                    "
+            + str(error4)
+            + "\n  tolerance:                "
+            + str(tolerance),
+        )
 
-
-        
         ## CMS Underlying bond (Isin: XS0228052402 CRDIT 0 8/22/20)
         ## maturity doesn't occur on a business day
-        
-        cmsBondStartDate1 = Date(22,August,2005)
-        cmsBondMaturityDate1 = Date(22,August,2020)
-        cmsBondSchedule1 = Schedule(cmsBondStartDate1,
-                                  cmsBondMaturityDate1,
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBondLeg1 = list(CmsLeg([self.faceAmount],cmsBondSchedule1, self.swapIndex,
-                                 Thirty360(),Following,[fixingDays],[],[],[0.055],[0.025],inArrears))
-        cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1, Following)
-        cmsBondLeg1.append(SimpleCashFlow(100.0, cmsbondRedemption1))
-        cmsBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1)
+
+        cmsBondStartDate1 = ql.Date(22, ql.August, 2005)
+        cmsBondMaturityDate1 = ql.Date(22, ql.August, 2020)
+        cmsBondSchedule1 = ql.Schedule(
+            cmsBondStartDate1,
+            cmsBondMaturityDate1,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBondLeg1 = list(
+            ql.CmsLeg(
+                [self.faceAmount],
+                cmsBondSchedule1,
+                self.swapIndex,
+                ql.Thirty360(),
+                ql.Following,
+                [fixingDays],
+                [],
+                [],
+                [0.055],
+                [0.025],
+                inArrears,
+            )
+        )
+        cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1, ql.Following)
+        cmsBondLeg1.append(ql.SimpleCashFlow(100.0, cmsbondRedemption1))
+        cmsBond1 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1
+        )
         cmsBond1.setPricingEngine(bondEngine)
 
-        setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(18,August,2006), 0.04158)
+        ql.setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(18, ql.August, 2006), 0.04158)
         cmsBondMktPrice1 = 88.45  ## market price observed on 7th June 2007
-        cmsBondMktFullPrice1 = cmsBondMktPrice1+cmsBond1.accruedAmount()
-        cmsBondParAssetSwap1 = AssetSwap(payFixedRate,
-                                       cmsBond1, cmsBondMktPrice1,
-                                       self.iborIndex, self.spread,
-                                       Schedule(),
-                                       self.iborIndex.dayCounter(),
-                                       parAssetSwap)
+        cmsBondMktFullPrice1 = cmsBondMktPrice1 + cmsBond1.accruedAmount()
+        cmsBondParAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond1,
+            cmsBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsBondParAssetSwap1.setPricingEngine(swapEngine)
         cmsBondParAssetSwapSpread1 = cmsBondParAssetSwap1.fairSpread()
-        cmsBondMktAssetSwap1 = AssetSwap(payFixedRate,
-                                       cmsBond1, cmsBondMktPrice1,
-                                       self.iborIndex, self.spread,
-                                       Schedule(),
-                                       self.iborIndex.dayCounter(),
-                                       mktAssetSwap)
+        cmsBondMktAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond1,
+            cmsBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         cmsBondMktAssetSwap1.setPricingEngine(swapEngine)
         cmsBondMktAssetSwapSpread1 = cmsBondMktAssetSwap1.fairSpread()
-        error5 = abs(cmsBondMktAssetSwapSpread1-
-                      100*cmsBondParAssetSwapSpread1/cmsBondMktFullPrice1)
+        error5 = abs(cmsBondMktAssetSwapSpread1 - 100 * cmsBondParAssetSwapSpread1 / cmsBondMktFullPrice1)
 
-        self.assertFalse(error5>tolerance,
+        self.assertFalse(
+            error5 > tolerance,
             "wrong asset swap spreads for cms bond:"
-            + "\n  market asset swap spread: " + str(cmsBondMktAssetSwapSpread1)
-            + "\n  par asset swap spread:    " + str(100*cmsBondParAssetSwapSpread1/cmsBondMktFullPrice1)
-            + "\n  error:                    " + str(error5)
-            + "\n  tolerance:                " + str(tolerance))
+            + "\n  market asset swap spread: "
+            + str(cmsBondMktAssetSwapSpread1)
+            + "\n  par asset swap spread:    "
+            + str(100 * cmsBondParAssetSwapSpread1 / cmsBondMktFullPrice1)
+            + "\n  error:                    "
+            + str(error5)
+            + "\n  tolerance:                "
+            + str(tolerance),
+        )
 
-         ## CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
-         ## maturity occurs on a business day
+        ## CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
+        ## maturity occurs on a business day
 
-        cmsBondStartDate2 = Date(6,May,2005)
-        cmsBondMaturityDate2 = Date(6,May,2015)
-        cmsBondSchedule2 = Schedule(cmsBondStartDate2,
-                                  cmsBondMaturityDate2,
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBondLeg2 = list(CmsLeg([self.faceAmount],cmsBondSchedule2, self.swapIndex,
-                             Thirty360(),Following,[fixingDays],[0.84],[],[],[],inArrears))
-        cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2, Following)
-        cmsBondLeg2.append(SimpleCashFlow(100.0, cmsbondRedemption2))
-        cmsBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                     cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2)
+        cmsBondStartDate2 = ql.Date(6, ql.May, 2005)
+        cmsBondMaturityDate2 = ql.Date(6, ql.May, 2015)
+        cmsBondSchedule2 = ql.Schedule(
+            cmsBondStartDate2,
+            cmsBondMaturityDate2,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBondLeg2 = list(
+            ql.CmsLeg(
+                [self.faceAmount],
+                cmsBondSchedule2,
+                self.swapIndex,
+                ql.Thirty360(),
+                ql.Following,
+                [fixingDays],
+                [0.84],
+                [],
+                [],
+                [],
+                inArrears,
+            )
+        )
+        cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2, ql.Following)
+        cmsBondLeg2.append(ql.SimpleCashFlow(100.0, cmsbondRedemption2))
+        cmsBond2 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2
+        )
         cmsBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(4,May,2006), 0.04217)
+        ql.setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(4, ql.May, 2006), 0.04217)
         cmsBondMktPrice2 = 94.08  ## market price observed on 7th June 2007
-        cmsBondMktFullPrice2 = cmsBondMktPrice2+cmsBond2.accruedAmount()
-        cmsBondParAssetSwap2 = AssetSwap(payFixedRate,
-                                       cmsBond2, cmsBondMktPrice2,
-                                       self.iborIndex, self.spread,
-                                       Schedule(),
-                                       self.iborIndex.dayCounter(),
-                                       parAssetSwap)
+        cmsBondMktFullPrice2 = cmsBondMktPrice2 + cmsBond2.accruedAmount()
+        cmsBondParAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond2,
+            cmsBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsBondParAssetSwap2.setPricingEngine(swapEngine)
         cmsBondParAssetSwapSpread2 = cmsBondParAssetSwap2.fairSpread()
-        cmsBondMktAssetSwap2 = AssetSwap(payFixedRate,
-                                       cmsBond2, cmsBondMktPrice2,
-                                       self.iborIndex, self.spread,
-                                       Schedule(),
-                                       self.iborIndex.dayCounter(),
-                                       mktAssetSwap)
+        cmsBondMktAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond2,
+            cmsBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         cmsBondMktAssetSwap2.setPricingEngine(swapEngine)
         cmsBondMktAssetSwapSpread2 = cmsBondMktAssetSwap2.fairSpread()
-        error6 = abs(cmsBondMktAssetSwapSpread2-
-                      100*cmsBondParAssetSwapSpread2/cmsBondMktFullPrice2)
+        error6 = abs(cmsBondMktAssetSwapSpread2 - 100 * cmsBondParAssetSwapSpread2 / cmsBondMktFullPrice2)
 
-        self.assertFalse(error6>tolerance, 
+        self.assertFalse(
+            error6 > tolerance,
             "wrong asset swap spreads for cms bond:"
-            + "\n  market asset swap spread: " + str(cmsBondMktAssetSwapSpread2)
-            + "\n  par asset swap spread:    " + str(cmsBondParAssetSwapSpread2)
-            + "\n  error:                    " + str(error6)
-            + "\n  tolerance:                " + str(tolerance))
+            + "\n  market asset swap spread: "
+            + str(cmsBondMktAssetSwapSpread2)
+            + "\n  par asset swap spread:    "
+            + str(cmsBondParAssetSwapSpread2)
+            + "\n  error:                    "
+            + str(error6)
+            + "\n  tolerance:                "
+            + str(tolerance),
+        )
 
         ## Zero Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
         ## maturity doesn't occur on a business day
 
-        zeroCpnBondStartDate1 = Date(19,December,1985)
-        zeroCpnBondMaturityDate1 = Date(20,December,2015)
-        zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1,
-                                                          Following)
-        zeroCpnBondLeg1 = Leg([SimpleCashFlow(100.0, zeroCpnBondRedemption1)])
-        zeroCpnBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1)
+        zeroCpnBondStartDate1 = ql.Date(19, ql.December, 1985)
+        zeroCpnBondMaturityDate1 = ql.Date(20, ql.December, 2015)
+        zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1, ql.Following)
+        zeroCpnBondLeg1 = ql.Leg([ql.SimpleCashFlow(100.0, zeroCpnBondRedemption1)])
+        zeroCpnBond1 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            zeroCpnBondMaturityDate1,
+            zeroCpnBondStartDate1,
+            zeroCpnBondLeg1,
+        )
         zeroCpnBond1.setPricingEngine(bondEngine)
 
         ## market price observed on 12th June 2007
-        zeroCpnBondMktPrice1 = 70.436 
-        zeroCpnBondMktFullPrice1 = zeroCpnBondMktPrice1+zeroCpnBond1.accruedAmount()
-        zeroCpnBondParAssetSwap1 = AssetSwap(payFixedRate,zeroCpnBond1,
-                                           zeroCpnBondMktPrice1,
-                                           self.iborIndex, self.spread,
-                                           Schedule(),
-                                           self.iborIndex.dayCounter(),
-                                           parAssetSwap)
+        zeroCpnBondMktPrice1 = 70.436
+        zeroCpnBondMktFullPrice1 = zeroCpnBondMktPrice1 + zeroCpnBond1.accruedAmount()
+        zeroCpnBondParAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond1,
+            zeroCpnBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnBondParAssetSwap1.setPricingEngine(swapEngine)
         zeroCpnBondParAssetSwapSpread1 = zeroCpnBondParAssetSwap1.fairSpread()
-        zeroCpnBondMktAssetSwap1 = AssetSwap(payFixedRate,zeroCpnBond1,
-                                           zeroCpnBondMktPrice1,
-                                           self.iborIndex, self.spread,
-                                           Schedule(),
-                                           self.iborIndex.dayCounter(),
-                                           mktAssetSwap)
+        zeroCpnBondMktAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond1,
+            zeroCpnBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         zeroCpnBondMktAssetSwap1.setPricingEngine(swapEngine)
         zeroCpnBondMktAssetSwapSpread1 = zeroCpnBondMktAssetSwap1.fairSpread()
-        error7 = abs(zeroCpnBondMktAssetSwapSpread1-
-                      100*zeroCpnBondParAssetSwapSpread1/zeroCpnBondMktFullPrice1)
+        error7 = abs(zeroCpnBondMktAssetSwapSpread1 - 100 * zeroCpnBondParAssetSwapSpread1 / zeroCpnBondMktFullPrice1)
 
-        self.assertFalse(error7>tolerance,
+        self.assertFalse(
+            error7 > tolerance,
             "wrong asset swap spreads for zero cpn bond:"
-            + "\n  market asset swap spread: " + str(zeroCpnBondMktAssetSwapSpread1)
-            + "\n  par asset swap spread:    " + str(zeroCpnBondParAssetSwapSpread1)
-            + "\n  error:                    " + str(error7)
-            + "\n  tolerance:                " + str(tolerance))
+            + "\n  market asset swap spread: "
+            + str(zeroCpnBondMktAssetSwapSpread1)
+            + "\n  par asset swap spread:    "
+            + str(zeroCpnBondParAssetSwapSpread1)
+            + "\n  error:                    "
+            + str(error7)
+            + "\n  tolerance:                "
+            + str(tolerance),
+        )
 
         ## Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
         ## maturity occurs on a business day
 
-        zeroCpnBondStartDate2 = Date(17,February,1998)
-        zeroCpnBondMaturityDate2 = Date(17,February,2028)
-        zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2,
-                                                          Following)
-        zeroCpnBondLeg2 = Leg([SimpleCashFlow(100.0, zerocpbondRedemption2)])
-        zeroCpnBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2)
+        zeroCpnBondStartDate2 = ql.Date(17, ql.February, 1998)
+        zeroCpnBondMaturityDate2 = ql.Date(17, ql.February, 2028)
+        zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2, ql.Following)
+        zeroCpnBondLeg2 = ql.Leg([ql.SimpleCashFlow(100.0, zerocpbondRedemption2)])
+        zeroCpnBond2 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            zeroCpnBondMaturityDate2,
+            zeroCpnBondStartDate2,
+            zeroCpnBondLeg2,
+        )
         zeroCpnBond2.setPricingEngine(bondEngine)
 
         ## zeroCpnBondPrice2 = zeroCpnBond2.cleanPrice()
         ## market price observed on 12th June 2007
-        zeroCpnBondMktPrice2 = 35.160 
-        zeroCpnBondMktFullPrice2 = zeroCpnBondMktPrice2+zeroCpnBond2.accruedAmount()
-        zeroCpnBondParAssetSwap2 = AssetSwap(payFixedRate,zeroCpnBond2,
-                                           zeroCpnBondMktPrice2,
-                                           self.iborIndex, self.spread,
-                                           Schedule(),
-                                           self.iborIndex.dayCounter(),
-                                           parAssetSwap)
+        zeroCpnBondMktPrice2 = 35.160
+        zeroCpnBondMktFullPrice2 = zeroCpnBondMktPrice2 + zeroCpnBond2.accruedAmount()
+        zeroCpnBondParAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond2,
+            zeroCpnBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnBondParAssetSwap2.setPricingEngine(swapEngine)
         zeroCpnBondParAssetSwapSpread2 = zeroCpnBondParAssetSwap2.fairSpread()
-        zeroCpnBondMktAssetSwap2 = AssetSwap(payFixedRate,zeroCpnBond2,
-                                           zeroCpnBondMktPrice2,
-                                           self.iborIndex, self.spread,
-                                           Schedule(),
-                                           self.iborIndex.dayCounter(),
-                                           mktAssetSwap)
+        zeroCpnBondMktAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond2,
+            zeroCpnBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            mktAssetSwap,
+        )
         zeroCpnBondMktAssetSwap2.setPricingEngine(swapEngine)
         zeroCpnBondMktAssetSwapSpread2 = zeroCpnBondMktAssetSwap2.fairSpread()
-        error8 = abs(zeroCpnBondMktAssetSwapSpread2-
-                      100*zeroCpnBondParAssetSwapSpread2/zeroCpnBondMktFullPrice2)
+        error8 = abs(zeroCpnBondMktAssetSwapSpread2 - 100 * zeroCpnBondParAssetSwapSpread2 / zeroCpnBondMktFullPrice2)
 
-        self.assertFalse(error8>tolerance, 
+        self.assertFalse(
+            error8 > tolerance,
             "wrong asset swap spreads for zero cpn bond:"
-            + "\n  market asset swap spread: " + str(zeroCpnBondMktAssetSwapSpread2)
-            + "\n  par asset swap spread:    " + str(zeroCpnBondParAssetSwapSpread2)
-            + "\n  error:                    " + str(error8)
-            + "\n  tolerance:                " + str(tolerance))
+            + "\n  market asset swap spread: "
+            + str(zeroCpnBondMktAssetSwapSpread2)
+            + "\n  par asset swap spread:    "
+            + str(zeroCpnBondParAssetSwapSpread2)
+            + "\n  error:                    "
+            + str(error8)
+            + "\n  tolerance:                "
+            + str(tolerance),
+        )
 
-
-
-    def testZSpreadWithGenericBond(self) :
+    def testZSpreadWithGenericBond(self):
         """Testing clean and dirty price with null Z-spread against theoretical prices..."""
-        
-        bondCalendar = TARGET()
+
+        bondCalendar = ql.TARGET()
         settlementDays = 3
         fixingDays = 2
         inArrears = False
@@ -2095,698 +3177,1139 @@ class AssetSwapTest(unittest.TestCase):
         ## Fixed Underlying bond (Isin: DE0001135275 DBR 4 01/04/37)
         ## maturity doesn't occur on a business day
 
-        fixedBondStartDate1 = Date(4,January,2005)
-        fixedBondMaturityDate1 = Date(4,January,2037)
-        fixedBondSchedule1 = Schedule(fixedBondStartDate1,
-                                    fixedBondMaturityDate1,
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBondLeg1 = list(FixedRateLeg(fixedBondSchedule1, ActualActual(ActualActual.ISDA),  [self.faceAmount], [0.04]))
-        fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1, Following)
-        fixedBondLeg1.append(SimpleCashFlow(100.0, fixedbondRedemption1))
-        fixedBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 fixedBondMaturityDate1, fixedBondStartDate1,
-                 fixedBondLeg1)
-        bondEngine = DiscountingBondEngine(self.termStructure)
+        fixedBondStartDate1 = ql.Date(4, ql.January, 2005)
+        fixedBondMaturityDate1 = ql.Date(4, ql.January, 2037)
+        fixedBondSchedule1 = ql.Schedule(
+            fixedBondStartDate1,
+            fixedBondMaturityDate1,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBondLeg1 = list(
+            ql.FixedRateLeg(fixedBondSchedule1, ql.ActualActual(ql.ActualActual.ISDA), [self.faceAmount], [0.04])
+        )
+        fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1, ql.Following)
+        fixedBondLeg1.append(ql.SimpleCashFlow(100.0, fixedbondRedemption1))
+        fixedBond1 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, fixedBondMaturityDate1, fixedBondStartDate1, fixedBondLeg1
+        )
+        bondEngine = ql.DiscountingBondEngine(self.termStructure)
         fixedBond1.setPricingEngine(bondEngine)
 
         fixedBondImpliedValue1 = fixedBond1.cleanPrice()
         fixedBondSettlementDate1 = fixedBond1.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YieldCurve
-        fixedBondCleanPrice1 = cleanPriceFromZSpread(fixedBond1, self.yieldCurve, self.spread,
-             Actual365Fixed(), self.compounding, Annual, fixedBondSettlementDate1)
+        fixedBondCleanPrice1 = ql.cleanPriceFromZSpread(
+            fixedBond1,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Annual,
+            fixedBondSettlementDate1,
+        )
         tolerance = 1.0e-13
-        error1 = abs(fixedBondImpliedValue1-fixedBondCleanPrice1)
-        self.assertFalse(error1>tolerance, 
+        error1 = abs(fixedBondImpliedValue1 - fixedBondCleanPrice1)
+        self.assertFalse(
+            error1 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  market asset swap spread: " + str(fixedBondImpliedValue1)
-            + "\n  par asset swap spread: " + str(fixedBondCleanPrice1)
-            + "\n  error:                 " + str(error1)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  market asset swap spread: "
+            + str(fixedBondImpliedValue1)
+            + "\n  par asset swap spread: "
+            + str(fixedBondCleanPrice1)
+            + "\n  error:                 "
+            + str(error1)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## Fixed Underlying bond (Isin: IT0006527060 IBRD 5 02/05/19)
         ## maturity occurs on a business day
 
-        fixedBondStartDate2 = Date(5,February,2005)
-        fixedBondMaturityDate2 = Date(5,February,2019)
-        fixedBondSchedule2 = Schedule(fixedBondStartDate2,
-                                    fixedBondMaturityDate2,
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBondLeg2 = list(FixedRateLeg(fixedBondSchedule2, Thirty360(Thirty360.BondBasis),
-                                     [self.faceAmount],[0.05]))
-        fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2, Following)
-        fixedBondLeg2.append(SimpleCashFlow(100.0, fixedbondRedemption2))
-        fixedBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2)
+        fixedBondStartDate2 = ql.Date(5, ql.February, 2005)
+        fixedBondMaturityDate2 = ql.Date(5, ql.February, 2019)
+        fixedBondSchedule2 = ql.Schedule(
+            fixedBondStartDate2,
+            fixedBondMaturityDate2,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBondLeg2 = list(
+            ql.FixedRateLeg(fixedBondSchedule2, ql.Thirty360(ql.Thirty360.BondBasis), [self.faceAmount], [0.05])
+        )
+        fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2, ql.Following)
+        fixedBondLeg2.append(ql.SimpleCashFlow(100.0, fixedbondRedemption2))
+        fixedBond2 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2
+        )
         fixedBond2.setPricingEngine(bondEngine)
 
         fixedBondImpliedValue2 = fixedBond2.cleanPrice()
-        fixedBondSettlementDate2= fixedBond2.settlementDate()
+        fixedBondSettlementDate2 = fixedBond2.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YieldCurve
 
-        fixedBondCleanPrice2 = cleanPriceFromZSpread(fixedBond2, self.yieldCurve, self.spread,
-             Actual365Fixed(), self.compounding, Annual, fixedBondSettlementDate2)
-        error3 = abs(fixedBondImpliedValue2-fixedBondCleanPrice2)
-        self.assertFalse(error3>tolerance, 
+        fixedBondCleanPrice2 = ql.cleanPriceFromZSpread(
+            fixedBond2,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Annual,
+            fixedBondSettlementDate2,
+        )
+        error3 = abs(fixedBondImpliedValue2 - fixedBondCleanPrice2)
+        self.assertFalse(
+            error3 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  market asset swap spread: " + str(fixedBondImpliedValue2)
-            + "\n  par asset swap spread: " + str(fixedBondCleanPrice2)
-            + "\n  error:                 " + str(error3)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  market asset swap spread: "
+            + str(fixedBondImpliedValue2)
+            + "\n  par asset swap spread: "
+            + str(fixedBondCleanPrice2)
+            + "\n  error:                 "
+            + str(error3)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## FRN Underlying bond (Isin: IT0003543847 ISPIM 0 09/29/13)
         ## maturity doesn't occur on a business day
 
-        floatingBondStartDate1 = Date(29,September,2003)
-        floatingBondMaturityDate1 = Date(29,September,2013)
-        floatingBondSchedule1 = Schedule(floatingBondStartDate1,
-                                       floatingBondMaturityDate1,
-                                       Period(Semiannual), bondCalendar,
-                                       Unadjusted, Unadjusted,
-                                       DateGeneration.Backward, False)
-        floatingBondLeg1 = list(IborLeg([self.faceAmount],floatingBondSchedule1, self.iborIndex,
-                                   Actual360(),Following,[fixingDays], [],[0.0056],[],[], inArrears))
-        floatingbondRedemption1 = bondCalendar.adjust(floatingBondMaturityDate1, Following)
-        floatingBondLeg1.append(SimpleCashFlow(100.0, floatingbondRedemption1))
-        floatingBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 floatingBondMaturityDate1, floatingBondStartDate1,
-                 floatingBondLeg1)
+        floatingBondStartDate1 = ql.Date(29, ql.September, 2003)
+        floatingBondMaturityDate1 = ql.Date(29, ql.September, 2013)
+        floatingBondSchedule1 = ql.Schedule(
+            floatingBondStartDate1,
+            floatingBondMaturityDate1,
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        floatingBondLeg1 = list(
+            ql.IborLeg(
+                [self.faceAmount],
+                floatingBondSchedule1,
+                self.iborIndex,
+                ql.Actual360(),
+                ql.Following,
+                [fixingDays],
+                [],
+                [0.0056],
+                [],
+                [],
+                inArrears,
+            )
+        )
+        floatingbondRedemption1 = bondCalendar.adjust(floatingBondMaturityDate1, ql.Following)
+        floatingBondLeg1.append(ql.SimpleCashFlow(100.0, floatingbondRedemption1))
+        floatingBond1 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            floatingBondMaturityDate1,
+            floatingBondStartDate1,
+            floatingBondLeg1,
+        )
         floatingBond1.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond1.cashflows(), self.pricer)
-        self.iborIndex.addFixing(Date(27,March,2007), 0.0402)
+        ql.setCouponPricer(floatingBond1.cashflows(), self.pricer)
+        self.iborIndex.addFixing(ql.Date(27, ql.March, 2007), 0.0402)
         floatingBondImpliedValue1 = floatingBond1.cleanPrice()
-        floatingBondSettlementDate1= floatingBond1.settlementDate()
+        floatingBondSettlementDate1 = floatingBond1.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YieldCurve
-        floatingBondCleanPrice1 = cleanPriceFromZSpread(floatingBond1, self.yieldCurve, 
-            self.spread, Actual365Fixed(), self.compounding, Semiannual,
-            fixedBondSettlementDate1)
-        error5 = abs(floatingBondImpliedValue1-floatingBondCleanPrice1)
-        self.assertFalse(error5>tolerance,
+        floatingBondCleanPrice1 = ql.cleanPriceFromZSpread(
+            floatingBond1,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Semiannual,
+            floatingBondSettlementDate1,
+        )
+        error5 = abs(floatingBondImpliedValue1 - floatingBondCleanPrice1)
+        self.assertFalse(
+            error5 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  market asset swap spread: " + str(floatingBondImpliedValue1)
-            + "\n  par asset swap spread: " + str(floatingBondCleanPrice1)
-            + "\n  error:                 " + str(error5)
-            + "\n  tolerance:             " + str(tolerance))
-    
+            + "\n  market asset swap spread: "
+            + str(floatingBondImpliedValue1)
+            + "\n  par asset swap spread: "
+            + str(floatingBondCleanPrice1)
+            + "\n  error:                 "
+            + str(error5)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## FRN Underlying bond (Isin: XS0090566539 COE 0 09/24/18)
         ## maturity occurs on a business day
 
-        floatingBondStartDate2 = Date(24,September,2004)
-        floatingBondMaturityDate2 = Date(24,September,2018)
-        floatingBondSchedule2 = Schedule(floatingBondStartDate2,
-                                       floatingBondMaturityDate2,
-                                       Period(Semiannual), bondCalendar,
-                                       ModifiedFollowing, ModifiedFollowing,
-                                       DateGeneration.Backward, False)
-        floatingBondLeg2 = list(IborLeg([self.faceAmount],floatingBondSchedule2, self.iborIndex,
-                                        Actual360(),ModifiedFollowing, [fixingDays],[],[0.0025],[],[], inArrears))
-        floatingbondRedemption2 = bondCalendar.adjust(floatingBondMaturityDate2, ModifiedFollowing)
-        floatingBondLeg2.append(SimpleCashFlow(100.0, floatingbondRedemption2))
-        floatingBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 floatingBondMaturityDate2, floatingBondStartDate2, floatingBondLeg2)
+        floatingBondStartDate2 = ql.Date(24, ql.September, 2004)
+        floatingBondMaturityDate2 = ql.Date(24, ql.September, 2018)
+        floatingBondSchedule2 = ql.Schedule(
+            floatingBondStartDate2,
+            floatingBondMaturityDate2,
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.ModifiedFollowing,
+            ql.ModifiedFollowing,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        floatingBondLeg2 = list(
+            ql.IborLeg(
+                [self.faceAmount],
+                floatingBondSchedule2,
+                self.iborIndex,
+                ql.Actual360(),
+                ql.ModifiedFollowing,
+                [fixingDays],
+                [],
+                [0.0025],
+                [],
+                [],
+                inArrears,
+            )
+        )
+        floatingbondRedemption2 = bondCalendar.adjust(floatingBondMaturityDate2, ql.ModifiedFollowing)
+        floatingBondLeg2.append(ql.SimpleCashFlow(100.0, floatingbondRedemption2))
+        floatingBond2 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            floatingBondMaturityDate2,
+            floatingBondStartDate2,
+            floatingBondLeg2,
+        )
         floatingBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond2.cashflows(), self.pricer)
-        self.iborIndex.addFixing(Date(22,March,2007), 0.04013)
+        ql.setCouponPricer(floatingBond2.cashflows(), self.pricer)
+        self.iborIndex.addFixing(ql.Date(22, ql.March, 2007), 0.04013)
         floatingBondImpliedValue2 = floatingBond2.cleanPrice()
-        floatingBondSettlementDate2= floatingBond2.settlementDate()
+        floatingBondSettlementDate2 = floatingBond2.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YieldCurve
-        floatingBondCleanPrice2 = cleanPriceFromZSpread(floatingBond2, self.yieldCurve, 
-            self.spread, Actual365Fixed(), self.compounding, Semiannual, fixedBondSettlementDate1)
-        error7 = abs(floatingBondImpliedValue2-floatingBondCleanPrice2)
-        self.assertFalse(error7>tolerance,
+        floatingBondCleanPrice2 = ql.cleanPriceFromZSpread(
+            floatingBond2,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Semiannual,
+            floatingBondSettlementDate2,
+        )
+        error7 = abs(floatingBondImpliedValue2 - floatingBondCleanPrice2)
+        self.assertFalse(
+            error7 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  market asset swap spread: " + str(floatingBondImpliedValue2)
-            + "\n  par asset swap spread: " + str(floatingBondCleanPrice2)
-            + "\n  error:                 " + str(error7)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  market asset swap spread: "
+            + str(floatingBondImpliedValue2)
+            + "\n  par asset swap spread: "
+            + str(floatingBondCleanPrice2)
+            + "\n  error:                 "
+            + str(error7)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## CMS Underlying bond (Isin: XS0228052402 CRDIT 0 8/22/20)
         ## maturity doesn't occur on a business day
 
-        cmsBondStartDate1 = Date(22,August,2005)
-        cmsBondMaturityDate1 = Date(22,August,2020)
-        cmsBondSchedule1 = Schedule(cmsBondStartDate1,
-                                  cmsBondMaturityDate1,
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBondLeg1 = list(CmsLeg([self.faceAmount],cmsBondSchedule1, self.swapIndex,
-                             Thirty360(),Following,[fixingDays],[],[],[0.055],[0.025],inArrears))
-        cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1, Following)
-        cmsBondLeg1.append(SimpleCashFlow(100.0, cmsbondRedemption1))
-        cmsBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1)
+        cmsBondStartDate1 = ql.Date(22, ql.August, 2005)
+        cmsBondMaturityDate1 = ql.Date(22, ql.August, 2020)
+        cmsBondSchedule1 = ql.Schedule(
+            cmsBondStartDate1,
+            cmsBondMaturityDate1,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBondLeg1 = list(
+            ql.CmsLeg(
+                [self.faceAmount],
+                cmsBondSchedule1,
+                self.swapIndex,
+                ql.Thirty360(),
+                ql.Following,
+                [fixingDays],
+                [],
+                [],
+                [0.055],
+                [0.025],
+                inArrears,
+            )
+        )
+        cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1, ql.Following)
+        cmsBondLeg1.append(ql.SimpleCashFlow(100.0, cmsbondRedemption1))
+        cmsBond1 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1
+        )
         cmsBond1.setPricingEngine(bondEngine)
 
-        setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(18,August,2006), 0.04158)
+        ql.setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(18, ql.August, 2006), 0.04158)
         cmsBondImpliedValue1 = cmsBond1.cleanPrice()
-        cmsBondSettlementDate1= cmsBond1.settlementDate()
+        cmsBondSettlementDate1 = cmsBond1.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YieldCurve
-        cmsBondCleanPrice1 = cleanPriceFromZSpread(cmsBond1, self.yieldCurve, self.spread,
-                                 Actual365Fixed(), self.compounding, Annual, cmsBondSettlementDate1)
-        error9 = abs(cmsBondImpliedValue1-cmsBondCleanPrice1)
-        self.assertFalse(error9>tolerance, 
+        cmsBondCleanPrice1 = ql.cleanPriceFromZSpread(
+            cmsBond1,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Annual,
+            cmsBondSettlementDate1,
+        )
+        error9 = abs(cmsBondImpliedValue1 - cmsBondCleanPrice1)
+        self.assertFalse(
+            error9 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  market asset swap spread: " + str(cmsBondImpliedValue1)
-            + "\n  par asset swap spread: " + str(cmsBondCleanPrice1)
-            + "\n  error:                 " + str(error9)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  market asset swap spread: "
+            + str(cmsBondImpliedValue1)
+            + "\n  par asset swap spread: "
+            + str(cmsBondCleanPrice1)
+            + "\n  error:                 "
+            + str(error9)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
         ## maturity occurs on a business day
-       
-        cmsBondStartDate2 = Date(6,May,2005)
-        cmsBondMaturityDate2 = Date(6,May,2015)
-        cmsBondSchedule2 = Schedule(cmsBondStartDate2,
-                                  cmsBondMaturityDate2,
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBondLeg2 = list(CmsLeg([self.faceAmount],cmsBondSchedule2, self.swapIndex,
-                                  Thirty360(),Following,[fixingDays],[0.84],[],[],[],inArrears))
-        cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2, Following)
-        cmsBondLeg2.append(SimpleCashFlow(100.0, cmsbondRedemption2))
-        cmsBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2)
+
+        cmsBondStartDate2 = ql.Date(6, ql.May, 2005)
+        cmsBondMaturityDate2 = ql.Date(6, ql.May, 2015)
+        cmsBondSchedule2 = ql.Schedule(
+            cmsBondStartDate2,
+            cmsBondMaturityDate2,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBondLeg2 = list(
+            ql.CmsLeg(
+                [self.faceAmount],
+                cmsBondSchedule2,
+                self.swapIndex,
+                ql.Thirty360(),
+                ql.Following,
+                [fixingDays],
+                [0.84],
+                [],
+                [],
+                [],
+                inArrears,
+            )
+        )
+        cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2, ql.Following)
+        cmsBondLeg2.append(ql.SimpleCashFlow(100.0, cmsbondRedemption2))
+        cmsBond2 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2
+        )
         cmsBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(4,May,2006), 0.04217)
+        ql.setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(4, ql.May, 2006), 0.04217)
         cmsBondImpliedValue2 = cmsBond2.cleanPrice()
-        cmsBondSettlementDate2= cmsBond2.settlementDate()
+        cmsBondSettlementDate2 = cmsBond2.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YieldCurve
-        cmsBondCleanPrice2 = cleanPriceFromZSpread(cmsBond2, self.yieldCurve, self.spread,
-             Actual365Fixed(), self.compounding, Annual, cmsBondSettlementDate2)
-        error11 = abs(cmsBondImpliedValue2-cmsBondCleanPrice2)
-        self.assertFalse(error11>tolerance,
+        cmsBondCleanPrice2 = ql.cleanPriceFromZSpread(
+            cmsBond2,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Annual,
+            cmsBondSettlementDate2,
+        )
+        error11 = abs(cmsBondImpliedValue2 - cmsBondCleanPrice2)
+        self.assertFalse(
+            error11 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  market asset swap spread: " + str(cmsBondImpliedValue2)
-            + "\n  par asset swap spread: " + str(cmsBondCleanPrice2)
-            + "\n  error:                 " + str(error11)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  market asset swap spread: "
+            + str(cmsBondImpliedValue2)
+            + "\n  par asset swap spread: "
+            + str(cmsBondCleanPrice2)
+            + "\n  error:                 "
+            + str(error11)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## Zero Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
         ## maturity doesn't occur on a business day
 
-        zeroCpnBondStartDate1 = Date(19,December,1985)
-        zeroCpnBondMaturityDate1 = Date(20,December,2015)
-        zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1,
-                                                          Following)
-        zeroCpnBondLeg1 = Leg([SimpleCashFlow(100.0, zeroCpnBondRedemption1)])
-        zeroCpnBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                         zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1)
+        zeroCpnBondStartDate1 = ql.Date(19, ql.December, 1985)
+        zeroCpnBondMaturityDate1 = ql.Date(20, ql.December, 2015)
+        zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1, ql.Following)
+        zeroCpnBondLeg1 = ql.Leg([ql.SimpleCashFlow(100.0, zeroCpnBondRedemption1)])
+        zeroCpnBond1 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            zeroCpnBondMaturityDate1,
+            zeroCpnBondStartDate1,
+            zeroCpnBondLeg1,
+        )
         zeroCpnBond1.setPricingEngine(bondEngine)
 
         zeroCpnBondImpliedValue1 = zeroCpnBond1.cleanPrice()
-        zeroCpnBondSettlementDate1= zeroCpnBond1.settlementDate()
+        zeroCpnBondSettlementDate1 = zeroCpnBond1.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YieldCurve
-        zeroCpnBondCleanPrice1 = cleanPriceFromZSpread(zeroCpnBond1, self.yieldCurve,
-                                  self.spread,
-                                  Actual365Fixed(),
-                                  self.compounding, Annual,
-                                  zeroCpnBondSettlementDate1)
-        error13 = abs(zeroCpnBondImpliedValue1-zeroCpnBondCleanPrice1)
-        self.assertFalse(error13>tolerance,
+        zeroCpnBondCleanPrice1 = ql.cleanPriceFromZSpread(
+            zeroCpnBond1,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Annual,
+            zeroCpnBondSettlementDate1,
+        )
+        error13 = abs(zeroCpnBondImpliedValue1 - zeroCpnBondCleanPrice1)
+        self.assertFalse(
+            error13 > tolerance,
             "wrong clean price for zero coupon bond:"
-            + "\n  zero cpn implied value: " + str(zeroCpnBondImpliedValue1)
-            + "\n  zero cpn price: " + str(zeroCpnBondCleanPrice1)
-            + "\n  error:                 " + str(error13)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  zero cpn implied value: "
+            + str(zeroCpnBondImpliedValue1)
+            + "\n  zero cpn price: "
+            + str(zeroCpnBondCleanPrice1)
+            + "\n  error:                 "
+            + str(error13)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
         ## maturity occurs on a business day
 
-        zeroCpnBondStartDate2 = Date(17,February,1998)
-        zeroCpnBondMaturityDate2 = Date(17,February,2028)
-        zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2, Following)
-        zeroCpnBondLeg2 = Leg([SimpleCashFlow(100.0, zerocpbondRedemption2)])
-        zeroCpnBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2)
+        zeroCpnBondStartDate2 = ql.Date(17, ql.February, 1998)
+        zeroCpnBondMaturityDate2 = ql.Date(17, ql.February, 2028)
+        zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2, ql.Following)
+        zeroCpnBondLeg2 = ql.Leg([ql.SimpleCashFlow(100.0, zerocpbondRedemption2)])
+        zeroCpnBond2 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            zeroCpnBondMaturityDate2,
+            zeroCpnBondStartDate2,
+            zeroCpnBondLeg2,
+        )
         zeroCpnBond2.setPricingEngine(bondEngine)
 
         zeroCpnBondImpliedValue2 = zeroCpnBond2.cleanPrice()
-        zeroCpnBondSettlementDate2= zeroCpnBond2.settlementDate()
+        zeroCpnBondSettlementDate2 = zeroCpnBond2.settlementDate()
         ## standard market conventions:
         ## bond's frequency + coumpounding and daycounter of the YieldCurve
-        zeroCpnBondCleanPrice2 = cleanPriceFromZSpread(zeroCpnBond2,
-                                  self.yieldCurve,
-                                  self.spread,
-                                  Actual365Fixed(),
-                                  self.compounding, Annual,
-                                  zeroCpnBondSettlementDate2)
-        error15 = abs(zeroCpnBondImpliedValue2-zeroCpnBondCleanPrice2)
+        zeroCpnBondCleanPrice2 = ql.cleanPriceFromZSpread(
+            zeroCpnBond2,
+            self.yieldCurve,
+            self.spread,
+            ql.Actual365Fixed(),
+            self.compounding,
+            ql.Annual,
+            zeroCpnBondSettlementDate2,
+        )
+        error15 = abs(zeroCpnBondImpliedValue2 - zeroCpnBondCleanPrice2)
 
-        self.assertFalse(error15>tolerance,
+        self.assertFalse(
+            error15 > tolerance,
             "wrong clean price for zero coupon bond:"
-            + "\n  zero cpn implied value: " + str(zeroCpnBondImpliedValue2)
-            + "\n  zero cpn price: " + str(zeroCpnBondCleanPrice2)
-            + "\n  error:                 " + str(error15)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  zero cpn implied value: "
+            + str(zeroCpnBondImpliedValue2)
+            + "\n  zero cpn price: "
+            + str(zeroCpnBondCleanPrice2)
+            + "\n  error:                 "
+            + str(error15)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
-
-
-    def testSpecializedBondVsGenericBond(self) :
+    def testSpecializedBondVsGenericBond(self):
         """Testing clean and dirty prices for specialized bond against equivalent generic bond..."""
 
-        bondCalendar = TARGET()
+        bondCalendar = ql.TARGET()
         settlementDays = 3
         fixingDays = 2
         inArrears = False
 
         ## Fixed Underlying bond (Isin: DE0001135275 DBR 4 01/04/37)
         ## maturity doesn't occur on a business day
-        fixedBondStartDate1 = Date(4,January,2005)
-        fixedBondMaturityDate1 = Date(4,January,2037)
-        fixedBondSchedule1 = Schedule(fixedBondStartDate1,
-                                    fixedBondMaturityDate1,
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBondLeg1 = list(FixedRateLeg(fixedBondSchedule1, ActualActual(ActualActual.ISDA), [self.faceAmount],
-                                     [0.04]))
-        fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1, Following)
-        fixedBondLeg1.append(SimpleCashFlow(100.0, fixedbondRedemption1))
+        fixedBondStartDate1 = ql.Date(4, ql.January, 2005)
+        fixedBondMaturityDate1 = ql.Date(4, ql.January, 2037)
+        fixedBondSchedule1 = ql.Schedule(
+            fixedBondStartDate1,
+            fixedBondMaturityDate1,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBondLeg1 = list(
+            ql.FixedRateLeg(fixedBondSchedule1, ql.ActualActual(ql.ActualActual.ISDA), [self.faceAmount], [0.04])
+        )
+        fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1, ql.Following)
+        fixedBondLeg1.append(ql.SimpleCashFlow(100.0, fixedbondRedemption1))
         ## generic bond
-        fixedBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                         fixedBondMaturityDate1, fixedBondStartDate1,
-                         fixedBondLeg1)
-        bondEngine = DiscountingBondEngine(self.termStructure)
+        fixedBond1 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, fixedBondMaturityDate1, fixedBondStartDate1, fixedBondLeg1
+        )
+        bondEngine = ql.DiscountingBondEngine(self.termStructure)
         fixedBond1.setPricingEngine(bondEngine)
 
         ## equivalent specialized fixed rate bond
-        fixedSpecializedBond1 = FixedRateBond(settlementDays, self.faceAmount, fixedBondSchedule1,
-                          [0.04], ActualActual(ActualActual.ISDA), Following,
-                          100.0, Date(4,January,2005))
+        fixedSpecializedBond1 = ql.FixedRateBond(
+            settlementDays,
+            self.faceAmount,
+            fixedBondSchedule1,
+            [0.04],
+            ql.ActualActual(ql.ActualActual.ISDA),
+            ql.Following,
+            100.0,
+            ql.Date(4, ql.January, 2005),
+        )
         fixedSpecializedBond1.setPricingEngine(bondEngine)
 
         fixedBondTheoValue1 = fixedBond1.cleanPrice()
         fixedSpecializedBondTheoValue1 = fixedSpecializedBond1.cleanPrice()
         tolerance = 1.0e-13
-        error1 = abs(fixedBondTheoValue1-fixedSpecializedBondTheoValue1)
+        error1 = abs(fixedBondTheoValue1 - fixedSpecializedBondTheoValue1)
 
-        self.assertFalse(error1>tolerance,
+        self.assertFalse(
+            error1 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  specialized fixed rate bond's theo clean price: "  + str(fixedBondTheoValue1)
-            + "\n  generic equivalent bond's theo clean price: "  + str(fixedSpecializedBondTheoValue1)
-            + "\n  error:                 " + str(error1)
-            + "\n  tolerance:             " + str(tolerance))
-        
-        fixedBondTheoDirty1 = fixedBondTheoValue1+fixedBond1.accruedAmount()
-        fixedSpecializedTheoDirty1 = fixedSpecializedBondTheoValue1+ fixedSpecializedBond1.accruedAmount()
-        error2 = abs(fixedBondTheoDirty1-fixedSpecializedTheoDirty1)
+            + "\n  specialized fixed rate bond's theo clean price: "
+            + str(fixedBondTheoValue1)
+            + "\n  generic equivalent bond's theo clean price: "
+            + str(fixedSpecializedBondTheoValue1)
+            + "\n  error:                 "
+            + str(error1)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
-        self.assertFalse(error2>tolerance,
+        fixedBondTheoDirty1 = fixedBondTheoValue1 + fixedBond1.accruedAmount()
+        fixedSpecializedTheoDirty1 = fixedSpecializedBondTheoValue1 + fixedSpecializedBond1.accruedAmount()
+        error2 = abs(fixedBondTheoDirty1 - fixedSpecializedTheoDirty1)
+
+        self.assertFalse(
+            error2 > tolerance,
             "wrong dirty price for fixed bond:"
-            + "\n  specialized fixed rate bond's theo dirty price: " +  str(fixedBondTheoDirty1)
-            + "\n  generic equivalent bond's theo dirty price: " + str(fixedSpecializedTheoDirty1)
-            + "\n  error:                 " + str(error2)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  specialized fixed rate bond's theo dirty price: "
+            + str(fixedBondTheoDirty1)
+            + "\n  generic equivalent bond's theo dirty price: "
+            + str(fixedSpecializedTheoDirty1)
+            + "\n  error:                 "
+            + str(error2)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## Fixed Underlying bond (Isin: IT0006527060 IBRD 5 02/05/19)
         ## maturity occurs on a business day
-        fixedBondStartDate2 = Date(5,February,2005)
-        fixedBondMaturityDate2 = Date(5,February,2019)
-        fixedBondSchedule2 = Schedule(fixedBondStartDate2,
-                                    fixedBondMaturityDate2,
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBondLeg2 = list(FixedRateLeg(fixedBondSchedule2, Thirty360(Thirty360.BondBasis),[self.faceAmount],[0.05]))
-        fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2, Following)
-        fixedBondLeg2.append(SimpleCashFlow(100.0, fixedbondRedemption2))
+        fixedBondStartDate2 = ql.Date(5, ql.February, 2005)
+        fixedBondMaturityDate2 = ql.Date(5, ql.February, 2019)
+        fixedBondSchedule2 = ql.Schedule(
+            fixedBondStartDate2,
+            fixedBondMaturityDate2,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBondLeg2 = list(
+            ql.FixedRateLeg(fixedBondSchedule2, ql.Thirty360(ql.Thirty360.BondBasis), [self.faceAmount], [0.05])
+        )
+        fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2, ql.Following)
+        fixedBondLeg2.append(ql.SimpleCashFlow(100.0, fixedbondRedemption2))
 
         ## generic bond
-        fixedBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2)
+        fixedBond2 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2
+        )
         fixedBond2.setPricingEngine(bondEngine)
 
         ## equivalent specialized fixed rate bond
-        fixedSpecializedBond2 = FixedRateBond(settlementDays, self.faceAmount, fixedBondSchedule2,
-                          [0.05],Thirty360(Thirty360.BondBasis), Following,
-                          100.0, Date(5,February,2005))
+        fixedSpecializedBond2 = ql.FixedRateBond(
+            settlementDays,
+            self.faceAmount,
+            fixedBondSchedule2,
+            [0.05],
+            ql.Thirty360(ql.Thirty360.BondBasis),
+            ql.Following,
+            100.0,
+            ql.Date(5, ql.February, 2005),
+        )
         fixedSpecializedBond2.setPricingEngine(bondEngine)
 
         fixedBondTheoValue2 = fixedBond2.cleanPrice()
         fixedSpecializedBondTheoValue2 = fixedSpecializedBond2.cleanPrice()
 
-        error3 = abs(fixedBondTheoValue2-fixedSpecializedBondTheoValue2)
-        self.assertFalse(error3>tolerance, 
+        error3 = abs(fixedBondTheoValue2 - fixedSpecializedBondTheoValue2)
+        self.assertFalse(
+            error3 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  specialized fixed rate bond's theo clean price: "   + str(fixedBondTheoValue2)
-            + "\n  generic equivalent bond's theo clean price: " + str(fixedSpecializedBondTheoValue2)
-            + "\n  error:                 " + str(error3)
-            + "\n  tolerance:             " + str(tolerance))
-        
-        fixedBondTheoDirty2 = fixedBondTheoValue2+ fixedBond2.accruedAmount()
-        fixedSpecializedBondTheoDirty2 = fixedSpecializedBondTheoValue2+ fixedSpecializedBond2.accruedAmount()
+            + "\n  specialized fixed rate bond's theo clean price: "
+            + str(fixedBondTheoValue2)
+            + "\n  generic equivalent bond's theo clean price: "
+            + str(fixedSpecializedBondTheoValue2)
+            + "\n  error:                 "
+            + str(error3)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
-        error4 = abs(fixedBondTheoDirty2-fixedSpecializedBondTheoDirty2)
-        self.assertFalse(error4>tolerance, 
+        fixedBondTheoDirty2 = fixedBondTheoValue2 + fixedBond2.accruedAmount()
+        fixedSpecializedBondTheoDirty2 = fixedSpecializedBondTheoValue2 + fixedSpecializedBond2.accruedAmount()
+
+        error4 = abs(fixedBondTheoDirty2 - fixedSpecializedBondTheoDirty2)
+        self.assertFalse(
+            error4 > tolerance,
             "wrong dirty price for fixed bond:"
-            + "\n  specialized fixed rate bond's dirty clean price: "  + str(fixedBondTheoDirty2)
-            + "\n  generic equivalent bond's theo dirty price: "  + str(fixedSpecializedBondTheoDirty2)
-            + "\n  error:                 " + str(error4)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  specialized fixed rate bond's dirty clean price: "
+            + str(fixedBondTheoDirty2)
+            + "\n  generic equivalent bond's theo dirty price: "
+            + str(fixedSpecializedBondTheoDirty2)
+            + "\n  error:                 "
+            + str(error4)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## FRN Underlying bond (Isin: IT0003543847 ISPIM 0 09/29/13)
         ## maturity doesn't occur on a business day
-        floatingBondStartDate1 = Date(29,September,2003)
-        floatingBondMaturityDate1 = Date(29,September,2013)
-        floatingBondSchedule1 = Schedule(floatingBondStartDate1,
-                                       floatingBondMaturityDate1,
-                                      Period(Semiannual), bondCalendar,
-                                       Unadjusted, Unadjusted,
-                                       DateGeneration.Backward, False)
-        floatingBondLeg1 = list(IborLeg([self.faceAmount],floatingBondSchedule1, self.iborIndex,
-                                   Actual360(),Following,[fixingDays],[],[0.0056],[],[],inArrears))
-        floatingbondRedemption1 = bondCalendar.adjust(floatingBondMaturityDate1, Following)
-        floatingBondLeg1.append(SimpleCashFlow(100.0, floatingbondRedemption1))
+        floatingBondStartDate1 = ql.Date(29, ql.September, 2003)
+        floatingBondMaturityDate1 = ql.Date(29, ql.September, 2013)
+        floatingBondSchedule1 = ql.Schedule(
+            floatingBondStartDate1,
+            floatingBondMaturityDate1,
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        floatingBondLeg1 = list(
+            ql.IborLeg(
+                [self.faceAmount],
+                floatingBondSchedule1,
+                self.iborIndex,
+                ql.Actual360(),
+                ql.Following,
+                [fixingDays],
+                [],
+                [0.0056],
+                [],
+                [],
+                inArrears,
+            )
+        )
+        floatingbondRedemption1 = bondCalendar.adjust(floatingBondMaturityDate1, ql.Following)
+        floatingBondLeg1.append(ql.SimpleCashFlow(100.0, floatingbondRedemption1))
         ## generic bond
-        floatingBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 floatingBondMaturityDate1, floatingBondStartDate1,
-                 floatingBondLeg1)
+        floatingBond1 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            floatingBondMaturityDate1,
+            floatingBondStartDate1,
+            floatingBondLeg1,
+        )
         floatingBond1.setPricingEngine(bondEngine)
 
         ## equivalent specialized floater
-        floatingSpecializedBond1 = FloatingRateBond(settlementDays, self.faceAmount,
-                                floatingBondSchedule1,
-                                self.iborIndex, Actual360(),
-                                Following, fixingDays,
-                                [1],
-                                [0.0056],
-                                [], [],
-                                inArrears,
-                                100.0, Date(29,September,2003))
+        floatingSpecializedBond1 = ql.FloatingRateBond(
+            settlementDays,
+            self.faceAmount,
+            floatingBondSchedule1,
+            self.iborIndex,
+            ql.Actual360(),
+            ql.Following,
+            fixingDays,
+            [1],
+            [0.0056],
+            [],
+            [],
+            inArrears,
+            100.0,
+            ql.Date(29, ql.September, 2003),
+        )
         floatingSpecializedBond1.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond1.cashflows(), self.pricer)
-        setCouponPricer(floatingSpecializedBond1.cashflows(), self.pricer)
-        self.iborIndex.addFixing(Date(27,March,2007), 0.0402)
+        ql.setCouponPricer(floatingBond1.cashflows(), self.pricer)
+        ql.setCouponPricer(floatingSpecializedBond1.cashflows(), self.pricer)
+        self.iborIndex.addFixing(ql.Date(27, ql.March, 2007), 0.0402)
         floatingBondTheoValue1 = floatingBond1.cleanPrice()
         floatingSpecializedBondTheoValue1 = floatingSpecializedBond1.cleanPrice()
 
-        error5 = abs(floatingBondTheoValue1-
-                                floatingSpecializedBondTheoValue1)
-        self.assertFalse(error5>tolerance, 
+        error5 = abs(floatingBondTheoValue1 - floatingSpecializedBondTheoValue1)
+        self.assertFalse(
+            error5 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  generic fixed rate bond's theo clean price: " + str(floatingBondTheoValue1)
-            + "\n  equivalent specialized bond's theo clean price: " + str(floatingSpecializedBondTheoValue1)
-            + "\n  error:                 " + str(error5)
-            + "\n  tolerance:             " + str(tolerance))
-        
-        floatingBondTheoDirty1 = floatingBondTheoValue1+ floatingBond1.accruedAmount()
+            + "\n  generic fixed rate bond's theo clean price: "
+            + str(floatingBondTheoValue1)
+            + "\n  equivalent specialized bond's theo clean price: "
+            + str(floatingSpecializedBondTheoValue1)
+            + "\n  error:                 "
+            + str(error5)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
+        floatingBondTheoDirty1 = floatingBondTheoValue1 + floatingBond1.accruedAmount()
         floatingSpecializedBondTheoDirty1 = floatingSpecializedBondTheoValue1 + floatingSpecializedBond1.accruedAmount()
-        error6 = abs(floatingBondTheoDirty1-
-                                floatingSpecializedBondTheoDirty1)
-        self.assertFalse(error6>tolerance,
+        error6 = abs(floatingBondTheoDirty1 - floatingSpecializedBondTheoDirty1)
+        self.assertFalse(
+            error6 > tolerance,
             "wrong dirty price for frn bond:"
-            + "\n  generic frn bond's dirty clean price: " + str(floatingBondTheoDirty1)
-            + "\n  equivalent specialized bond's theo dirty price: " + str(floatingSpecializedBondTheoDirty1)
-            + "\n  error:                 " + str(error6)
-            + "\n  tolerance:             " + str(tolerance))
-   
+            + "\n  generic frn bond's dirty clean price: "
+            + str(floatingBondTheoDirty1)
+            + "\n  equivalent specialized bond's theo dirty price: "
+            + str(floatingSpecializedBondTheoDirty1)
+            + "\n  error:                 "
+            + str(error6)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## FRN Underlying bond (Isin: XS0090566539 COE 0 09/24/18)
         ## maturity occurs on a business day
-        floatingBondStartDate2 = Date(24,September,2004)
-        floatingBondMaturityDate2 = Date(24,September,2018)
-        floatingBondSchedule2 = Schedule(floatingBondStartDate2,
-                                       floatingBondMaturityDate2,
-                                       Period(Semiannual), bondCalendar,
-                                       ModifiedFollowing, ModifiedFollowing,
-                                       DateGeneration.Backward, False)
-        floatingBondLeg2 = list(IborLeg([self.faceAmount], floatingBondSchedule2, self.iborIndex,
-                                       Actual360(),ModifiedFollowing,[fixingDays], [],[0.0025],[],[],inArrears))
-        floatingbondRedemption2 = bondCalendar.adjust(floatingBondMaturityDate2, ModifiedFollowing)
-        floatingBondLeg2.append(SimpleCashFlow(100.0, floatingbondRedemption2))
+        floatingBondStartDate2 = ql.Date(24, ql.September, 2004)
+        floatingBondMaturityDate2 = ql.Date(24, ql.September, 2018)
+        floatingBondSchedule2 = ql.Schedule(
+            floatingBondStartDate2,
+            floatingBondMaturityDate2,
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.ModifiedFollowing,
+            ql.ModifiedFollowing,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        floatingBondLeg2 = list(
+            ql.IborLeg(
+                [self.faceAmount],
+                floatingBondSchedule2,
+                self.iborIndex,
+                ql.Actual360(),
+                ql.ModifiedFollowing,
+                [fixingDays],
+                [],
+                [0.0025],
+                [],
+                [],
+                inArrears,
+            )
+        )
+        floatingbondRedemption2 = bondCalendar.adjust(floatingBondMaturityDate2, ql.ModifiedFollowing)
+        floatingBondLeg2.append(ql.SimpleCashFlow(100.0, floatingbondRedemption2))
         ## generic bond
-        floatingBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 floatingBondMaturityDate2, floatingBondStartDate2,
-                 floatingBondLeg2)
+        floatingBond2 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            floatingBondMaturityDate2,
+            floatingBondStartDate2,
+            floatingBondLeg2,
+        )
         floatingBond2.setPricingEngine(bondEngine)
 
         ## equivalent specialized floater
-        floatingSpecializedBond2 = FloatingRateBond(settlementDays, self.faceAmount,
-                             floatingBondSchedule2,
-                             self.iborIndex, Actual360(),
-                             ModifiedFollowing, fixingDays,
-                             [1], [0.0025],
-                             [], [],
-                             inArrears,
-                             100.0, Date(24,September,2004))
+        floatingSpecializedBond2 = ql.FloatingRateBond(
+            settlementDays,
+            self.faceAmount,
+            floatingBondSchedule2,
+            self.iborIndex,
+            ql.Actual360(),
+            ql.ModifiedFollowing,
+            fixingDays,
+            [1],
+            [0.0025],
+            [],
+            [],
+            inArrears,
+            100.0,
+            ql.Date(24, ql.September, 2004),
+        )
         floatingSpecializedBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond2.cashflows(), self.pricer)
-        setCouponPricer(floatingSpecializedBond2.cashflows(), self.pricer)
+        ql.setCouponPricer(floatingBond2.cashflows(), self.pricer)
+        ql.setCouponPricer(floatingSpecializedBond2.cashflows(), self.pricer)
 
-        self.iborIndex.addFixing(Date(22,March,2007), 0.04013)
+        self.iborIndex.addFixing(ql.Date(22, ql.March, 2007), 0.04013)
 
         floatingBondTheoValue2 = floatingBond2.cleanPrice()
         floatingSpecializedBondTheoValue2 = floatingSpecializedBond2.cleanPrice()
 
-        error7 = abs(floatingBondTheoValue2-floatingSpecializedBondTheoValue2)
-        self.assertFalse(error7>tolerance, 
+        error7 = abs(floatingBondTheoValue2 - floatingSpecializedBondTheoValue2)
+        self.assertFalse(
+            error7 > tolerance,
             "wrong clean price for floater bond:"
-            + "\n  generic floater bond's theo clean price: " + str(floatingBondTheoValue2)
-            + "\n  equivalent specialized bond's theo clean price: " + str(floatingSpecializedBondTheoValue2)
-            + "\n  error:                 " + str(error7)
-            + "\n  tolerance:             " + str(tolerance))
-        
-        floatingBondTheoDirty2 = floatingBondTheoValue2+ floatingBond2.accruedAmount()
-        floatingSpecializedTheoDirty2 = floatingSpecializedBondTheoValue2+ floatingSpecializedBond2.accruedAmount()
+            + "\n  generic floater bond's theo clean price: "
+            + str(floatingBondTheoValue2)
+            + "\n  equivalent specialized bond's theo clean price: "
+            + str(floatingSpecializedBondTheoValue2)
+            + "\n  error:                 "
+            + str(error7)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
-        error8 = abs(floatingBondTheoDirty2-floatingSpecializedTheoDirty2)
-        self.assertFalse(error8>tolerance, 
+        floatingBondTheoDirty2 = floatingBondTheoValue2 + floatingBond2.accruedAmount()
+        floatingSpecializedTheoDirty2 = floatingSpecializedBondTheoValue2 + floatingSpecializedBond2.accruedAmount()
+
+        error8 = abs(floatingBondTheoDirty2 - floatingSpecializedTheoDirty2)
+        self.assertFalse(
+            error8 > tolerance,
             "wrong dirty price for floater bond:"
-            + "\n  generic floater bond's theo dirty price: " + str(floatingBondTheoDirty2)
-            + "\n  equivalent specialized  bond's theo dirty price: " + str(floatingSpecializedTheoDirty2)
-            + "\n  error:                 " + str(error8)
-            + "\n  tolerance:             " + str(tolerance))
-        
-
+            + "\n  generic floater bond's theo dirty price: "
+            + str(floatingBondTheoDirty2)
+            + "\n  equivalent specialized  bond's theo dirty price: "
+            + str(floatingSpecializedTheoDirty2)
+            + "\n  error:                 "
+            + str(error8)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## CMS Underlying bond (Isin: XS0228052402 CRDIT 0 8/22/20)
         ## maturity doesn't occur on a business day
-        cmsBondStartDate1 = Date(22,August,2005)
-        cmsBondMaturityDate1 = Date(22,August,2020)
-        cmsBondSchedule1 = Schedule(cmsBondStartDate1,
-                                  cmsBondMaturityDate1,
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBondLeg1 = list(CmsLeg([self.faceAmount],cmsBondSchedule1, self.swapIndex,
-                                 Thirty360(), Following, [fixingDays], [],[],[0.055],[0.025],inArrears))
-        cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1, Following)
-        cmsBondLeg1.append(SimpleCashFlow(100.0, cmsbondRedemption1))
+        cmsBondStartDate1 = ql.Date(22, ql.August, 2005)
+        cmsBondMaturityDate1 = ql.Date(22, ql.August, 2020)
+        cmsBondSchedule1 = ql.Schedule(
+            cmsBondStartDate1,
+            cmsBondMaturityDate1,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBondLeg1 = list(
+            ql.CmsLeg(
+                [self.faceAmount],
+                cmsBondSchedule1,
+                self.swapIndex,
+                ql.Thirty360(),
+                ql.Following,
+                [fixingDays],
+                [],
+                [],
+                [0.055],
+                [0.025],
+                inArrears,
+            )
+        )
+        cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1, ql.Following)
+        cmsBondLeg1.append(ql.SimpleCashFlow(100.0, cmsbondRedemption1))
         ## generic cms bond
-        cmsBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1)
+        cmsBond1 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1
+        )
         cmsBond1.setPricingEngine(bondEngine)
 
         ## equivalent specialized cms bond
-        cmsSpecializedBond1 = CmsRateBond(settlementDays, self.faceAmount, cmsBondSchedule1,
-                    self.swapIndex, Thirty360(),
-                    Following, fixingDays,
-                    [1.0], [0.0],
-                    [0.055],[0.025],
-                    inArrears,
-                    100.0, Date(22,August,2005))
+        cmsSpecializedBond1 = ql.CmsRateBond(
+            settlementDays,
+            self.faceAmount,
+            cmsBondSchedule1,
+            self.swapIndex,
+            ql.Thirty360(),
+            ql.Following,
+            fixingDays,
+            [1.0],
+            [0.0],
+            [0.055],
+            [0.025],
+            inArrears,
+            100.0,
+            ql.Date(22, ql.August, 2005),
+        )
         cmsSpecializedBond1.setPricingEngine(bondEngine)
 
-        setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
-        setCouponPricer(cmsSpecializedBond1.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(18,August,2006), 0.04158)
+        ql.setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
+        ql.setCouponPricer(cmsSpecializedBond1.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(18, ql.August, 2006), 0.04158)
         cmsBondTheoValue1 = cmsBond1.cleanPrice()
         cmsSpecializedBondTheoValue1 = cmsSpecializedBond1.cleanPrice()
-        error9 = abs(cmsBondTheoValue1-cmsSpecializedBondTheoValue1)
-        self.assertFalse(error9>tolerance, 
+        error9 = abs(cmsBondTheoValue1 - cmsSpecializedBondTheoValue1)
+        self.assertFalse(
+            error9 > tolerance,
             "wrong clean price for cms bond:"
-            + "\n  generic cms bond's theo clean price: " + str(cmsBondTheoValue1)
-            + "\n  equivalent specialized bond's theo clean price: " + str(cmsSpecializedBondTheoValue1)
-            + "\n  error:                 " + str(error9)
-            + "\n  tolerance:             " + str(tolerance))
-        
-        cmsBondTheoDirty1 = cmsBondTheoValue1+cmsBond1.accruedAmount()
-        cmsSpecializedBondTheoDirty1 = cmsSpecializedBondTheoValue1+ cmsSpecializedBond1.accruedAmount()
-        error10 = abs(cmsBondTheoDirty1-cmsSpecializedBondTheoDirty1)
-        self.assertFalse(error10>tolerance,
+            + "\n  generic cms bond's theo clean price: "
+            + str(cmsBondTheoValue1)
+            + "\n  equivalent specialized bond's theo clean price: "
+            + str(cmsSpecializedBondTheoValue1)
+            + "\n  error:                 "
+            + str(error9)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
+        cmsBondTheoDirty1 = cmsBondTheoValue1 + cmsBond1.accruedAmount()
+        cmsSpecializedBondTheoDirty1 = cmsSpecializedBondTheoValue1 + cmsSpecializedBond1.accruedAmount()
+        error10 = abs(cmsBondTheoDirty1 - cmsSpecializedBondTheoDirty1)
+        self.assertFalse(
+            error10 > tolerance,
             "wrong dirty price for cms bond:"
-            + "\n generic cms bond's theo dirty price: " + str(cmsBondTheoDirty1)
-            + "\n  specialized cms bond's theo dirty price: " + str(cmsSpecializedBondTheoDirty1)
-            + "\n  error:                 " + str(error10)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n generic cms bond's theo dirty price: "
+            + str(cmsBondTheoDirty1)
+            + "\n  specialized cms bond's theo dirty price: "
+            + str(cmsSpecializedBondTheoDirty1)
+            + "\n  error:                 "
+            + str(error10)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
         ## maturity occurs on a business day
-        cmsBondStartDate2 = Date(6,May,2005)
-        cmsBondMaturityDate2 = Date(6,May,2015)
-        cmsBondSchedule2 = Schedule(cmsBondStartDate2,
-                                  cmsBondMaturityDate2,
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBondLeg2 = list(CmsLeg([self.faceAmount],cmsBondSchedule2, self.swapIndex,
-                            Thirty360(),Following,[fixingDays],[0.84],[],[],[],inArrears))
-        cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2, Following)
-        cmsBondLeg2.append(SimpleCashFlow(100.0, cmsbondRedemption2))
+        cmsBondStartDate2 = ql.Date(6, ql.May, 2005)
+        cmsBondMaturityDate2 = ql.Date(6, ql.May, 2015)
+        cmsBondSchedule2 = ql.Schedule(
+            cmsBondStartDate2,
+            cmsBondMaturityDate2,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBondLeg2 = list(
+            ql.CmsLeg(
+                [self.faceAmount],
+                cmsBondSchedule2,
+                self.swapIndex,
+                ql.Thirty360(),
+                ql.Following,
+                [fixingDays],
+                [0.84],
+                [],
+                [],
+                [],
+                inArrears,
+            )
+        )
+        cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2, ql.Following)
+        cmsBondLeg2.append(ql.SimpleCashFlow(100.0, cmsbondRedemption2))
         ## generic bond
-        cmsBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2)
+        cmsBond2 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2
+        )
         cmsBond2.setPricingEngine(bondEngine)
-        
+
         ## equivalent specialized cms bond
-        cmsSpecializedBond2 = CmsRateBond(settlementDays, self.faceAmount, cmsBondSchedule2,
-                    self.swapIndex, Thirty360(),
-                    Following, fixingDays,
-                    [0.84], [0.0],
-                    [], [],
-                    inArrears,
-                    100.0, Date(6,May,2005))
+        cmsSpecializedBond2 = ql.CmsRateBond(
+            settlementDays,
+            self.faceAmount,
+            cmsBondSchedule2,
+            self.swapIndex,
+            ql.Thirty360(),
+            ql.Following,
+            fixingDays,
+            [0.84],
+            [0.0],
+            [],
+            [],
+            inArrears,
+            100.0,
+            ql.Date(6, ql.May, 2005),
+        )
         cmsSpecializedBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
-        setCouponPricer(cmsSpecializedBond2.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(4,May,2006), 0.04217)
+        ql.setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
+        ql.setCouponPricer(cmsSpecializedBond2.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(4, ql.May, 2006), 0.04217)
         cmsBondTheoValue2 = cmsBond2.cleanPrice()
         cmsSpecializedBondTheoValue2 = cmsSpecializedBond2.cleanPrice()
 
-        error11 = abs(cmsBondTheoValue2-cmsSpecializedBondTheoValue2)
-        self.assertFalse(error11>tolerance, 
+        error11 = abs(cmsBondTheoValue2 - cmsSpecializedBondTheoValue2)
+        self.assertFalse(
+            error11 > tolerance,
             "wrong clean price for cms bond:"
-            + "\n  generic cms bond's theo clean price: " + str(cmsBondTheoValue2)
-            + "\n  cms bond's theo clean price: " + str(cmsSpecializedBondTheoValue2)
-            + "\n  error:                 " + str(error11) 
-            + "\n  tolerance:             " + str(tolerance))
-        
-        cmsBondTheoDirty2 = cmsBondTheoValue2+cmsBond2.accruedAmount()
-        cmsSpecializedBondTheoDirty2 = cmsSpecializedBondTheoValue2+cmsSpecializedBond2.accruedAmount()
-        error12 = abs(cmsBondTheoDirty2-cmsSpecializedBondTheoDirty2)
-        self.assertFalse(error12>tolerance,
+            + "\n  generic cms bond's theo clean price: "
+            + str(cmsBondTheoValue2)
+            + "\n  cms bond's theo clean price: "
+            + str(cmsSpecializedBondTheoValue2)
+            + "\n  error:                 "
+            + str(error11)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
+        cmsBondTheoDirty2 = cmsBondTheoValue2 + cmsBond2.accruedAmount()
+        cmsSpecializedBondTheoDirty2 = cmsSpecializedBondTheoValue2 + cmsSpecializedBond2.accruedAmount()
+        error12 = abs(cmsBondTheoDirty2 - cmsSpecializedBondTheoDirty2)
+        self.assertFalse(
+            error12 > tolerance,
             "wrong dirty price for cms bond:"
-            + "\n  generic cms bond's dirty price: " + str(cmsBondTheoDirty2)
-            + "\n  specialized cms bond's theo dirty price: " + str(cmsSpecializedBondTheoDirty2)
-            + "\n  error:                 " + str(error12)
-            + "\n  tolerance:             " + str(tolerance))
-        
-        
+            + "\n  generic cms bond's dirty price: "
+            + str(cmsBondTheoDirty2)
+            + "\n  specialized cms bond's theo dirty price: "
+            + str(cmsSpecializedBondTheoDirty2)
+            + "\n  error:                 "
+            + str(error12)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
         ## Zero Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
         ## maturity doesn't occur on a business day
-        zeroCpnBondStartDate1 = Date(19,December,1985)
-        zeroCpnBondMaturityDate1 = Date(20,December,2015)
-        zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1,
-                                                          Following)
-        zeroCpnBondLeg1 = Leg([SimpleCashFlow(100.0, zeroCpnBondRedemption1)])
+        zeroCpnBondStartDate1 = ql.Date(19, ql.December, 1985)
+        zeroCpnBondMaturityDate1 = ql.Date(20, ql.December, 2015)
+        zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1, ql.Following)
+        zeroCpnBondLeg1 = ql.Leg([ql.SimpleCashFlow(100.0, zeroCpnBondRedemption1)])
 
         ## generic bond
-        zeroCpnBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1)
+        zeroCpnBond1 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            zeroCpnBondMaturityDate1,
+            zeroCpnBondStartDate1,
+            zeroCpnBondLeg1,
+        )
         zeroCpnBond1.setPricingEngine(bondEngine)
 
         ## specialized zerocpn bond
-        zeroCpnSpecializedBond1 = ZeroCouponBond(settlementDays, bondCalendar, self.faceAmount,
-                      Date(20,December,2015),
-                      Following,
-                      100.0, Date(19,December,1985))
+        zeroCpnSpecializedBond1 = ql.ZeroCouponBond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            ql.Date(20, ql.December, 2015),
+            ql.Following,
+            100.0,
+            ql.Date(19, ql.December, 1985),
+        )
         zeroCpnSpecializedBond1.setPricingEngine(bondEngine)
 
         zeroCpnBondTheoValue1 = zeroCpnBond1.cleanPrice()
         zeroCpnSpecializedBondTheoValue1 = zeroCpnSpecializedBond1.cleanPrice()
 
-        error13 = abs(zeroCpnBondTheoValue1-zeroCpnSpecializedBondTheoValue1)
-        self.assertFalse(error13>tolerance, 
+        error13 = abs(zeroCpnBondTheoValue1 - zeroCpnSpecializedBondTheoValue1)
+        self.assertFalse(
+            error13 > tolerance,
             "wrong clean price for zero coupon bond:"
-            + "\n  generic zero bond's clean price: " + str(zeroCpnBondTheoValue1)
-            + "\n  specialized zero bond's clean price: " + str(zeroCpnSpecializedBondTheoValue1)
-            + "\n  error:                 " + str(error13)
-            + "\n  tolerance:             " + str(tolerance))
-        
-        zeroCpnBondTheoDirty1 = zeroCpnBondTheoValue1+ zeroCpnBond1.accruedAmount()
-        zeroCpnSpecializedBondTheoDirty1 = zeroCpnSpecializedBondTheoValue1+ \
-            zeroCpnSpecializedBond1.accruedAmount()
-        error14 = abs(zeroCpnBondTheoDirty1-zeroCpnSpecializedBondTheoDirty1)
-        self.assertFalse(error14>tolerance, 
+            + "\n  generic zero bond's clean price: "
+            + str(zeroCpnBondTheoValue1)
+            + "\n  specialized zero bond's clean price: "
+            + str(zeroCpnSpecializedBondTheoValue1)
+            + "\n  error:                 "
+            + str(error13)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
+        zeroCpnBondTheoDirty1 = zeroCpnBondTheoValue1 + zeroCpnBond1.accruedAmount()
+        zeroCpnSpecializedBondTheoDirty1 = zeroCpnSpecializedBondTheoValue1 + zeroCpnSpecializedBond1.accruedAmount()
+        error14 = abs(zeroCpnBondTheoDirty1 - zeroCpnSpecializedBondTheoDirty1)
+        self.assertFalse(
+            error14 > tolerance,
             "wrong dirty price for zero bond:"
-            + "\n  generic zerocpn bond's dirty price: " + str(zeroCpnBondTheoDirty1)
-            + "\n  specialized zerocpn bond's clean price: " + str(zeroCpnSpecializedBondTheoDirty1)
-            + "\n  error:                 " + str(error14)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  generic zerocpn bond's dirty price: "
+            + str(zeroCpnBondTheoDirty1)
+            + "\n  specialized zerocpn bond's clean price: "
+            + str(zeroCpnSpecializedBondTheoDirty1)
+            + "\n  error:                 "
+            + str(error14)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
         ## maturity occurs on a business day
-        zeroCpnBondStartDate2 = Date(17,February,1998)
-        zeroCpnBondMaturityDate2 = Date(17,February,2028)
-        zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2,
-                                                          Following)
-        zeroCpnBondLeg2 = Leg([SimpleCashFlow(100.0, zerocpbondRedemption2)])
+        zeroCpnBondStartDate2 = ql.Date(17, ql.February, 1998)
+        zeroCpnBondMaturityDate2 = ql.Date(17, ql.February, 2028)
+        zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2, ql.Following)
+        zeroCpnBondLeg2 = ql.Leg([ql.SimpleCashFlow(100.0, zerocpbondRedemption2)])
         ## generic bond
-        zeroCpnBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2)
+        zeroCpnBond2 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            zeroCpnBondMaturityDate2,
+            zeroCpnBondStartDate2,
+            zeroCpnBondLeg2,
+        )
         zeroCpnBond2.setPricingEngine(bondEngine)
 
         ## specialized zerocpn bond
-        zeroCpnSpecializedBond2 = ZeroCouponBond(settlementDays, bondCalendar, self.faceAmount,
-                       Date(17,February,2028),
-                       Following,
-                       100.0, Date(17,February,1998))
+        zeroCpnSpecializedBond2 = ql.ZeroCouponBond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            ql.Date(17, ql.February, 2028),
+            ql.Following,
+            100.0,
+            ql.Date(17, ql.February, 1998),
+        )
         zeroCpnSpecializedBond2.setPricingEngine(bondEngine)
 
         zeroCpnBondTheoValue2 = zeroCpnBond2.cleanPrice()
         zeroCpnSpecializedBondTheoValue2 = zeroCpnSpecializedBond2.cleanPrice()
 
-        error15 = abs(zeroCpnBondTheoValue2 -zeroCpnSpecializedBondTheoValue2)
-        self.assertFalse(error15>tolerance, 
+        error15 = abs(zeroCpnBondTheoValue2 - zeroCpnSpecializedBondTheoValue2)
+        self.assertFalse(
+            error15 > tolerance,
             "wrong clean price for zero coupon bond:"
-            + "\n  generic zerocpn bond's clean price: " + str(zeroCpnBondTheoValue2)
-            + "\n  specialized zerocpn bond's clean price: " + str(zeroCpnSpecializedBondTheoValue2)
-            + "\n  error:                 " + str(error15)
-            + "\n  tolerance:             " + str(tolerance))
-        
-        zeroCpnBondTheoDirty2 = zeroCpnBondTheoValue2+ zeroCpnBond2.accruedAmount()
+            + "\n  generic zerocpn bond's clean price: "
+            + str(zeroCpnBondTheoValue2)
+            + "\n  specialized zerocpn bond's clean price: "
+            + str(zeroCpnSpecializedBondTheoValue2)
+            + "\n  error:                 "
+            + str(error15)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
-        zeroCpnSpecializedBondTheoDirty2 = \
-            zeroCpnSpecializedBondTheoValue2+ \
-            zeroCpnSpecializedBond2.accruedAmount()
+        zeroCpnBondTheoDirty2 = zeroCpnBondTheoValue2 + zeroCpnBond2.accruedAmount()
 
-        error16 = abs(zeroCpnBondTheoDirty2-zeroCpnSpecializedBondTheoDirty2)
-        self.assertFalse(error16>tolerance, 
+        zeroCpnSpecializedBondTheoDirty2 = zeroCpnSpecializedBondTheoValue2 + zeroCpnSpecializedBond2.accruedAmount()
+
+        error16 = abs(zeroCpnBondTheoDirty2 - zeroCpnSpecializedBondTheoDirty2)
+        self.assertFalse(
+            error16 > tolerance,
             "wrong dirty price for zero coupon bond:"
-            + "\n  generic zerocpn bond's dirty price: " + str(zeroCpnBondTheoDirty2)
-            + "\n  specialized zerocpn bond's dirty price: " + str(zeroCpnSpecializedBondTheoDirty2)
-            + "\n  error:                 " + str(error16)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  generic zerocpn bond's dirty price: "
+            + str(zeroCpnBondTheoDirty2)
+            + "\n  specialized zerocpn bond's dirty price: "
+            + str(zeroCpnSpecializedBondTheoDirty2)
+            + "\n  error:                 "
+            + str(error16)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
-
-
-    def testSpecializedBondVsGenericBondUsingAsw(self) :
+    def testSpecializedBondVsGenericBondUsingAsw(self):
         """Testing asset-swap prices and spreads for specialized bond against equivalent generic bond..."""
-        
-        bondCalendar = TARGET()
+
+        bondCalendar = ql.TARGET()
         settlementDays = 3
         fixingDays = 2
         payFixedRate = True
@@ -2795,676 +4318,1037 @@ class AssetSwapTest(unittest.TestCase):
 
         ## Fixed bond (Isin: DE0001135275 DBR 4 01/04/37)
         ## maturity doesn't occur on a business day
-        fixedBondStartDate1 = Date(4,January,2005)
-        fixedBondMaturityDate1 = Date(4,January,2037)
-        fixedBondSchedule1 = Schedule(fixedBondStartDate1,
-                                    fixedBondMaturityDate1,
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBondLeg1 = list(FixedRateLeg(fixedBondSchedule1,
-                             ActualActual(ActualActual.ISDA), [self.faceAmount],[0.04]))
-        fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1, Following)
-        fixedBondLeg1.append(SimpleCashFlow(100.0, fixedbondRedemption1))
+        fixedBondStartDate1 = ql.Date(4, ql.January, 2005)
+        fixedBondMaturityDate1 = ql.Date(4, ql.January, 2037)
+        fixedBondSchedule1 = ql.Schedule(
+            fixedBondStartDate1,
+            fixedBondMaturityDate1,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBondLeg1 = list(
+            ql.FixedRateLeg(fixedBondSchedule1, ql.ActualActual(ql.ActualActual.ISDA), [self.faceAmount], [0.04])
+        )
+        fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1, ql.Following)
+        fixedBondLeg1.append(ql.SimpleCashFlow(100.0, fixedbondRedemption1))
         ## generic bond
-        fixedBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 fixedBondMaturityDate1, fixedBondStartDate1, fixedBondLeg1)
+        fixedBond1 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, fixedBondMaturityDate1, fixedBondStartDate1, fixedBondLeg1
+        )
 
-        bondEngine = DiscountingBondEngine(self.termStructure)
-        swapEngine = DiscountingSwapEngine(self.termStructure, False)
+        bondEngine = ql.DiscountingBondEngine(self.termStructure)
+        swapEngine = ql.DiscountingSwapEngine(self.termStructure, False)
         fixedBond1.setPricingEngine(bondEngine)
 
         ## equivalent specialized fixed rate bond
-        fixedSpecializedBond1 = FixedRateBond(settlementDays, self.faceAmount, fixedBondSchedule1,
-                          [0.04], ActualActual(ActualActual.ISDA), Following,
-                          100.0, Date(4,January,2005))
+        fixedSpecializedBond1 = ql.FixedRateBond(
+            settlementDays,
+            self.faceAmount,
+            fixedBondSchedule1,
+            [0.04],
+            ql.ActualActual(ql.ActualActual.ISDA),
+            ql.Following,
+            100.0,
+            ql.Date(4, ql.January, 2005),
+        )
         fixedSpecializedBond1.setPricingEngine(bondEngine)
 
         fixedBondPrice1 = fixedBond1.cleanPrice()
         fixedSpecializedBondPrice1 = fixedSpecializedBond1.cleanPrice()
-        fixedBondAssetSwap1 = AssetSwap(payFixedRate,
-                                      fixedBond1, fixedBondPrice1,
-                                      self.iborIndex, self.nonnullspread,
-                                      Schedule(),
-                                      self.iborIndex.dayCounter(),
-                                      parAssetSwap)
+        fixedBondAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond1,
+            fixedBondPrice1,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedBondAssetSwap1.setPricingEngine(swapEngine)
-        fixedSpecializedBondAssetSwap1 = AssetSwap(payFixedRate,
-                                                 fixedSpecializedBond1,
-                                                 fixedSpecializedBondPrice1,
-                                                 self.iborIndex,
-                                                 self.nonnullspread,
-                                                 Schedule(),
-                                                 self.iborIndex.dayCounter(),
-                                                 parAssetSwap)
+        fixedSpecializedBondAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            fixedSpecializedBond1,
+            fixedSpecializedBondPrice1,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedSpecializedBondAssetSwap1.setPricingEngine(swapEngine)
         fixedBondAssetSwapPrice1 = fixedBondAssetSwap1.fairCleanPrice()
         fixedSpecializedBondAssetSwapPrice1 = fixedSpecializedBondAssetSwap1.fairCleanPrice()
         tolerance = 1.0e-13
-        error1 = abs(fixedBondAssetSwapPrice1-fixedSpecializedBondAssetSwapPrice1)
-        self.assertFalse(error1>tolerance, 
+        error1 = abs(fixedBondAssetSwapPrice1 - fixedSpecializedBondAssetSwapPrice1)
+        self.assertFalse(
+            error1 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  generic  fixed rate bond's  clean price: " + str(fixedBondAssetSwapPrice1)
-            + "\n  equivalent specialized bond's clean price: " + str(fixedSpecializedBondAssetSwapPrice1)
-            + "\n  error:                 " + str(error1)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  generic  fixed rate bond's  clean price: "
+            + str(fixedBondAssetSwapPrice1)
+            + "\n  equivalent specialized bond's clean price: "
+            + str(fixedSpecializedBondAssetSwapPrice1)
+            + "\n  error:                 "
+            + str(error1)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
         ## market executable price as of 4th sept 2007
-        fixedBondMktPrice1= 91.832
-        fixedBondASW1 = AssetSwap(payFixedRate,
-                                fixedBond1, fixedBondMktPrice1,
-                                self.iborIndex, self.spread,
-                                Schedule(),
-                                self.iborIndex.dayCounter(),
-                                parAssetSwap)
+        fixedBondMktPrice1 = 91.832
+        fixedBondASW1 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond1,
+            fixedBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedBondASW1.setPricingEngine(swapEngine)
-        fixedSpecializedBondASW1 = AssetSwap(payFixedRate,
-                                           fixedSpecializedBond1,
-                                           fixedBondMktPrice1,
-                                           self.iborIndex, self.spread,
-                                           Schedule(),
-                                           self.iborIndex.dayCounter(),
-                                           parAssetSwap)
+        fixedSpecializedBondASW1 = ql.AssetSwap(
+            payFixedRate,
+            fixedSpecializedBond1,
+            fixedBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedSpecializedBondASW1.setPricingEngine(swapEngine)
         fixedBondASWSpread1 = fixedBondASW1.fairSpread()
         fixedSpecializedBondASWSpread1 = fixedSpecializedBondASW1.fairSpread()
-        error2 = abs(fixedBondASWSpread1-fixedSpecializedBondASWSpread1)
-        self.assertFalse(error2>tolerance, 
+        error2 = abs(fixedBondASWSpread1 - fixedSpecializedBondASWSpread1)
+        self.assertFalse(
+            error2 > tolerance,
             "wrong asw spread  for fixed bond:"
-            + "\n  generic  fixed rate bond's  asw spread: " + str(fixedBondASWSpread1)
-            + "\n  equivalent specialized bond's asw spread: " + str(fixedSpecializedBondASWSpread1)
-            + "\n  error:                 " + str(error2)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  generic  fixed rate bond's  asw spread: "
+            + str(fixedBondASWSpread1)
+            + "\n  equivalent specialized bond's asw spread: "
+            + str(fixedSpecializedBondASWSpread1)
+            + "\n  error:                 "
+            + str(error2)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
-         ##Fixed bond (Isin: IT0006527060 IBRD 5 02/05/19)
-         ##maturity occurs on a business day
+        ##Fixed bond (Isin: IT0006527060 IBRD 5 02/05/19)
+        ##maturity occurs on a business day
 
-        fixedBondStartDate2 = Date(5,February,2005)
-        fixedBondMaturityDate2 = Date(5,February,2019)
-        fixedBondSchedule2 = Schedule(fixedBondStartDate2,
-                                    fixedBondMaturityDate2,
-                                    Period(Annual), bondCalendar,
-                                    Unadjusted, Unadjusted,
-                                    DateGeneration.Backward, False)
-        fixedBondLeg2 = list(FixedRateLeg(fixedBondSchedule2, Thirty360(Thirty360.BondBasis),[self.faceAmount],
-                                    [0.05]))
-        fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2, Following)
-        fixedBondLeg2.append(SimpleCashFlow(100.0, fixedbondRedemption2))
+        fixedBondStartDate2 = ql.Date(5, ql.February, 2005)
+        fixedBondMaturityDate2 = ql.Date(5, ql.February, 2019)
+        fixedBondSchedule2 = ql.Schedule(
+            fixedBondStartDate2,
+            fixedBondMaturityDate2,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        fixedBondLeg2 = list(
+            ql.FixedRateLeg(fixedBondSchedule2, ql.Thirty360(ql.Thirty360.BondBasis), [self.faceAmount], [0.05])
+        )
+        fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2, ql.Following)
+        fixedBondLeg2.append(ql.SimpleCashFlow(100.0, fixedbondRedemption2))
 
         ## generic bond
-        fixedBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2)
+        fixedBond2 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2
+        )
         fixedBond2.setPricingEngine(bondEngine)
 
         ## equivalent specialized fixed rate bond
-        fixedSpecializedBond2 = FixedRateBond(settlementDays, self.faceAmount, fixedBondSchedule2,
-                          [0.05], Thirty360(Thirty360.BondBasis), Following,
-                          100.0, Date(5,February,2005))
+        fixedSpecializedBond2 = ql.FixedRateBond(
+            settlementDays,
+            self.faceAmount,
+            fixedBondSchedule2,
+            [0.05],
+            ql.Thirty360(ql.Thirty360.BondBasis),
+            ql.Following,
+            100.0,
+            ql.Date(5, ql.February, 2005),
+        )
         fixedSpecializedBond2.setPricingEngine(bondEngine)
 
         fixedBondPrice2 = fixedBond2.cleanPrice()
         fixedSpecializedBondPrice2 = fixedSpecializedBond2.cleanPrice()
-        fixedBondAssetSwap2 = AssetSwap(payFixedRate,
-                                      fixedBond2, fixedBondPrice2,
-                                      self.iborIndex, self.nonnullspread,
-                                      Schedule(),
-                                      self.iborIndex.dayCounter(),
-                                      parAssetSwap)
+        fixedBondAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond2,
+            fixedBondPrice2,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedBondAssetSwap2.setPricingEngine(swapEngine)
-        fixedSpecializedBondAssetSwap2 = AssetSwap(payFixedRate,
-                                                 fixedSpecializedBond2,
-                                                 fixedSpecializedBondPrice2,
-                                                 self.iborIndex,
-                                                 self.nonnullspread,
-                                                 Schedule(),
-                                                 self.iborIndex.dayCounter(),
-                                                 parAssetSwap)
+        fixedSpecializedBondAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            fixedSpecializedBond2,
+            fixedSpecializedBondPrice2,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedSpecializedBondAssetSwap2.setPricingEngine(swapEngine)
         fixedBondAssetSwapPrice2 = fixedBondAssetSwap2.fairCleanPrice()
         fixedSpecializedBondAssetSwapPrice2 = fixedSpecializedBondAssetSwap2.fairCleanPrice()
 
-        error3 = abs(fixedBondAssetSwapPrice2-fixedSpecializedBondAssetSwapPrice2)
-        self.assertFalse(error3>tolerance, 
+        error3 = abs(fixedBondAssetSwapPrice2 - fixedSpecializedBondAssetSwapPrice2)
+        self.assertFalse(
+            error3 > tolerance,
             "wrong clean price for fixed bond:"
-            + "\n  generic  fixed rate bond's clean price: " + str(fixedBondAssetSwapPrice2)
-            + "\n  equivalent specialized  bond's clean price: " + str(fixedSpecializedBondAssetSwapPrice2)
-            + "\n  error:                 " + str(error3)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  generic  fixed rate bond's clean price: "
+            + str(fixedBondAssetSwapPrice2)
+            + "\n  equivalent specialized  bond's clean price: "
+            + str(fixedSpecializedBondAssetSwapPrice2)
+            + "\n  error:                 "
+            + str(error3)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
         ## market executable price as of 4th sept 2007
-        fixedBondMktPrice2= 102.178
-        fixedBondASW2 = AssetSwap(payFixedRate,
-                                fixedBond2, fixedBondMktPrice2,
-                                self.iborIndex, self.spread,
-                                Schedule(),
-                                self.iborIndex.dayCounter(),
-                                parAssetSwap)
+        fixedBondMktPrice2 = 102.178
+        fixedBondASW2 = ql.AssetSwap(
+            payFixedRate,
+            fixedBond2,
+            fixedBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedBondASW2.setPricingEngine(swapEngine)
-        fixedSpecializedBondASW2 = AssetSwap(payFixedRate,
-                                           fixedSpecializedBond2,
-                                           fixedBondMktPrice2,
-                                           self.iborIndex, self.spread,
-                                           Schedule(),
-                                           self.iborIndex.dayCounter(),
-                                           parAssetSwap)
+        fixedSpecializedBondASW2 = ql.AssetSwap(
+            payFixedRate,
+            fixedSpecializedBond2,
+            fixedBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         fixedSpecializedBondASW2.setPricingEngine(swapEngine)
         fixedBondASWSpread2 = fixedBondASW2.fairSpread()
         fixedSpecializedBondASWSpread2 = fixedSpecializedBondASW2.fairSpread()
-        error4 = abs(fixedBondASWSpread2-fixedSpecializedBondASWSpread2)
-        self.assertFalse(error4>tolerance, 
+        error4 = abs(fixedBondASWSpread2 - fixedSpecializedBondASWSpread2)
+        self.assertFalse(
+            error4 > tolerance,
             "wrong asw spread for fixed bond:"
-            + "\n  generic  fixed rate bond's  asw spread: " + str(fixedBondASWSpread2)
-            + "\n  equivalent specialized bond's asw spread: " + str(fixedSpecializedBondASWSpread2)
-            + "\n  error:                 " + str(error4)
-            + "\n  tolerance:             " + str(tolerance))
-        
-
+            + "\n  generic  fixed rate bond's  asw spread: "
+            + str(fixedBondASWSpread2)
+            + "\n  equivalent specialized bond's asw spread: "
+            + str(fixedSpecializedBondASWSpread2)
+            + "\n  error:                 "
+            + str(error4)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ##FRN bond (Isin: IT0003543847 ISPIM 0 09/29/13)
         ##maturity doesn't occur on a business day
-        floatingBondStartDate1 = Date(29,September,2003)
-        floatingBondMaturityDate1 = Date(29,September,2013)
-        floatingBondSchedule1 = Schedule(floatingBondStartDate1,
-                                       floatingBondMaturityDate1,
-                                       Period(Semiannual), bondCalendar,
-                                       Unadjusted, Unadjusted,
-                                       DateGeneration.Backward, False)
-        floatingBondLeg1 = list(IborLeg([self.faceAmount],floatingBondSchedule1, self.iborIndex,
-                                   Actual360(), Following,[fixingDays],[],[0.0056],[],[],inArrears))
-        floatingbondRedemption1 = bondCalendar.adjust(floatingBondMaturityDate1, Following)
-        floatingBondLeg1.append(SimpleCashFlow(100.0, floatingbondRedemption1))
+        floatingBondStartDate1 = ql.Date(29, ql.September, 2003)
+        floatingBondMaturityDate1 = ql.Date(29, ql.September, 2013)
+        floatingBondSchedule1 = ql.Schedule(
+            floatingBondStartDate1,
+            floatingBondMaturityDate1,
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        floatingBondLeg1 = list(
+            ql.IborLeg(
+                [self.faceAmount],
+                floatingBondSchedule1,
+                self.iborIndex,
+                ql.Actual360(),
+                ql.Following,
+                [fixingDays],
+                [],
+                [0.0056],
+                [],
+                [],
+                inArrears,
+            )
+        )
+        floatingbondRedemption1 = bondCalendar.adjust(floatingBondMaturityDate1, ql.Following)
+        floatingBondLeg1.append(ql.SimpleCashFlow(100.0, floatingbondRedemption1))
         ## generic bond
-        floatingBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 floatingBondMaturityDate1, floatingBondStartDate1,
-                 floatingBondLeg1)
+        floatingBond1 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            floatingBondMaturityDate1,
+            floatingBondStartDate1,
+            floatingBondLeg1,
+        )
         floatingBond1.setPricingEngine(bondEngine)
 
         ## equivalent specialized floater
-        floatingSpecializedBond1 = FloatingRateBond(settlementDays, self.faceAmount,
-                                floatingBondSchedule1,
-                                self.iborIndex, Actual360(),
-                                Following, fixingDays,
-                                [1],
-                                [0.0056],
-                                [], [],
-                                inArrears,
-                                100.0, Date(29,September,2003))
+        floatingSpecializedBond1 = ql.FloatingRateBond(
+            settlementDays,
+            self.faceAmount,
+            floatingBondSchedule1,
+            self.iborIndex,
+            ql.Actual360(),
+            ql.Following,
+            fixingDays,
+            [1],
+            [0.0056],
+            [],
+            [],
+            inArrears,
+            100.0,
+            ql.Date(29, ql.September, 2003),
+        )
         floatingSpecializedBond1.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond1.cashflows(), self.pricer)
-        setCouponPricer(floatingSpecializedBond1.cashflows(), self.pricer)
-        self.iborIndex.addFixing(Date(27,March,2007), 0.0402)
+        ql.setCouponPricer(floatingBond1.cashflows(), self.pricer)
+        ql.setCouponPricer(floatingSpecializedBond1.cashflows(), self.pricer)
+        self.iborIndex.addFixing(ql.Date(27, ql.March, 2007), 0.0402)
         floatingBondPrice1 = floatingBond1.cleanPrice()
-        floatingSpecializedBondPrice1= floatingSpecializedBond1.cleanPrice()
-        floatingBondAssetSwap1 = AssetSwap(payFixedRate,
-                                         floatingBond1, floatingBondPrice1,
-                                         self.iborIndex, self.nonnullspread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         parAssetSwap)
+        floatingSpecializedBondPrice1 = floatingSpecializedBond1.cleanPrice()
+        floatingBondAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond1,
+            floatingBondPrice1,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingBondAssetSwap1.setPricingEngine(swapEngine)
-        floatingSpecializedBondAssetSwap1 = AssetSwap(payFixedRate,
-                                                    floatingSpecializedBond1,
-                                                    floatingSpecializedBondPrice1,
-                                                    self.iborIndex,
-                                                    self.nonnullspread,
-                                                    Schedule(),
-                                                    self.iborIndex.dayCounter(),
-                                                    parAssetSwap)
+        floatingSpecializedBondAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            floatingSpecializedBond1,
+            floatingSpecializedBondPrice1,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingSpecializedBondAssetSwap1.setPricingEngine(swapEngine)
         floatingBondAssetSwapPrice1 = floatingBondAssetSwap1.fairCleanPrice()
-        floatingSpecializedBondAssetSwapPrice1 =  floatingSpecializedBondAssetSwap1.fairCleanPrice()
+        floatingSpecializedBondAssetSwapPrice1 = floatingSpecializedBondAssetSwap1.fairCleanPrice()
 
-        error5 = abs(floatingBondAssetSwapPrice1-floatingSpecializedBondAssetSwapPrice1)
-        self.assertFalse(error5>tolerance, 
+        error5 = abs(floatingBondAssetSwapPrice1 - floatingSpecializedBondAssetSwapPrice1)
+        self.assertFalse(
+            error5 > tolerance,
             "wrong clean price for frnbond:"
-            + "\n  generic frn rate bond's clean price: " + str(floatingBondAssetSwapPrice1)
-            + "\n  equivalent specialized  bond's price: " + str(floatingSpecializedBondAssetSwapPrice1)
-            + "\n  error:                 " + str(error5)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  generic frn rate bond's clean price: "
+            + str(floatingBondAssetSwapPrice1)
+            + "\n  equivalent specialized  bond's price: "
+            + str(floatingSpecializedBondAssetSwapPrice1)
+            + "\n  error:                 "
+            + str(error5)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
         ## market executable price as of 4th sept 2007
-        floatingBondMktPrice1= 101.33
-        floatingBondASW1 = AssetSwap(payFixedRate,
-                                   floatingBond1, floatingBondMktPrice1,
-                                   self.iborIndex, self.spread,
-                                   Schedule(),
-                                   self.iborIndex.dayCounter(),
-                                   parAssetSwap)
+        floatingBondMktPrice1 = 101.33
+        floatingBondASW1 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond1,
+            floatingBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingBondASW1.setPricingEngine(swapEngine)
-        floatingSpecializedBondASW1 = AssetSwap(payFixedRate,
-                                              floatingSpecializedBond1,
-                                              floatingBondMktPrice1,
-                                              self.iborIndex, self.spread,
-                                              Schedule(),
-                                              self.iborIndex.dayCounter(),
-                                              parAssetSwap)
+        floatingSpecializedBondASW1 = ql.AssetSwap(
+            payFixedRate,
+            floatingSpecializedBond1,
+            floatingBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingSpecializedBondASW1.setPricingEngine(swapEngine)
         floatingBondASWSpread1 = floatingBondASW1.fairSpread()
         floatingSpecializedBondASWSpread1 = floatingSpecializedBondASW1.fairSpread()
-        error6 = abs(floatingBondASWSpread1-floatingSpecializedBondASWSpread1)
-        self.assertFalse(error6>tolerance, 
+        error6 = abs(floatingBondASWSpread1 - floatingSpecializedBondASWSpread1)
+        self.assertFalse(
+            error6 > tolerance,
             "wrong asw spread for fixed bond:"
-            + "\n  generic  frn rate bond's  asw spread: " + str(floatingBondASWSpread1)
-            + "\n  equivalent specialized bond's asw spread: " + str(floatingSpecializedBondASWSpread1)
-            + "\n  error:                 " + str(error6)
-            + "\n  tolerance:             " + str(tolerance))
-     
+            + "\n  generic  frn rate bond's  asw spread: "
+            + str(floatingBondASWSpread1)
+            + "\n  equivalent specialized bond's asw spread: "
+            + str(floatingSpecializedBondASWSpread1)
+            + "\n  error:                 "
+            + str(error6)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
         ##FRN bond (Isin: XS0090566539 COE 0 09/24/18)
         ##maturity occurs on a business day
-        floatingBondStartDate2 = Date(24,September,2004)
-        floatingBondMaturityDate2 = Date(24,September,2018)
-        floatingBondSchedule2 = Schedule(floatingBondStartDate2,
-                                       floatingBondMaturityDate2,
-                                       Period(Semiannual), bondCalendar,
-                                       ModifiedFollowing, ModifiedFollowing,
-                                       DateGeneration.Backward, False)
-        floatingBondLeg2 = list(IborLeg([self.faceAmount],floatingBondSchedule2, self.iborIndex,
-                                        Actual360(),ModifiedFollowing,[fixingDays],[],[0.0025],[],[],inArrears))
-        floatingbondRedemption2 = bondCalendar.adjust(floatingBondMaturityDate2, ModifiedFollowing)
-        floatingBondLeg2.append(SimpleCashFlow(100.0, floatingbondRedemption2))
+        floatingBondStartDate2 = ql.Date(24, ql.September, 2004)
+        floatingBondMaturityDate2 = ql.Date(24, ql.September, 2018)
+        floatingBondSchedule2 = ql.Schedule(
+            floatingBondStartDate2,
+            floatingBondMaturityDate2,
+            ql.Period(ql.Semiannual),
+            bondCalendar,
+            ql.ModifiedFollowing,
+            ql.ModifiedFollowing,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        floatingBondLeg2 = list(
+            ql.IborLeg(
+                [self.faceAmount],
+                floatingBondSchedule2,
+                self.iborIndex,
+                ql.Actual360(),
+                ql.ModifiedFollowing,
+                [fixingDays],
+                [],
+                [0.0025],
+                [],
+                [],
+                inArrears,
+            )
+        )
+        floatingbondRedemption2 = bondCalendar.adjust(floatingBondMaturityDate2, ql.ModifiedFollowing)
+        floatingBondLeg2.append(ql.SimpleCashFlow(100.0, floatingbondRedemption2))
         ## generic bond
-        floatingBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 floatingBondMaturityDate2, floatingBondStartDate2,
-                 floatingBondLeg2)
+        floatingBond2 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            floatingBondMaturityDate2,
+            floatingBondStartDate2,
+            floatingBondLeg2,
+        )
         floatingBond2.setPricingEngine(bondEngine)
 
         ## equivalent specialized floater
-        floatingSpecializedBond2 = FloatingRateBond(settlementDays, self.faceAmount,
-                             floatingBondSchedule2,
-                             self.iborIndex, Actual360(),
-                             ModifiedFollowing, fixingDays,
-                             [1],
-                             [0.0025],
-                             [], [],
-                             inArrears,
-                             100.0, Date(24,September,2004))
+        floatingSpecializedBond2 = ql.FloatingRateBond(
+            settlementDays,
+            self.faceAmount,
+            floatingBondSchedule2,
+            self.iborIndex,
+            ql.Actual360(),
+            ql.ModifiedFollowing,
+            fixingDays,
+            [1],
+            [0.0025],
+            [],
+            [],
+            inArrears,
+            100.0,
+            ql.Date(24, ql.September, 2004),
+        )
         floatingSpecializedBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(floatingBond2.cashflows(), self.pricer)
-        setCouponPricer(floatingSpecializedBond2.cashflows(), self.pricer)
+        ql.setCouponPricer(floatingBond2.cashflows(), self.pricer)
+        ql.setCouponPricer(floatingSpecializedBond2.cashflows(), self.pricer)
 
-        self.iborIndex.addFixing(Date(22,March,2007), 0.04013)
+        self.iborIndex.addFixing(ql.Date(22, ql.March, 2007), 0.04013)
 
         floatingBondPrice2 = floatingBond2.cleanPrice()
-        floatingSpecializedBondPrice2= floatingSpecializedBond2.cleanPrice()
-        floatingBondAssetSwap2 = AssetSwap(payFixedRate,
-                                         floatingBond2, floatingBondPrice2,
-                                         self.iborIndex, self.nonnullspread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         parAssetSwap)
+        floatingSpecializedBondPrice2 = floatingSpecializedBond2.cleanPrice()
+        floatingBondAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond2,
+            floatingBondPrice2,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingBondAssetSwap2.setPricingEngine(swapEngine)
-        floatingSpecializedBondAssetSwap2 = AssetSwap(payFixedRate,
-                                                    floatingSpecializedBond2,
-                                                    floatingSpecializedBondPrice2,
-                                                    self.iborIndex,
-                                                    self.nonnullspread,
-                                                    Schedule(),
-                                                    self.iborIndex.dayCounter(),
-                                                    parAssetSwap)
+        floatingSpecializedBondAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            floatingSpecializedBond2,
+            floatingSpecializedBondPrice2,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingSpecializedBondAssetSwap2.setPricingEngine(swapEngine)
         floatingBondAssetSwapPrice2 = floatingBondAssetSwap2.fairCleanPrice()
         floatingSpecializedBondAssetSwapPrice2 = floatingSpecializedBondAssetSwap2.fairCleanPrice()
-        error7 = abs(floatingBondAssetSwapPrice2-floatingSpecializedBondAssetSwapPrice2)
-        self.assertFalse(error7>tolerance, 
+        error7 = abs(floatingBondAssetSwapPrice2 - floatingSpecializedBondAssetSwapPrice2)
+        self.assertFalse(
+            error7 > tolerance,
             "wrong clean price for frnbond:"
-            + "\n  generic frn rate bond's clean price: " + str(floatingBondAssetSwapPrice2)
-            + "\n  equivalent specialized frn  bond's price: " + str(floatingSpecializedBondAssetSwapPrice2)
-            + "\n  error:                 " + str(error7)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  generic frn rate bond's clean price: "
+            + str(floatingBondAssetSwapPrice2)
+            + "\n  equivalent specialized frn  bond's price: "
+            + str(floatingSpecializedBondAssetSwapPrice2)
+            + "\n  error:                 "
+            + str(error7)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
         ## market executable price as of 4th sept 2007
         floatingBondMktPrice2 = 101.26
-        floatingBondASW2 = AssetSwap(payFixedRate,
-                                   floatingBond2, floatingBondMktPrice2,
-                                   self.iborIndex, self.spread,
-                                   Schedule(),
-                                   self.iborIndex.dayCounter(),
-                                   parAssetSwap)
+        floatingBondASW2 = ql.AssetSwap(
+            payFixedRate,
+            floatingBond2,
+            floatingBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingBondASW2.setPricingEngine(swapEngine)
-        floatingSpecializedBondASW2 = AssetSwap(payFixedRate,
-                                              floatingSpecializedBond2,
-                                              floatingBondMktPrice2,
-                                              self.iborIndex, self.spread,
-                                              Schedule(),
-                                              self.iborIndex.dayCounter(),
-                                              parAssetSwap)
+        floatingSpecializedBondASW2 = ql.AssetSwap(
+            payFixedRate,
+            floatingSpecializedBond2,
+            floatingBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         floatingSpecializedBondASW2.setPricingEngine(swapEngine)
         floatingBondASWSpread2 = floatingBondASW2.fairSpread()
         floatingSpecializedBondASWSpread2 = floatingSpecializedBondASW2.fairSpread()
-        error8 = abs(floatingBondASWSpread2-floatingSpecializedBondASWSpread2)
-        self.assertFalse(error8>tolerance, 
+        error8 = abs(floatingBondASWSpread2 - floatingSpecializedBondASWSpread2)
+        self.assertFalse(
+            error8 > tolerance,
             "wrong asw spread for frn bond:"
-            + "\n  generic  frn rate bond's  asw spread: " + str(floatingBondASWSpread2)
-            + "\n  equivalent specialized bond's asw spread: " + str(floatingSpecializedBondASWSpread2)
-            + "\n  error:                 " + str(error8)
-            + "\n  tolerance:             " + str(tolerance))        
+            + "\n  generic  frn rate bond's  asw spread: "
+            + str(floatingBondASWSpread2)
+            + "\n  equivalent specialized bond's asw spread: "
+            + str(floatingSpecializedBondASWSpread2)
+            + "\n  error:                 "
+            + str(error8)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
         ## CMS bond (Isin: XS0228052402 CRDIT 0 8/22/20)
         ## maturity doesn't occur on a business day
-        
-        cmsBondStartDate1 = Date(22,August,2005)
-        cmsBondMaturityDate1 = Date(22,August,2020)
-        cmsBondSchedule1 = Schedule(cmsBondStartDate1,
-                                  cmsBondMaturityDate1,
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBondLeg1 = list(CmsLeg([self.faceAmount],cmsBondSchedule1, self.swapIndex,
-                                  Thirty360(),Following,[fixingDays], [],[],[0.055],[0.025],inArrears))
-        cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1,Following)
-        cmsBondLeg1.append(SimpleCashFlow(100.0, cmsbondRedemption1))
+
+        cmsBondStartDate1 = ql.Date(22, ql.August, 2005)
+        cmsBondMaturityDate1 = ql.Date(22, ql.August, 2020)
+        cmsBondSchedule1 = ql.Schedule(
+            cmsBondStartDate1,
+            cmsBondMaturityDate1,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBondLeg1 = list(
+            ql.CmsLeg(
+                [self.faceAmount],
+                cmsBondSchedule1,
+                self.swapIndex,
+                ql.Thirty360(),
+                ql.Following,
+                [fixingDays],
+                [],
+                [],
+                [0.055],
+                [0.025],
+                inArrears,
+            )
+        )
+        cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1, ql.Following)
+        cmsBondLeg1.append(ql.SimpleCashFlow(100.0, cmsbondRedemption1))
         ## generic cms bond
-        cmsBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1)
+        cmsBond1 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1
+        )
         cmsBond1.setPricingEngine(bondEngine)
 
         ## equivalent specialized cms bond
-        cmsSpecializedBond1 = CmsRateBond(settlementDays, self.faceAmount, cmsBondSchedule1,
-                    self.swapIndex, Thirty360(),
-                    Following, fixingDays,
-                    [1.0], [0.0],
-                    [0.055], [0.025],
-                    inArrears,
-                    100.0, Date(22,August,2005))
+        cmsSpecializedBond1 = ql.CmsRateBond(
+            settlementDays,
+            self.faceAmount,
+            cmsBondSchedule1,
+            self.swapIndex,
+            ql.Thirty360(),
+            ql.Following,
+            fixingDays,
+            [1.0],
+            [0.0],
+            [0.055],
+            [0.025],
+            inArrears,
+            100.0,
+            ql.Date(22, ql.August, 2005),
+        )
         cmsSpecializedBond1.setPricingEngine(bondEngine)
 
-
-        setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
-        setCouponPricer(cmsSpecializedBond1.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(18,August,2006), 0.04158)
+        ql.setCouponPricer(cmsBond1.cashflows(), self.cmspricer)
+        ql.setCouponPricer(cmsSpecializedBond1.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(18, ql.August, 2006), 0.04158)
         cmsBondPrice1 = cmsBond1.cleanPrice()
         cmsSpecializedBondPrice1 = cmsSpecializedBond1.cleanPrice()
-        cmsBondAssetSwap1 = AssetSwap(payFixedRate,cmsBond1, cmsBondPrice1,
-                                    self.iborIndex, self.nonnullspread,
-                                    Schedule(),self.iborIndex.dayCounter(),
-                                    parAssetSwap)
+        cmsBondAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond1,
+            cmsBondPrice1,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsBondAssetSwap1.setPricingEngine(swapEngine)
-        cmsSpecializedBondAssetSwap1 = AssetSwap(payFixedRate,cmsSpecializedBond1,
-                                               cmsSpecializedBondPrice1,
-                                               self.iborIndex,
-                                               self.nonnullspread,
-                                               Schedule(),
-                                               self.iborIndex.dayCounter(),
-                                               parAssetSwap)
+        cmsSpecializedBondAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            cmsSpecializedBond1,
+            cmsSpecializedBondPrice1,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsSpecializedBondAssetSwap1.setPricingEngine(swapEngine)
         cmsBondAssetSwapPrice1 = cmsBondAssetSwap1.fairCleanPrice()
         cmsSpecializedBondAssetSwapPrice1 = cmsSpecializedBondAssetSwap1.fairCleanPrice()
-        error9 = abs(cmsBondAssetSwapPrice1-cmsSpecializedBondAssetSwapPrice1)
-        self.assertFalse(error9>tolerance, 
+        error9 = abs(cmsBondAssetSwapPrice1 - cmsSpecializedBondAssetSwapPrice1)
+        self.assertFalse(
+            error9 > tolerance,
             "wrong clean price for cmsbond:"
-            + "\n  generic bond's clean price: " + str(cmsBondAssetSwapPrice1)
-            + "\n  equivalent specialized cms rate bond's price: " + str(cmsSpecializedBondAssetSwapPrice1)
-            + "\n  error:                 " + str(error9)
-            + "\n  tolerance:             " + str(tolerance))
-        
-        cmsBondMktPrice1 = 87.02## market executable price as of 4th sept 2007
-        cmsBondASW1 = AssetSwap(payFixedRate,
-                              cmsBond1, cmsBondMktPrice1,
-                              self.iborIndex, self.spread,
-                              Schedule(),
-                              self.iborIndex.dayCounter(),
-                              parAssetSwap)
+            + "\n  generic bond's clean price: "
+            + str(cmsBondAssetSwapPrice1)
+            + "\n  equivalent specialized cms rate bond's price: "
+            + str(cmsSpecializedBondAssetSwapPrice1)
+            + "\n  error:                 "
+            + str(error9)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
+        cmsBondMktPrice1 = 87.02  ## market executable price as of 4th sept 2007
+        cmsBondASW1 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond1,
+            cmsBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsBondASW1.setPricingEngine(swapEngine)
-        cmsSpecializedBondASW1 = AssetSwap(payFixedRate,
-                                         cmsSpecializedBond1,
-                                         cmsBondMktPrice1,
-                                         self.iborIndex, self.spread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         parAssetSwap)
+        cmsSpecializedBondASW1 = ql.AssetSwap(
+            payFixedRate,
+            cmsSpecializedBond1,
+            cmsBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsSpecializedBondASW1.setPricingEngine(swapEngine)
         cmsBondASWSpread1 = cmsBondASW1.fairSpread()
         cmsSpecializedBondASWSpread1 = cmsSpecializedBondASW1.fairSpread()
-        error10 = abs(cmsBondASWSpread1-cmsSpecializedBondASWSpread1)
-        self.assertFalse(error10>tolerance, 
+        error10 = abs(cmsBondASWSpread1 - cmsSpecializedBondASWSpread1)
+        self.assertFalse(
+            error10 > tolerance,
             "wrong asw spread for cm bond:"
-            + "\n  generic cms rate bond's  asw spread: " + str(cmsBondASWSpread1)
-            + "\n  equivalent specialized bond's asw spread: " + str(cmsSpecializedBondASWSpread1)
-            + "\n  error:                 " + str(error10)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  generic cms rate bond's  asw spread: "
+            + str(cmsBondASWSpread1)
+            + "\n  equivalent specialized bond's asw spread: "
+            + str(cmsSpecializedBondASWSpread1)
+            + "\n  error:                 "
+            + str(error10)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
-          ##CMS bond (Isin: XS0218766664 ISPIM 0 5/6/15)
-          ##maturity occurs on a business day
-        cmsBondStartDate2 = Date(6,May,2005)
-        cmsBondMaturityDate2 = Date(6,May,2015)
-        cmsBondSchedule2 = Schedule(cmsBondStartDate2,
-                                  cmsBondMaturityDate2,
-                                  Period(Annual), bondCalendar,
-                                  Unadjusted, Unadjusted,
-                                  DateGeneration.Backward, False)
-        cmsBondLeg2 = list(CmsLeg([self.faceAmount],cmsBondSchedule2, self.swapIndex,
-                             Thirty360(), Following, [fixingDays] , [0.84],[],[],[],inArrears))
-        cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2,
-                                                      Following)
-        cmsBondLeg2.append(SimpleCashFlow(100.0, cmsbondRedemption2))
+        ##CMS bond (Isin: XS0218766664 ISPIM 0 5/6/15)
+        ##maturity occurs on a business day
+        cmsBondStartDate2 = ql.Date(6, ql.May, 2005)
+        cmsBondMaturityDate2 = ql.Date(6, ql.May, 2015)
+        cmsBondSchedule2 = ql.Schedule(
+            cmsBondStartDate2,
+            cmsBondMaturityDate2,
+            ql.Period(ql.Annual),
+            bondCalendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
+        cmsBondLeg2 = list(
+            ql.CmsLeg(
+                [self.faceAmount],
+                cmsBondSchedule2,
+                self.swapIndex,
+                ql.Thirty360(),
+                ql.Following,
+                [fixingDays],
+                [0.84],
+                [],
+                [],
+                [],
+                inArrears,
+            )
+        )
+        cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2, ql.Following)
+        cmsBondLeg2.append(ql.SimpleCashFlow(100.0, cmsbondRedemption2))
         ## generic bond
-        cmsBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2)
+        cmsBond2 = ql.Bond(
+            settlementDays, bondCalendar, self.faceAmount, cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2
+        )
         cmsBond2.setPricingEngine(bondEngine)
 
         ## equivalent specialized cms bond
-        cmsSpecializedBond2 = CmsRateBond(settlementDays, self.faceAmount, cmsBondSchedule2,
-                    self.swapIndex, Thirty360(),
-                    Following, fixingDays,
-                    [0.84], [0.0],
-                    [], [],
-                    inArrears,
-                    100.0, Date(6,May,2005))
+        cmsSpecializedBond2 = ql.CmsRateBond(
+            settlementDays,
+            self.faceAmount,
+            cmsBondSchedule2,
+            self.swapIndex,
+            ql.Thirty360(),
+            ql.Following,
+            fixingDays,
+            [0.84],
+            [0.0],
+            [],
+            [],
+            inArrears,
+            100.0,
+            ql.Date(6, ql.May, 2005),
+        )
         cmsSpecializedBond2.setPricingEngine(bondEngine)
 
-        setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
-        setCouponPricer(cmsSpecializedBond2.cashflows(), self.cmspricer)
-        self.swapIndex.addFixing(Date(4,May,2006), 0.04217)
+        ql.setCouponPricer(cmsBond2.cashflows(), self.cmspricer)
+        ql.setCouponPricer(cmsSpecializedBond2.cashflows(), self.cmspricer)
+        self.swapIndex.addFixing(ql.Date(4, ql.May, 2006), 0.04217)
         cmsBondPrice2 = cmsBond2.cleanPrice()
         cmsSpecializedBondPrice2 = cmsSpecializedBond2.cleanPrice()
-        cmsBondAssetSwap2 = AssetSwap(payFixedRate,cmsBond2, cmsBondPrice2,
-                                    self.iborIndex, self.nonnullspread,
-                                    Schedule(),
-                                    self.iborIndex.dayCounter(),
-                                    parAssetSwap)
+        cmsBondAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond2,
+            cmsBondPrice2,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsBondAssetSwap2.setPricingEngine(swapEngine)
-        cmsSpecializedBondAssetSwap2 = AssetSwap(payFixedRate,cmsSpecializedBond2,
-                                               cmsSpecializedBondPrice2,
-                                               self.iborIndex,
-                                               self.nonnullspread,
-                                               Schedule(),
-                                               self.iborIndex.dayCounter(),
-                                               parAssetSwap)
+        cmsSpecializedBondAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            cmsSpecializedBond2,
+            cmsSpecializedBondPrice2,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsSpecializedBondAssetSwap2.setPricingEngine(swapEngine)
         cmsBondAssetSwapPrice2 = cmsBondAssetSwap2.fairCleanPrice()
         cmsSpecializedBondAssetSwapPrice2 = cmsSpecializedBondAssetSwap2.fairCleanPrice()
-        error11 = abs(cmsBondAssetSwapPrice2-cmsSpecializedBondAssetSwapPrice2)
-        self.assertFalse(error11>tolerance,
+        error11 = abs(cmsBondAssetSwapPrice2 - cmsSpecializedBondAssetSwapPrice2)
+        self.assertFalse(
+            error11 > tolerance,
             "wrong clean price for cmsbond:"
-            + "\n  generic  bond's clean price: " + str(cmsBondAssetSwapPrice2)
-            + "\n  equivalent specialized cms rate bond's price: "  + str(cmsSpecializedBondAssetSwapPrice2)
-            + "\n  error:                 " + str(error11)
-            + "\n  tolerance:             " + str(tolerance))
-        
-        cmsBondMktPrice2 = 94.35## market executable price as of 4th sept 2007
-        cmsBondASW2 = AssetSwap(payFixedRate,
-                              cmsBond2, cmsBondMktPrice2,
-                              self.iborIndex, self.spread,
-                              Schedule(),
-                              self.iborIndex.dayCounter(),
-                              parAssetSwap)
+            + "\n  generic  bond's clean price: "
+            + str(cmsBondAssetSwapPrice2)
+            + "\n  equivalent specialized cms rate bond's price: "
+            + str(cmsSpecializedBondAssetSwapPrice2)
+            + "\n  error:                 "
+            + str(error11)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
+        cmsBondMktPrice2 = 94.35  ## market executable price as of 4th sept 2007
+        cmsBondASW2 = ql.AssetSwap(
+            payFixedRate,
+            cmsBond2,
+            cmsBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsBondASW2.setPricingEngine(swapEngine)
-        cmsSpecializedBondASW2 = AssetSwap(payFixedRate,
-                                         cmsSpecializedBond2,
-                                         cmsBondMktPrice2,
-                                         self.iborIndex, self.spread,
-                                         Schedule(),
-                                         self.iborIndex.dayCounter(),
-                                         parAssetSwap)
+        cmsSpecializedBondASW2 = ql.AssetSwap(
+            payFixedRate,
+            cmsSpecializedBond2,
+            cmsBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         cmsSpecializedBondASW2.setPricingEngine(swapEngine)
         cmsBondASWSpread2 = cmsBondASW2.fairSpread()
         cmsSpecializedBondASWSpread2 = cmsSpecializedBondASW2.fairSpread()
-        error12 = abs(cmsBondASWSpread2-cmsSpecializedBondASWSpread2)
-        self.assertFalse(error12>tolerance,
+        error12 = abs(cmsBondASWSpread2 - cmsSpecializedBondASWSpread2)
+        self.assertFalse(
+            error12 > tolerance,
             "wrong asw spread for cm bond:"
-            + "\n  generic cms rate bond's  asw spread: " + str(cmsBondASWSpread2)
-            + "\n  equivalent specialized bond's asw spread: " + str(cmsSpecializedBondASWSpread2)
-            + "\n  error:                 " + str(error12)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  generic cms rate bond's  asw spread: "
+            + str(cmsBondASWSpread2)
+            + "\n  equivalent specialized bond's asw spread: "
+            + str(cmsSpecializedBondASWSpread2)
+            + "\n  error:                 "
+            + str(error12)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
-
-       ##  Zero-Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
-       ##  maturity doesn't occur on a business day
-        zeroCpnBondStartDate1 = Date(19,December,1985)
-        zeroCpnBondMaturityDate1 = Date(20,December,2015)
-        zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1, Following)
-        zeroCpnBondLeg1 = Leg([SimpleCashFlow(100.0, zeroCpnBondRedemption1)])
+        ##  Zero-Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
+        ##  maturity doesn't occur on a business day
+        zeroCpnBondStartDate1 = ql.Date(19, ql.December, 1985)
+        zeroCpnBondMaturityDate1 = ql.Date(20, ql.December, 2015)
+        zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1, ql.Following)
+        zeroCpnBondLeg1 = ql.Leg([ql.SimpleCashFlow(100.0, zeroCpnBondRedemption1)])
         ## generic bond
-        zeroCpnBond1 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1)
+        zeroCpnBond1 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            zeroCpnBondMaturityDate1,
+            zeroCpnBondStartDate1,
+            zeroCpnBondLeg1,
+        )
         zeroCpnBond1.setPricingEngine(bondEngine)
 
         ## specialized zerocpn bond
-        zeroCpnSpecializedBond1 = ZeroCouponBond(settlementDays, bondCalendar, self.faceAmount,
-                      Date(20,December,2015),
-                      Following,
-                      100.0, Date(19,December,1985))
+        zeroCpnSpecializedBond1 = ql.ZeroCouponBond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            ql.Date(20, ql.December, 2015),
+            ql.Following,
+            100.0,
+            ql.Date(19, ql.December, 1985),
+        )
         zeroCpnSpecializedBond1.setPricingEngine(bondEngine)
 
         zeroCpnBondPrice1 = zeroCpnBond1.cleanPrice()
         zeroCpnSpecializedBondPrice1 = zeroCpnSpecializedBond1.cleanPrice()
-        zeroCpnBondAssetSwap1 = AssetSwap(payFixedRate,zeroCpnBond1,
-                                        zeroCpnBondPrice1,
-                                        self.iborIndex, self.nonnullspread,
-                                        Schedule(),
-                                        self.iborIndex.dayCounter(),
-                                        parAssetSwap)
+        zeroCpnBondAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond1,
+            zeroCpnBondPrice1,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnBondAssetSwap1.setPricingEngine(swapEngine)
-        zeroCpnSpecializedBondAssetSwap1 = AssetSwap(payFixedRate,
-                                                   zeroCpnSpecializedBond1,
-                                                   zeroCpnSpecializedBondPrice1,
-                                                   self.iborIndex,
-                                                   self.nonnullspread,
-                                                   Schedule(),
-                                                   self.iborIndex.dayCounter(),
-                                                   parAssetSwap)
+        zeroCpnSpecializedBondAssetSwap1 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnSpecializedBond1,
+            zeroCpnSpecializedBondPrice1,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnSpecializedBondAssetSwap1.setPricingEngine(swapEngine)
         zeroCpnBondAssetSwapPrice1 = zeroCpnBondAssetSwap1.fairCleanPrice()
         zeroCpnSpecializedBondAssetSwapPrice1 = zeroCpnSpecializedBondAssetSwap1.fairCleanPrice()
-        error13 = abs(zeroCpnBondAssetSwapPrice1-zeroCpnSpecializedBondAssetSwapPrice1)
-        self.assertFalse(error13>tolerance, 
+        error13 = abs(zeroCpnBondAssetSwapPrice1 - zeroCpnSpecializedBondAssetSwapPrice1)
+        self.assertFalse(
+            error13 > tolerance,
             "wrong clean price for zerocpn bond:"
-            + "\n  generic zero cpn bond's clean price: " + str(zeroCpnBondAssetSwapPrice1)
-            + "\n  specialized equivalent bond's price: " + str(zeroCpnSpecializedBondAssetSwapPrice1)
-            + "\n  error:                 " + str(error13)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  generic zero cpn bond's clean price: "
+            + str(zeroCpnBondAssetSwapPrice1)
+            + "\n  specialized equivalent bond's price: "
+            + str(zeroCpnSpecializedBondAssetSwapPrice1)
+            + "\n  error:                 "
+            + str(error13)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
         ## market executable price as of 4th sept 2007
         zeroCpnBondMktPrice1 = 72.277
-        zeroCpnBondASW1 = AssetSwap(payFixedRate,
-                                  zeroCpnBond1,zeroCpnBondMktPrice1,
-                                  self.iborIndex, self.spread,
-                                  Schedule(),
-                                  self.iborIndex.dayCounter(),
-                                  parAssetSwap)
+        zeroCpnBondASW1 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond1,
+            zeroCpnBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnBondASW1.setPricingEngine(swapEngine)
-        zeroCpnSpecializedBondASW1 = AssetSwap(payFixedRate,
-                                             zeroCpnSpecializedBond1,
-                                             zeroCpnBondMktPrice1,
-                                             self.iborIndex, self.spread,
-                                             Schedule(),
-                                             self.iborIndex.dayCounter(),
-                                             parAssetSwap)
+        zeroCpnSpecializedBondASW1 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnSpecializedBond1,
+            zeroCpnBondMktPrice1,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnSpecializedBondASW1.setPricingEngine(swapEngine)
         zeroCpnBondASWSpread1 = zeroCpnBondASW1.fairSpread()
         zeroCpnSpecializedBondASWSpread1 = zeroCpnSpecializedBondASW1.fairSpread()
-        error14 = abs(zeroCpnBondASWSpread1-zeroCpnSpecializedBondASWSpread1)
-        self.assertFalse(error14>tolerance,  
+        error14 = abs(zeroCpnBondASWSpread1 - zeroCpnSpecializedBondASWSpread1)
+        self.assertFalse(
+            error14 > tolerance,
             "wrong asw spread for zeroCpn bond:"
-            + "\n  generic zeroCpn bond's  asw spread: " + str(zeroCpnBondASWSpread1)
-            + "\n  equivalent specialized bond's asw spread: " + str(zeroCpnSpecializedBondASWSpread1)
-            + "\n  error:                 " + str(error14)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  generic zeroCpn bond's  asw spread: "
+            + str(zeroCpnBondASWSpread1)
+            + "\n  equivalent specialized bond's asw spread: "
+            + str(zeroCpnSpecializedBondASWSpread1)
+            + "\n  error:                 "
+            + str(error14)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
-
-       ##  Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
-       ##  maturity doesn't occur on a business day
-        zeroCpnBondStartDate2 = Date(17,February,1998)
-        zeroCpnBondMaturityDate2 = Date(17,February,2028)
-        zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2, Following)
-        zeroCpnBondLeg2 = Leg([SimpleCashFlow(100.0, zerocpbondRedemption2)])
+        ##  Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
+        ##  maturity doesn't occur on a business day
+        zeroCpnBondStartDate2 = ql.Date(17, ql.February, 1998)
+        zeroCpnBondMaturityDate2 = ql.Date(17, ql.February, 2028)
+        zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2, ql.Following)
+        zeroCpnBondLeg2 = ql.Leg([ql.SimpleCashFlow(100.0, zerocpbondRedemption2)])
         ## generic bond
-        zeroCpnBond2 = Bond(settlementDays, bondCalendar, self.faceAmount,
-                 zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2)
+        zeroCpnBond2 = ql.Bond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            zeroCpnBondMaturityDate2,
+            zeroCpnBondStartDate2,
+            zeroCpnBondLeg2,
+        )
         zeroCpnBond2.setPricingEngine(bondEngine)
 
         ## specialized zerocpn bond
-        zeroCpnSpecializedBond2 = ZeroCouponBond(settlementDays, bondCalendar, self.faceAmount,
-                       Date(17,February,2028),
-                       Following,
-                       100.0, Date(17,February,1998))
+        zeroCpnSpecializedBond2 = ql.ZeroCouponBond(
+            settlementDays,
+            bondCalendar,
+            self.faceAmount,
+            ql.Date(17, ql.February, 2028),
+            ql.Following,
+            100.0,
+            ql.Date(17, ql.February, 1998),
+        )
         zeroCpnSpecializedBond2.setPricingEngine(bondEngine)
 
         zeroCpnBondPrice2 = zeroCpnBond2.cleanPrice()
         zeroCpnSpecializedBondPrice2 = zeroCpnSpecializedBond2.cleanPrice()
 
-        zeroCpnBondAssetSwap2 = AssetSwap(payFixedRate,zeroCpnBond2,
-                                        zeroCpnBondPrice2,
-                                        self.iborIndex, self.nonnullspread,
-                                        Schedule(),
-                                        self.iborIndex.dayCounter(),
-                                        parAssetSwap)
+        zeroCpnBondAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond2,
+            zeroCpnBondPrice2,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnBondAssetSwap2.setPricingEngine(swapEngine)
-        zeroCpnSpecializedBondAssetSwap2 = AssetSwap(payFixedRate,
-                                                   zeroCpnSpecializedBond2,
-                                                   zeroCpnSpecializedBondPrice2,
-                                                   self.iborIndex,
-                                                   self.nonnullspread,
-                                                   Schedule(),
-                                                   self.iborIndex.dayCounter(),
-                                                   parAssetSwap)
+        zeroCpnSpecializedBondAssetSwap2 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnSpecializedBond2,
+            zeroCpnSpecializedBondPrice2,
+            self.iborIndex,
+            self.nonnullspread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnSpecializedBondAssetSwap2.setPricingEngine(swapEngine)
         zeroCpnBondAssetSwapPrice2 = zeroCpnBondAssetSwap2.fairCleanPrice()
         zeroCpnSpecializedBondAssetSwapPrice2 = zeroCpnSpecializedBondAssetSwap2.fairCleanPrice()
-        error15 = abs(zeroCpnBondAssetSwapPrice2 -zeroCpnSpecializedBondAssetSwapPrice2)
-        self.assertFalse(error8>tolerance,
+        error15 = abs(zeroCpnBondAssetSwapPrice2 - zeroCpnSpecializedBondAssetSwapPrice2)
+        self.assertFalse(
+            error8 > tolerance,
             "wrong clean price for zerocpn bond:"
-            + "\n  generic zero cpn bond's clean price: " + str(zeroCpnBondAssetSwapPrice2)
-            + "\n  equivalent specialized bond's price: " + str(zeroCpnSpecializedBondAssetSwapPrice2)
-            + "\n  error:                 " + str(error15)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  generic zero cpn bond's clean price: "
+            + str(zeroCpnBondAssetSwapPrice2)
+            + "\n  equivalent specialized bond's price: "
+            + str(zeroCpnSpecializedBondAssetSwapPrice2)
+            + "\n  error:                 "
+            + str(error15)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
+
         ## market executable price as of 4th sept 2007
         zeroCpnBondMktPrice2 = 72.277
-        zeroCpnBondASW2 = AssetSwap(payFixedRate,
-                                  zeroCpnBond2,zeroCpnBondMktPrice2,
-                                  self.iborIndex, self.spread,
-                                  Schedule(),
-                                  self.iborIndex.dayCounter(),
-                                  parAssetSwap)
+        zeroCpnBondASW2 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnBond2,
+            zeroCpnBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnBondASW2.setPricingEngine(swapEngine)
-        zeroCpnSpecializedBondASW2 = AssetSwap(payFixedRate,
-                                             zeroCpnSpecializedBond2,
-                                             zeroCpnBondMktPrice2,
-                                             self.iborIndex, self.spread,
-                                             Schedule(),
-                                             self.iborIndex.dayCounter(),
-                                             parAssetSwap)
+        zeroCpnSpecializedBondASW2 = ql.AssetSwap(
+            payFixedRate,
+            zeroCpnSpecializedBond2,
+            zeroCpnBondMktPrice2,
+            self.iborIndex,
+            self.spread,
+            ql.Schedule(),
+            self.iborIndex.dayCounter(),
+            parAssetSwap,
+        )
         zeroCpnSpecializedBondASW2.setPricingEngine(swapEngine)
         zeroCpnBondASWSpread2 = zeroCpnBondASW2.fairSpread()
         zeroCpnSpecializedBondASWSpread2 = zeroCpnSpecializedBondASW2.fairSpread()
-        error16 = abs(zeroCpnBondASWSpread2-zeroCpnSpecializedBondASWSpread2)
-        self.assertFalse(error16>tolerance, 
+        error16 = abs(zeroCpnBondASWSpread2 - zeroCpnSpecializedBondASWSpread2)
+        self.assertFalse(
+            error16 > tolerance,
             "wrong asw spread for zeroCpn bond:"
-            + "\n  generic zeroCpn bond's  asw spread: " + str(zeroCpnBondASWSpread2)
-            + "\n  equivalent specialized bond's asw spread: " + str(zeroCpnSpecializedBondASWSpread2)
-            + "\n  error:                 " + str(error16)
-            + "\n  tolerance:             " + str(tolerance))
-        
+            + "\n  generic zeroCpn bond's  asw spread: "
+            + str(zeroCpnBondASWSpread2)
+            + "\n  equivalent specialized bond's asw spread: "
+            + str(zeroCpnSpecializedBondASWSpread2)
+            + "\n  error:                 "
+            + str(error16)
+            + "\n  tolerance:             "
+            + str(tolerance),
+        )
 
-if __name__ == '__main__':
-    print('testing QuantLib ' + QuantLib.__version__)
+
+if __name__ == "__main__":
+    print("testing QuantLib " + ql.__version__)
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(AssetSwapTest,'test'))
+    suite.addTest(unittest.makeSuite(AssetSwapTest, "test"))
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Python/test/bonds.py
+++ b/Python/test/bonds.py
@@ -15,40 +15,53 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
-import QuantLib
+import QuantLib as ql
 import unittest
+
 
 class FixedRateBondTest(unittest.TestCase):
     def setUp(self):
-        QuantLib.Settings.instance().setEvaluationDate(QuantLib.Date(2,1,2010))
+        ql.Settings.instance().setEvaluationDate(ql.Date(2, 1, 2010))
         self.settlement_days = 3
         self.face_amount = 100.0
         self.redemption = 100.0
-        self.issue_date = QuantLib.Date(2,1,2008)
-        self.maturity_date = QuantLib.Date(2,1,2018)
-        self.calendar = QuantLib.UnitedStates(QuantLib.UnitedStates.GovernmentBond)
-        self.day_counter = QuantLib.ActualActual(QuantLib.ActualActual.Bond)
-        self.sched = QuantLib.Schedule(self.issue_date, self.maturity_date,
-                                       QuantLib.Period(QuantLib.Semiannual), self.calendar,
-                                       QuantLib.Unadjusted, QuantLib.Unadjusted,
-                                       QuantLib.DateGeneration.Backward, False)
+        self.issue_date = ql.Date(2, 1, 2008)
+        self.maturity_date = ql.Date(2, 1, 2018)
+        self.calendar = ql.UnitedStates(ql.UnitedStates.GovernmentBond)
+        self.day_counter = ql.ActualActual(ql.ActualActual.Bond)
+        self.sched = ql.Schedule(
+            self.issue_date,
+            self.maturity_date,
+            ql.Period(ql.Semiannual),
+            self.calendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
         self.coupons = [0.05]
 
-        self.bond = QuantLib.FixedRateBond(self.settlement_days, self.face_amount,
-                                           self.sched, self.coupons, self.day_counter,
-                                           QuantLib.Following, self.redemption,
-                                           self.issue_date)
+        self.bond = ql.FixedRateBond(
+            self.settlement_days,
+            self.face_amount,
+            self.sched,
+            self.coupons,
+            self.day_counter,
+            ql.Following,
+            self.redemption,
+            self.issue_date,
+        )
 
-        self.flat_forward = QuantLib.FlatForward(self.issue_date,
-                                            self.coupons[0], self.day_counter,
-                                            QuantLib.Compounded, QuantLib.Semiannual)
-        self.term_structure_handle = QuantLib.RelinkableYieldTermStructureHandle(self.flat_forward)
-        bondEngine = QuantLib.DiscountingBondEngine(self.term_structure_handle)
+        self.flat_forward = ql.FlatForward(
+            self.issue_date, self.coupons[0], self.day_counter, ql.Compounded, ql.Semiannual
+        )
+        self.term_structure_handle = ql.RelinkableYieldTermStructureHandle(self.flat_forward)
+        bondEngine = ql.DiscountingBondEngine(self.term_structure_handle)
         self.bond.setPricingEngine(bondEngine)
 
     def testFrequency(self):
         """ Testing FixedRateBond frequency() method. """
-        self.assertEqual(self.bond.frequency(), QuantLib.Semiannual)
+        self.assertEqual(self.bond.frequency(), ql.Semiannual)
 
     def testDayCounter(self):
         """ Testing FixedRateBond dayCounter() method. """
@@ -61,18 +74,19 @@ class FixedRateBondTest(unittest.TestCase):
         self.assertEqual(self.bond.issueDate(), self.issue_date)
         self.assertEqual(self.bond.maturityDate(), self.maturity_date)
 
-    #def testSettlementValue(self):
+    # def testSettlementValue(self):
     #    """ Testing FixedRateBond settlement value. """
-    #    orig_date = QuantLib.Settings.evaluationDate
-    #    QuantLib.Settings.evaluationDate = self.issue_date + 1*QuantLib.Months
+    #    orig_date = ql.Settings.evaluationDate
+    #    ql.Settings.evaluationDate = self.issue_date + 1*ql.Months
     #    self.assertEqual(round(self.bond.settlementValue(100.0), 4), 102.3098)
-    #    QuantLib.Settings.evaluationDate = orig_date
+    #    ql.Settings.evaluationDate = orig_date
 
     def testCashFlows(self):
         """ Testing that the FixedRateBond gives the expected cash flows. """
-        self.assertEqual([round(cf.amount(), 4) for cf in self.bond.cashflows()],
-                         20*[round(self.face_amount * self.coupons[0] / 2, 4)] + \
-                         [round(self.redemption, 4)])
+        self.assertEqual(
+            [round(cf.amount(), 4) for cf in self.bond.cashflows()],
+            20 * [round(self.face_amount * self.coupons[0] / 2, 4)] + [round(self.redemption, 4)],
+        )
 
     def testRedemption(self):
         """ Testing FixedRateBond redemption value and date. """
@@ -101,46 +115,79 @@ class FixedRateBondTest(unittest.TestCase):
 
     def testCleanPrice(self):
         """ Testing FixedRateBond clean price. """
-        self.assertEqual(round(self.bond.cleanPrice(0.05, self.day_counter, QuantLib.Compounded,
-                                                    QuantLib.Semiannual, self.issue_date), 4),
-                         99.9964)
-        self.assertEqual(round(self.bond.cleanPrice(0.05, self.day_counter, QuantLib.Compounded,
-                                                    QuantLib.Semiannual, self.issue_date +
-                                                    QuantLib.Period(1, QuantLib.Months)), 4),
-                         99.9921)
+        self.assertEqual(
+            round(self.bond.cleanPrice(0.05, self.day_counter, ql.Compounded, ql.Semiannual, self.issue_date), 4),
+            99.9964,
+        )
+        self.assertEqual(
+            round(
+                self.bond.cleanPrice(
+                    0.05, self.day_counter, ql.Compounded, ql.Semiannual, self.issue_date + ql.Period(1, ql.Months)
+                ),
+                4,
+            ),
+            99.9921,
+        )
 
-        self.assertEqual(round(self.bond.cleanPrice(0.06, self.day_counter, QuantLib.Compounded,
-                                                    QuantLib.Semiannual, self.issue_date +
-                                                    QuantLib.Period(1,QuantLib.Months)), 4),
-                         92.5985)
-
+        self.assertEqual(
+            round(
+                self.bond.cleanPrice(
+                    0.06, self.day_counter, ql.Compounded, ql.Semiannual, self.issue_date + ql.Period(1, ql.Months)
+                ),
+                4,
+            ),
+            92.5985,
+        )
 
     def testDirtyPrice(self):
         """ Testing FixedRateBond dirty price. """
-        self.assertEqual(round(self.bond.dirtyPrice(0.05, self.day_counter, QuantLib.Compounded,
-                                                    QuantLib.Semiannual, self.issue_date), 4),
-                         99.9964)
-        self.assertEqual(round(self.bond.dirtyPrice(0.05, self.day_counter, QuantLib.Compounded,
-                                                    QuantLib.Semiannual, self.issue_date +
-                                                    QuantLib.Period(1,QuantLib.Months)), 4),
-                         100.4179)
-        self.assertEqual(round(self.bond.dirtyPrice(0.06, self.day_counter, QuantLib.Compounded,
-                                                    QuantLib.Semiannual, self.issue_date +
-                                                    QuantLib.Period(1,QuantLib.Months)), 4),
-                         93.0244)
+        self.assertEqual(
+            round(self.bond.dirtyPrice(0.05, self.day_counter, ql.Compounded, ql.Semiannual, self.issue_date), 4),
+            99.9964,
+        )
+        self.assertEqual(
+            round(
+                self.bond.dirtyPrice(
+                    0.05, self.day_counter, ql.Compounded, ql.Semiannual, self.issue_date + ql.Period(1, ql.Months)
+                ),
+                4,
+            ),
+            100.4179,
+        )
+        self.assertEqual(
+            round(
+                self.bond.dirtyPrice(
+                    0.06, self.day_counter, ql.Compounded, ql.Semiannual, self.issue_date + ql.Period(1, ql.Months)
+                ),
+                4,
+            ),
+            93.0244,
+        )
 
     def testCleanPriceFromZSpread(self):
         """ Testing FixedRateBond clean price derived from Z-spread. """
-        self.assertEqual(round(QuantLib.cleanPriceFromZSpread(
-                    self.bond, self.flat_forward, 0.01,
-                    self.day_counter, QuantLib.Compounded, QuantLib.Semiannual,
-                    self.issue_date + QuantLib.Period(1,QuantLib.Months)), 4), 92.5926)
-    
-    def tearDown(self):
-        QuantLib.Settings.instance().setEvaluationDate(QuantLib.Date())
+        self.assertEqual(
+            round(
+                ql.cleanPriceFromZSpread(
+                    self.bond,
+                    self.flat_forward,
+                    0.01,
+                    self.day_counter,
+                    ql.Compounded,
+                    ql.Semiannual,
+                    self.issue_date + ql.Period(1, ql.Months),
+                ),
+                4,
+            ),
+            92.5926,
+        )
 
-if __name__ == '__main__':
-    print('testing QuantLib ' + QuantLib.__version__)
+    def tearDown(self):
+        ql.Settings.instance().setEvaluationDate(ql.Date())
+
+
+if __name__ == "__main__":
+    print("testing QuantLib " + ql.__version__)
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(FixedRateBondTest,'test'))
+    suite.addTest(unittest.makeSuite(FixedRateBondTest, "test"))
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Python/test/cms.py
+++ b/Python/test/cms.py
@@ -15,192 +15,200 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
-from QuantLib import *
+import QuantLib as ql
 import unittest
+
 
 class CmsTest(unittest.TestCase):
     def setUp(self):
-        #global data
-        self.calendar = TARGET()
-        self.referenceDate = self.calendar.adjust(Date.todaysDate())
-        Settings.instance().evaluationDate = self.referenceDate
-        self.termStructure = RelinkableYieldTermStructureHandle()
-        self.termStructure.linkTo(FlatForward(self.referenceDate,
-                             QuoteHandle(SimpleQuote(0.05)), Actual365Fixed()))
+        # global data
+        self.calendar = ql.TARGET()
+        self.referenceDate = self.calendar.adjust(ql.Date.todaysDate())
+        ql.Settings.instance().evaluationDate = self.referenceDate
+        self.termStructure = ql.RelinkableYieldTermStructureHandle()
+        self.termStructure.linkTo(
+            ql.FlatForward(self.referenceDate, ql.QuoteHandle(ql.SimpleQuote(0.05)), ql.Actual365Fixed())
+        )
         self.yieldCurveModels = []
         self.numericalPricers = []
         self.analyticPricers = []
 
         # ATM Volatility structure
         self.atmOptionTenors = [
-            Period(1, Months),
-            Period(6, Months),
-            Period(1, Years),
-            Period(5, Years),
-            Period(10, Years),
-            Period(30, Years)
+            ql.Period(1, ql.Months),
+            ql.Period(6, ql.Months),
+            ql.Period(1, ql.Years),
+            ql.Period(5, ql.Years),
+            ql.Period(10, ql.Years),
+            ql.Period(30, ql.Years),
         ]
 
         self.atmSwapTenors = [
-            Period(1, Years),
-            Period(5, Years),
-            Period(10, Years),
-            Period(30, Years)
+            ql.Period(1, ql.Years),
+            ql.Period(5, ql.Years),
+            ql.Period(10, ql.Years),
+            ql.Period(30, ql.Years),
         ]
 
-        self.m = [[0.1300, 0.1560, 0.1390, 0.1220],
-                  [0.1440, 0.1580, 0.1460, 0.1260],
-                  [0.1600, 0.1590, 0.1470, 0.1290],
-                  [0.1640, 0.1470, 0.1370, 0.1220],
-                  [0.1400, 0.1300, 0.1250, 0.1100],
-                  [0.1130, 0.1090, 0.1070, 0.0930]]
+        self.m = [
+            [0.1300, 0.1560, 0.1390, 0.1220],
+            [0.1440, 0.1580, 0.1460, 0.1260],
+            [0.1600, 0.1590, 0.1470, 0.1290],
+            [0.1640, 0.1470, 0.1370, 0.1220],
+            [0.1400, 0.1300, 0.1250, 0.1100],
+            [0.1130, 0.1090, 0.1070, 0.0930],
+        ]
 
-        self.atmVol = SwaptionVolatilityStructureHandle(
-                SwaptionVolatilityMatrix(self.calendar,
-                                         Following,
-                                         self.atmOptionTenors,
-                                         self.atmSwapTenors,
-                                         Matrix(self.m),
-                                         Actual365Fixed()))
+        self.atmVol = ql.SwaptionVolatilityStructureHandle(
+            ql.SwaptionVolatilityMatrix(
+                self.calendar,
+                ql.Following,
+                self.atmOptionTenors,
+                self.atmSwapTenors,
+                ql.Matrix(self.m),
+                ql.Actual365Fixed(),
+            )
+        )
 
         ###Vol cubes
-        self.optionTenors = [
-            Period(1, Years),
-            Period(10, Years),
-            Period(30, Years)
-        ]
+        self.optionTenors = [ql.Period(1, ql.Years), ql.Period(10, ql.Years), ql.Period(30, ql.Years)]
 
-        self.swapTenors = [
-            Period(2, Years),
-            Period(10, Years),
-            Period(30, Years)
-        ]
+        self.swapTenors = [ql.Period(2, ql.Years), ql.Period(10, ql.Years), ql.Period(30, ql.Years)]
 
-        self.strikeSpreads = [
-            -0.020,
-            -0.005,
-            +0.000,
-            +0.005,
-            +0.020
-        ]
+        self.strikeSpreads = [-0.020, -0.005, +0.000, +0.005, +0.020]
 
-        self.nRows = len(self.optionTenors)*len(self.swapTenors)
+        self.nRows = len(self.optionTenors) * len(self.swapTenors)
         self.nCols = len(self.strikeSpreads)
-        self.volSpreadsMatrix = [[0.0599,0.0049,0.0000,-0.0001,0.0127],
-                                 [0.0729,0.0086,0.0000,-0.0024,0.0098],
-                                 [0.0738,0.0102,0.0000,-0.0039,0.0065],
-                                 [0.0465,0.0063,0.0000,-0.0032,-0.0010],
-                                 [0.0558,0.0084,0.0000,-0.0050,-0.0057],
-                                 [0.0576,0.0083,0.0000,-0.0043,-0.0014],
-                                 [0.0437,0.0059,0.0000,-0.0030,-0.0006],
-                                 [0.0533,0.0078,0.0000,-0.0045,-0.0046],
-                                 [0.0545,0.0079,0.0000,-0.0042,-0.0020]]
+        self.volSpreadsMatrix = [
+            [0.0599, 0.0049, 0.0000, -0.0001, 0.0127],
+            [0.0729, 0.0086, 0.0000, -0.0024, 0.0098],
+            [0.0738, 0.0102, 0.0000, -0.0039, 0.0065],
+            [0.0465, 0.0063, 0.0000, -0.0032, -0.0010],
+            [0.0558, 0.0084, 0.0000, -0.0050, -0.0057],
+            [0.0576, 0.0083, 0.0000, -0.0043, -0.0014],
+            [0.0437, 0.0059, 0.0000, -0.0030, -0.0006],
+            [0.0533, 0.0078, 0.0000, -0.0045, -0.0046],
+            [0.0545, 0.0079, 0.0000, -0.0042, -0.0020],
+        ]
 
         self.volSpreads = []
         for i in range(self.nRows):
             self.volSpreadsRow = []
             for j in range(self.nCols):
-                self.volSpreadsRow.append(
-                    QuoteHandle(SimpleQuote(self.volSpreadsMatrix[i][j])))
+                self.volSpreadsRow.append(ql.QuoteHandle(ql.SimpleQuote(self.volSpreadsMatrix[i][j])))
             self.volSpreads.append(self.volSpreadsRow)
 
-        self.iborIndex = Euribor6M(self.termStructure)
-        self.swapIndexBase = EuriborSwapIsdaFixA(Period(10,Years),
-                                                 self.termStructure)
-        self.shortSwapIndexBase = EuriborSwapIsdaFixA(Period(2,Years),
-                                                      self.termStructure)
+        self.iborIndex = ql.Euribor6M(self.termStructure)
+        self.swapIndexBase = ql.EuriborSwapIsdaFixA(ql.Period(10, ql.Years), self.termStructure)
+        self.shortSwapIndexBase = ql.EuriborSwapIsdaFixA(ql.Period(2, ql.Years), self.termStructure)
 
         self.vegaWeightedSmileFit = False
-        self.SabrVolCube2 = SwaptionVolatilityStructureHandle(
-                SwaptionVolCube2(self.atmVol,
-                                 self.optionTenors,
-                                 self.swapTenors,
-                                 self.strikeSpreads,
-                                 self.volSpreads,
-                                 self.swapIndexBase,
-                                 self.shortSwapIndexBase,
-                                 self.vegaWeightedSmileFit))
+        self.SabrVolCube2 = ql.SwaptionVolatilityStructureHandle(
+            ql.SwaptionVolCube2(
+                self.atmVol,
+                self.optionTenors,
+                self.swapTenors,
+                self.strikeSpreads,
+                self.volSpreads,
+                self.swapIndexBase,
+                self.shortSwapIndexBase,
+                self.vegaWeightedSmileFit,
+            )
+        )
         self.SabrVolCube2.enableExtrapolation()
 
         self.guess = []
-        self.guessMatrix = [[0.2,0.5,0.4,0.0],
-                            [0.2,0.5,0.4,0.0],
-                            [0.2,0.5,0.4,0.0],
-                            [0.2,0.5,0.4,0.0],
-                            [0.2,0.5,0.4,0.0],
-                            [0.2,0.5,0.4,0.0],
-                            [0.2,0.5,0.4,0.0],
-                            [0.2,0.5,0.4,0.0],
-                            [0.2,0.5,0.4,0.0]]
+        self.guessMatrix = [
+            [0.2, 0.5, 0.4, 0.0],
+            [0.2, 0.5, 0.4, 0.0],
+            [0.2, 0.5, 0.4, 0.0],
+            [0.2, 0.5, 0.4, 0.0],
+            [0.2, 0.5, 0.4, 0.0],
+            [0.2, 0.5, 0.4, 0.0],
+            [0.2, 0.5, 0.4, 0.0],
+            [0.2, 0.5, 0.4, 0.0],
+            [0.2, 0.5, 0.4, 0.0],
+        ]
 
         for i in range(self.nRows):
             self.guessRow = []
             for j in range(4):
-                self.guessRow.append(
-                    QuoteHandle(SimpleQuote(self.guessMatrix[i][j])))
+                self.guessRow.append(ql.QuoteHandle(ql.SimpleQuote(self.guessMatrix[i][j])))
             self.guess.append(self.guessRow)
 
-        self.isParameterFixed = [False,True,False,False]
+        self.isParameterFixed = [False, True, False, False]
         ### FIXME
         self.isAtmCalibrated = False
         ##
-        self.SabrVolCube1 = SwaptionVolatilityStructureHandle(
-                SwaptionVolCube1(self.atmVol,
-                                 self.optionTenors,
-                                 self.swapTenors,
-                                 self.strikeSpreads,
-                                 self.volSpreads,
-                                 self.swapIndexBase,
-                                 self.shortSwapIndexBase,
-                                 self.vegaWeightedSmileFit,
-                                 self.guess,
-                                 self.isParameterFixed,
-                                 self.isAtmCalibrated))
+        self.SabrVolCube1 = ql.SwaptionVolatilityStructureHandle(
+            ql.SwaptionVolCube1(
+                self.atmVol,
+                self.optionTenors,
+                self.swapTenors,
+                self.strikeSpreads,
+                self.volSpreads,
+                self.swapIndexBase,
+                self.shortSwapIndexBase,
+                self.vegaWeightedSmileFit,
+                self.guess,
+                self.isParameterFixed,
+                self.isAtmCalibrated,
+            )
+        )
         ##SabrVolCube1.enableExtrapolation()
 
         self.yieldCurveModels = [
-            GFunctionFactory.Standard,
-            GFunctionFactory.ExactYield,
-            GFunctionFactory.ParallelShifts,
-            GFunctionFactory.NonParallelShifts
+            ql.GFunctionFactory.Standard,
+            ql.GFunctionFactory.ExactYield,
+            ql.GFunctionFactory.ParallelShifts,
+            ql.GFunctionFactory.NonParallelShifts,
         ]
 
-        self.zeroMeanRev = QuoteHandle(SimpleQuote(0.0))
+        self.zeroMeanRev = ql.QuoteHandle(ql.SimpleQuote(0.0))
 
         self.numericalPricers = {}
         self.analyticPricers = {}
         for m in self.yieldCurveModels:
-            self.numericalPricers[m] = NumericHaganPricer(self.atmVol, m,
-                                                          self.zeroMeanRev)
-            self.analyticPricers[m] = AnalyticHaganPricer(self.atmVol, m,
-                                                          self.zeroMeanRev)
+            self.numericalPricers[m] = ql.NumericHaganPricer(self.atmVol, m, self.zeroMeanRev)
+            self.analyticPricers[m] = ql.AnalyticHaganPricer(self.atmVol, m, self.zeroMeanRev)
 
     def testFairRate(self):
         """Testing Hagan-pricer flat-vol equivalence for coupons..."""
-        swapIndex = SwapIndex("EuriborSwapIsdaFixA",
-                              Period(10,Years),
-                              self.iborIndex.fixingDays(),
-                              self.iborIndex.currency(),
-                              self.iborIndex.fixingCalendar(),
-                              Period(1,Years),
-                              Unadjusted,
-                              self.iborIndex.dayCounter(),
-                              self.iborIndex)
-        startDate = self.termStructure.referenceDate() + Period(20,Years)
-        paymentDate = startDate + Period(1,Years)
+        swapIndex = ql.SwapIndex(
+            "EuriborSwapIsdaFixA",
+            ql.Period(10, ql.Years),
+            self.iborIndex.fixingDays(),
+            self.iborIndex.currency(),
+            self.iborIndex.fixingCalendar(),
+            ql.Period(1, ql.Years),
+            ql.Unadjusted,
+            self.iborIndex.dayCounter(),
+            self.iborIndex,
+        )
+        startDate = self.termStructure.referenceDate() + ql.Period(20, ql.Years)
+        paymentDate = startDate + ql.Period(1, ql.Years)
         endDate = paymentDate
         nominal = 1.0
-        infiniteCap = nullDouble()
-        infiniteFloor = nullDouble()
+        infiniteCap = ql.nullDouble()
+        infiniteFloor = ql.nullDouble()
         gearing = 1.0
         spread = 0.0
-        coupon = CappedFlooredCmsCoupon(paymentDate, nominal,
-                                        startDate, endDate,
-                                        swapIndex.fixingDays(), swapIndex,
-                                        gearing, spread,
-                                        infiniteCap, infiniteFloor,
-                                        startDate, endDate,
-                                        self.iborIndex.dayCounter(),False)
+        coupon = ql.CappedFlooredCmsCoupon(
+            paymentDate,
+            nominal,
+            startDate,
+            endDate,
+            swapIndex.fixingDays(),
+            swapIndex,
+            gearing,
+            spread,
+            infiniteCap,
+            infiniteFloor,
+            startDate,
+            endDate,
+            self.iborIndex.dayCounter(),
+            False,
+        )
 
         for m in self.yieldCurveModels:
             self.numericalPricers[m].setSwaptionVolatility(self.atmVol)
@@ -209,73 +217,89 @@ class CmsTest(unittest.TestCase):
             self.analyticPricers[m].setSwaptionVolatility(self.atmVol)
             coupon.setPricer(self.analyticPricers[m])
             rate1 = coupon.rate()
-            difference =  abs(rate1-rate0)
+            difference = abs(rate1 - rate0)
             tol = 2.0e-4
-            self.assertTrue(difference<tol)
+            self.assertTrue(difference < tol)
 
     def testParity(self):
         """Testing put-call parity for capped-floored CMS coupons..."""
-        swaptionVols = [
-            self.atmVol,
-            self.SabrVolCube1,
-            self.SabrVolCube2
-        ]
-        swapIndex = EuriborSwapIsdaFixA(Period(10,Years),
-                                        self.iborIndex.forwardingTermStructure())
-        startDate = self.termStructure.referenceDate() + Period(20,Years)
-        paymentDate = startDate + Period(1,Years)
+        swaptionVols = [self.atmVol, self.SabrVolCube1, self.SabrVolCube2]
+        swapIndex = ql.EuriborSwapIsdaFixA(ql.Period(10, ql.Years), self.iborIndex.forwardingTermStructure())
+        startDate = self.termStructure.referenceDate() + ql.Period(20, ql.Years)
+        paymentDate = startDate + ql.Period(1, ql.Years)
         endDate = paymentDate
         nominal = 1.0
-        infiniteCap = nullDouble()
-        infiniteFloor = nullDouble()
+        infiniteCap = ql.nullDouble()
+        infiniteFloor = ql.nullDouble()
         gearing = 1.0
         spread = 0.0
         discount = self.termStructure.discount(paymentDate)
-        swaplet = CappedFlooredCmsCoupon(paymentDate, nominal,
-                                         startDate, endDate,
-                                         swapIndex.fixingDays(),
-                                         swapIndex,
-                                         gearing, spread,
-                                         infiniteCap, infiniteFloor,
-                                         startDate, endDate,
-                                         self.iborIndex.dayCounter())
-        strikes = [0.02,0.07]
+        swaplet = ql.CappedFlooredCmsCoupon(
+            paymentDate,
+            nominal,
+            startDate,
+            endDate,
+            swapIndex.fixingDays(),
+            swapIndex,
+            gearing,
+            spread,
+            infiniteCap,
+            infiniteFloor,
+            startDate,
+            endDate,
+            self.iborIndex.dayCounter(),
+        )
+        strikes = [0.02, 0.07]
         for k in strikes:
-            caplet = CappedFlooredCmsCoupon(paymentDate, nominal,
-                                            startDate, endDate,
-                                            swapIndex.fixingDays(),
-                                            swapIndex,
-                                            gearing, spread,
-                                            k, infiniteFloor,
-                                            startDate, endDate,
-                                            self.iborIndex.dayCounter())
-            floorlet = CappedFlooredCmsCoupon(paymentDate, nominal,
-                                              startDate, endDate,
-                                              swapIndex.fixingDays(),
-                                              swapIndex,
-                                              gearing, spread,
-                                              infiniteCap, k,
-                                              startDate, endDate,
-                                              self.iborIndex.dayCounter())
+            caplet = ql.CappedFlooredCmsCoupon(
+                paymentDate,
+                nominal,
+                startDate,
+                endDate,
+                swapIndex.fixingDays(),
+                swapIndex,
+                gearing,
+                spread,
+                k,
+                infiniteFloor,
+                startDate,
+                endDate,
+                self.iborIndex.dayCounter(),
+            )
+            floorlet = ql.CappedFlooredCmsCoupon(
+                paymentDate,
+                nominal,
+                startDate,
+                endDate,
+                swapIndex.fixingDays(),
+                swapIndex,
+                gearing,
+                spread,
+                infiniteCap,
+                k,
+                startDate,
+                endDate,
+                self.iborIndex.dayCounter(),
+            )
             for vol in swaptionVols:
                 for m in self.yieldCurveModels:
                     self.numericalPricers[m].setSwaptionVolatility(vol)
                     self.analyticPricers[m].setSwaptionVolatility(vol)
-                    pricers = [self.numericalPricers[m],self.analyticPricers[m]]
+                    pricers = [self.numericalPricers[m], self.analyticPricers[m]]
                     for p in pricers:
                         swaplet.setPricer(p)
                         caplet.setPricer(p)
                         floorlet.setPricer(p)
-                        swapletPrice = (swaplet.price(self.termStructure)
-                                        + swaplet.accrualPeriod()*k*discount)
+                        swapletPrice = swaplet.price(self.termStructure) + swaplet.accrualPeriod() * k * discount
                         capletPrice = caplet.price(self.termStructure)
                         floorletPrice = floorlet.price(self.termStructure)
-                        difference = abs(capletPrice+floorletPrice-swapletPrice)
+                        difference = abs(capletPrice + floorletPrice - swapletPrice)
                         tol = 2.0e-5
-                        self.assertTrue(difference<tol)
+                        self.assertTrue(difference < tol)
 
-if __name__ == '__main__':
-    print('testing QuantLib ' + QuantLib.__version__)
+
+if __name__ == "__main__":
+    print("testing QuantLib " + ql.__version__)
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(CmsTest,'test'))
+    suite.addTest(unittest.makeSuite(CmsTest, "test"))
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Python/test/date.py
+++ b/Python/test/date.py
@@ -15,8 +15,9 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
-import QuantLib
+import QuantLib as ql
 import unittest
+
 
 class DateTest(unittest.TestCase):
     def setUp(self):
@@ -24,46 +25,51 @@ class DateTest(unittest.TestCase):
 
     def testArithmetics(self):
         "Testing date arithmetics"
-        date = QuantLib.Date_minDate()
+        date = ql.Date_minDate()
 
-        dold   = date.dayOfMonth()
-        mold   = date.month()
-        yold   = date.year()
+        dold = date.dayOfMonth()
+        mold = date.month()
+        yold = date.year()
 
-        while date < QuantLib.Date_maxDate():
+        while date < ql.Date_maxDate():
             date += 1
 
-            d   = date.dayOfMonth()
-            m   = date.month()
-            y   = date.year()
+            d = date.dayOfMonth()
+            m = date.month()
+            y = date.year()
 
             # check if skipping any date
-            if not ((d==dold+1 and m==mold      and y==yold  ) or
-                    (d==1      and m==mold+1    and y==yold  ) or
-                    (d==1      and m==1         and y==yold+1)):
-                self.fail("""
+            if not (
+                (d == dold + 1 and m == mold and y == yold)
+                or (d == 1 and m == mold + 1 and y == yold)
+                or (d == 1 and m == 1 and y == yold + 1)
+            ):
+                self.fail(
+                    """
 wrong day, month, year increment
     date: %(t)s
     day, month, year: %(d)d, %(m)d, %(y)d
     previous:         %(dold)d, %(mold)d, %(yold)d
-                """ % locals())
+                """
+                    % locals()
+                )
             dold = d
             mold = m
             yold = y
-            
+
     def testHolidayList(self):
         """ Testing Calendar testHolidayList() method. """
-        holidayLstFunction = QuantLib.Calendar.holidayList(QuantLib.Poland(),QuantLib.Date(31, 12, 2014),QuantLib.Date(3, 4, 2015),False)
-        holidayLstManual = (QuantLib.Date(1,1,2015), QuantLib.Date(6,1,2015))
+        holidayLstFunction = ql.Calendar.holidayList(ql.Poland(), ql.Date(31, 12, 2014), ql.Date(3, 4, 2015), False)
+        holidayLstManual = (ql.Date(1, 1, 2015), ql.Date(6, 1, 2015))
         # check if dates both from function and from manual imput are the same
-        self.assertTrue(all([(a == b) for a, b in zip (holidayLstFunction, holidayLstManual)]))
-        
+        self.assertTrue(all([(a == b) for a, b in zip(holidayLstFunction, holidayLstManual)]))
+
     def tearDown(self):
         pass
 
 
-if __name__ == '__main__':
-    print('testing QuantLib ' + QuantLib.__version__) 
+if __name__ == "__main__":
+    print("testing QuantLib " + ql.__version__)
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(DateTest,'test'))
+    suite.addTest(unittest.makeSuite(DateTest, "test"))
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Python/test/daycounters.py
+++ b/Python/test/daycounters.py
@@ -1,21 +1,27 @@
-import QuantLib
+import QuantLib as ql
 import unittest
+
 
 class DayCountersTest(unittest.TestCase):
     def runTest(self):
         "Testing daycounters"
 
-        calendar    = QuantLib.UnitedStates()
+        calendar = ql.UnitedStates()
 
         #
-        # Check that SWIG signature for Business252 calendar allows to pass custom calendar into the class constructor.
-        # Old QuantLib-SWIG versions allow only to create Business252 calendar with default constructor parameter (Brazil calendar),
-        # and generate an exception when trying to pass a custom calendar as a parameter. So we just check here that no exception occurs.
+        # Check that SWIG signature for Business252 calendar allows to
+        # pass custom calendar into the class constructor.  Old
+        # QuantLib-SWIG versions allow only to create Business252
+        # calendar with default constructor parameter (Brazil
+        # calendar), and generate an exception when trying to pass a
+        # custom calendar as a parameter. So we just check here that
+        # no exception occurs.
         #
-        day_counter = QuantLib.Business252(calendar)
+        ql.Business252(calendar)
 
-if __name__ == '__main__':
-    print('testing QuantLib ' + QuantLib.__version__) 
+
+if __name__ == "__main__":
+    print("testing QuantLib " + ql.__version__)
     suite = unittest.TestSuite()
     suite.addTest(DayCountersTest())
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Python/test/iborindex.py
+++ b/Python/test/iborindex.py
@@ -16,70 +16,61 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
-from QuantLib import *
+import QuantLib as ql
 import unittest
 
 
 class IborIndexTest(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
-        cls.euribor3m = Euribor3M()
-    
+        cls.euribor3m = ql.Euribor3M()
+
     def setUp(self):
         self.euribor3m.clearFixings()
         # values are not real due to copyrights of the fixing
-        self.euribor3m.addFixing(Date(17, 7, 2018), -0.3)
-        self.euribor3m.addFixings([Date(12, 7, 2018), Date(13, 7, 2018)],
-                                  [-0.3, - 0.3])
+        self.euribor3m.addFixing(ql.Date(17, 7, 2018), -0.3)
+        self.euribor3m.addFixings([ql.Date(12, 7, 2018), ql.Date(13, 7, 2018)], [-0.3, -0.3])
 
     def testAddFixingFail(self):
         """Testing for RuntimeError while trying to overwrite fixing value"""
 
         with self.assertRaises(RuntimeError):
             # attempt to overwrite value that is already set at different level
-            self.euribor3m.addFixing(Date(17, 7, 2018), -0.4)
-        
+            self.euribor3m.addFixing(ql.Date(17, 7, 2018), -0.4)
+
         with self.assertRaises(RuntimeError):
             # attempt to overwrite value that is already set at different level
-            self.euribor3m.addFixings([Date(12, 7, 2018), Date(13, 7, 2018)],
-                                      [-0.4, - 0.4])
-                                      
+            self.euribor3m.addFixings([ql.Date(12, 7, 2018), ql.Date(13, 7, 2018)], [-0.4, -0.4])
+
     def testAddFixing(self):
         """Testing for overwriting fixing value"""
 
         force_overwrite = True
         try:
             # attempt to overwrite value that is already set at different level
-            self.euribor3m.addFixing(Date(17, 7, 2018), -0.4,
-                                     force_overwrite)
-            self.euribor3m.addFixings([Date(12, 7, 2018), Date(13, 7, 2018)],
-                                      [-0.4, - 0.4],
-                                      force_overwrite)
+            self.euribor3m.addFixing(ql.Date(17, 7, 2018), -0.4, force_overwrite)
+            self.euribor3m.addFixings([ql.Date(12, 7, 2018), ql.Date(13, 7, 2018)], [-0.4, -0.4], force_overwrite)
             # try clearFixings and repeat with original levels
             self.euribor3m.clearFixings()
-            self.euribor3m.addFixing(Date(17, 7, 2018), -0.3)
-            self.euribor3m.addFixings([Date(12, 7, 2018), Date(13, 7, 2018)],
-                                      [-0.3, - 0.3])
+            self.euribor3m.addFixing(ql.Date(17, 7, 2018), -0.3)
+            self.euribor3m.addFixings([ql.Date(12, 7, 2018), ql.Date(13, 7, 2018)], [-0.3, -0.3])
 
         except RuntimeError as err:
-            raise AssertionError("Failed to overwrite index fixixng "
-                                 + "{}".format(err))
-    
+            raise AssertionError("Failed to overwrite index fixixng " + "{}".format(err))
+
     def testTimeSeries(self):
         """Testing for getting time series of the fixing"""
 
-        dates = (Date(12, 7, 2018), Date(13, 7, 2018), Date(17, 7, 2018))
+        dates = (ql.Date(12, 7, 2018), ql.Date(13, 7, 2018), ql.Date(17, 7, 2018))
         values = (-0.3, -0.3, -0.3)
         for expected, actual in zip(dates, self.euribor3m.timeSeries().dates()):
             self.assertTrue(expected == actual)
-        for expected, actual in zip(values,
-                                    self.euribor3m.timeSeries().values()):
+        for expected, actual in zip(values, self.euribor3m.timeSeries().values()):
             self.assertTrue(expected == actual)
-        
 
-if __name__ == '__main__':
-    print('testing QuantLib ' + QuantLib.__version__)
+
+if __name__ == "__main__":
+    print("testing QuantLib " + ql.__version__)
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(IborIndexTest, 'test'))
+    suite.addTest(unittest.makeSuite(IborIndexTest, "test"))
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Python/test/instruments.py
+++ b/Python/test/instruments.py
@@ -15,25 +15,28 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
-import QuantLib
+import QuantLib as ql
 import unittest
 
 flag = None
+
+
 def raiseFlag():
     global flag
     flag = 1
+
 
 class InstrumentTest(unittest.TestCase):
     def testObservable(self):
         "Testing observability of stocks"
         global flag
         flag = None
-        me1 = QuantLib.SimpleQuote(0.0)
-        h = QuantLib.RelinkableQuoteHandle(me1)
-        s = QuantLib.Stock(h)
+        me1 = ql.SimpleQuote(0.0)
+        h = ql.RelinkableQuoteHandle(me1)
+        s = ql.Stock(h)
         s.NPV()
 
-        obs = QuantLib.Observer(raiseFlag)
+        obs = ql.Observer(raiseFlag)
         obs.registerWith(s)
 
         me1.setValue(3.14)
@@ -42,7 +45,7 @@ class InstrumentTest(unittest.TestCase):
 
         s.NPV()
         flag = None
-        me2 = QuantLib.SimpleQuote(0.0)
+        me2 = ql.SimpleQuote(0.0)
         h.linkTo(me2)
         if not flag:
             self.fail("Observer was not notified of instrument change")
@@ -57,8 +60,9 @@ class InstrumentTest(unittest.TestCase):
         if not flag:
             self.fail("Observer was not notified of instrument change")
 
-if __name__ == '__main__':
-    print('testing QuantLib ' + QuantLib.__version__)
+
+if __name__ == "__main__":
+    print("testing QuantLib " + ql.__version__)
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(InstrumentTest,'test'))
+    suite.addTest(unittest.makeSuite(InstrumentTest, "test"))
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Python/test/integrals.py
+++ b/Python/test/integrals.py
@@ -15,48 +15,57 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
-import QuantLib
+import QuantLib as ql
 import unittest
 import math
 
-class IntegralTest(unittest.TestCase):
-    def Gauss(self,x):
-        return math.exp(-x*x/2.0)/math.sqrt(2*math.pi)
-    def singleTest(self,I):
-        tolerance = 1e-4
-        cases = [["f(x) = 1",        lambda x: 1,    0.0,     1.0, 1.0],
-                 ["f(x) = x",        lambda x: x,    0.0,     1.0, 0.5],
-                 ["f(x) = x^2",      lambda x: x*x,  0.0,     1.0, 1.0/3.0],
-                 ["f(x) = sin(x)",   math.sin,       0.0, math.pi, 2.0],
-                 ["f(x) = cos(x)",   math.cos,       0.0, math.pi, 0.0],
-                 ["f(x) = Gauss(x)", self.Gauss,   -10.0,    10.0, 1.0]]
 
-        for tag,f,a,b,expected in cases:
-            calculated = I(f,a,b)
-            if not (abs(calculated-expected) <= tolerance):
-                self.fail("""
+class IntegralTest(unittest.TestCase):
+    def Gauss(self, x):
+        return math.exp(-x * x / 2.0) / math.sqrt(2 * math.pi)
+
+    def singleTest(self, I):
+        tolerance = 1e-4
+        cases = [
+            ["f(x) = 1", lambda x: 1, 0.0, 1.0, 1.0],
+            ["f(x) = x", lambda x: x, 0.0, 1.0, 0.5],
+            ["f(x) = x^2", lambda x: x * x, 0.0, 1.0, 1.0 / 3.0],
+            ["f(x) = sin(x)", math.sin, 0.0, math.pi, 2.0],
+            ["f(x) = cos(x)", math.cos, 0.0, math.pi, 0.0],
+            ["f(x) = Gauss(x)", self.Gauss, -10.0, 10.0, 1.0],
+        ]
+
+        for tag, f, a, b, expected in cases:
+            calculated = I(f, a, b)
+            if not (abs(calculated - expected) <= tolerance):
+                self.fail(
+                    """
 integrating %(tag)s
     calculated: %(calculated)f
     expected  : %(expected)f
-                      """ % locals())
+                      """
+                    % locals()
+                )
 
     def testSegment(self):
         "Testing segment integration"
-        self.singleTest(QuantLib.SegmentIntegral(10000))
+        self.singleTest(ql.SegmentIntegral(10000))
+
     def testTrapezoid(self):
         "Testing trapezoid integration"
-        self.singleTest(QuantLib.TrapezoidIntegralDefault(1.0e-4, 1000))
+        self.singleTest(ql.TrapezoidIntegralDefault(1.0e-4, 1000))
+
     def testSimpson(self):
         "Testing Simpson integration"
-        self.singleTest(QuantLib.SimpsonIntegral(1.0e-4, 1000))
+        self.singleTest(ql.SimpsonIntegral(1.0e-4, 1000))
+
     def testKronrod(self):
         "Testing Gauss-Kronrod integration"
-        self.singleTest(QuantLib.GaussKronrodAdaptive(1.0e-4))
+        self.singleTest(ql.GaussKronrodAdaptive(1.0e-4))
 
 
-
-if __name__ == '__main__':
-    print('testing QuantLib ' + QuantLib.__version__)
+if __name__ == "__main__":
+    print("testing QuantLib " + ql.__version__)
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(IntegralTest,'test'))
+    suite.addTest(unittest.makeSuite(IntegralTest, "test"))
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Python/test/marketelements.py
+++ b/Python/test/marketelements.py
@@ -15,45 +15,49 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
-import QuantLib
+import QuantLib as ql
 import unittest
 
 flag = None
+
+
 def raiseFlag():
     global flag
     flag = 1
+
 
 class MarketElementTest(unittest.TestCase):
     def testObservable(self):
         "Testing observability of market elements"
         global flag
         flag = None
-        me = QuantLib.SimpleQuote(0.0)
-        obs = QuantLib.Observer(raiseFlag)
+        me = ql.SimpleQuote(0.0)
+        obs = ql.Observer(raiseFlag)
         obs.registerWith(me)
         me.setValue(3.14)
         if not flag:
             self.fail("Observer was not notified of market element change")
+
     def testObservableHandle(self):
         "Testing observability of market element handles"
         global flag
         flag = None
-        me1 = QuantLib.SimpleQuote(0.0)
-        h = QuantLib.RelinkableQuoteHandle(me1)
-        obs = QuantLib.Observer(raiseFlag)
+        me1 = ql.SimpleQuote(0.0)
+        h = ql.RelinkableQuoteHandle(me1)
+        obs = ql.Observer(raiseFlag)
         obs.registerWith(h)
         me1.setValue(3.14)
         if not flag:
             self.fail("Observer was not notified of market element change")
         flag = None
-        me2 = QuantLib.SimpleQuote(0.0)
+        me2 = ql.SimpleQuote(0.0)
         h.linkTo(me2)
         if not flag:
             self.fail("Observer was not notified of market element change")
 
 
-if __name__ == '__main__':
-    print('testing QuantLib ' + QuantLib.__version__)
+if __name__ == "__main__":
+    print("testing QuantLib " + ql.__version__)
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(MarketElementTest,'test'))
+    suite.addTest(unittest.makeSuite(MarketElementTest, "test"))
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Python/test/ratehelpers.py
+++ b/Python/test/ratehelpers.py
@@ -18,39 +18,45 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
-import QuantLib
+import QuantLib as ql
 import unittest
 
 
 class FixedRateBondHelperTest(unittest.TestCase):
     def setUp(self):
-        QuantLib.Settings.instance().setEvaluationDate(QuantLib.Date(2,1,2010))
+        ql.Settings.instance().setEvaluationDate(ql.Date(2, 1, 2010))
         self.settlement_days = 3
         self.face_amount = 100.0
         self.redemption = 100.0
-        self.quote_handle = QuantLib.QuoteHandle(QuantLib.SimpleQuote(100.0))
+        self.quote_handle = ql.QuoteHandle(ql.SimpleQuote(100.0))
 
-        self.issue_date = QuantLib.Date(2, 1, 2008)
-        self.maturity_date = QuantLib.Date(2, 1, 2018)
-        self.calendar = QuantLib.UnitedStates(
-            QuantLib.UnitedStates.GovernmentBond)
-        self.day_counter = QuantLib.ActualActual(QuantLib.ActualActual.Bond)
-        self.sched = QuantLib.Schedule(self.issue_date, self.maturity_date,
-                                       QuantLib.Period(QuantLib.Semiannual),
-                                       self.calendar,
-                                       QuantLib.Unadjusted, QuantLib.Unadjusted,
-                                       QuantLib.DateGeneration.Backward, False)
+        self.issue_date = ql.Date(2, 1, 2008)
+        self.maturity_date = ql.Date(2, 1, 2018)
+        self.calendar = ql.UnitedStates(ql.UnitedStates.GovernmentBond)
+        self.day_counter = ql.ActualActual(ql.ActualActual.Bond)
+        self.sched = ql.Schedule(
+            self.issue_date,
+            self.maturity_date,
+            ql.Period(ql.Semiannual),
+            self.calendar,
+            ql.Unadjusted,
+            ql.Unadjusted,
+            ql.DateGeneration.Backward,
+            False,
+        )
         self.coupons = [0.05]
 
-        self.bond_helper = QuantLib.FixedRateBondHelper(self.quote_handle,
-                                                        self.settlement_days,
-                                                        self.face_amount,
-                                                        self.sched,
-                                                        self.coupons,
-                                                        self.day_counter,
-                                                        QuantLib.Following,
-                                                        self.redemption,
-                                                        self.issue_date)
+        self.bond_helper = ql.FixedRateBondHelper(
+            self.quote_handle,
+            self.settlement_days,
+            self.face_amount,
+            self.sched,
+            self.coupons,
+            self.day_counter,
+            ql.Following,
+            self.redemption,
+            self.issue_date,
+        )
 
     def testBond(self):
         """ Testing FixedRateBondHelper bond() method. """
@@ -63,18 +69,17 @@ class FxSwapRateHelperTest(unittest.TestCase):
     def setUp(self):
 
         # Market rates are artificial, just close to real ones.
-        self.default_quote_date = QuantLib.Date(26, 8, 2016)
+        self.default_quote_date = ql.Date(26, 8, 2016)
 
-        self.fx_swap_quotes = {(1, QuantLib.Months): 20e-4,
-                               (3, QuantLib.Months): 60e-4,
-                               (6, QuantLib.Months): 120e-4,
-                               (1, QuantLib.Years): 240e-4}
+        self.fx_swap_quotes = {
+            (1, ql.Months): 20e-4,
+            (3, ql.Months): 60e-4,
+            (6, ql.Months): 120e-4,
+            (1, ql.Years): 240e-4,
+        }
 
-        # Valid only for the quote date of QuantLib.Date(26, 8, 2016)
-        self.maturities = [QuantLib.Date(30, 9, 2016),
-                           QuantLib.Date(30, 11, 2016),
-                           QuantLib.Date(28, 2, 2017),
-                           QuantLib.Date(30, 8, 2017)]
+        # Valid only for the quote date of ql.Date(26, 8, 2016)
+        self.maturities = [ql.Date(30, 9, 2016), ql.Date(30, 11, 2016), ql.Date(28, 2, 2017), ql.Date(30, 8, 2017)]
 
         self.fx_spot_quote_EURPLN = 4.3
         self.fx_spot_quote_EURUSD = 1.1
@@ -85,69 +90,76 @@ class FxSwapRateHelperTest(unittest.TestCase):
         :param quotes_date: date fro which it is assumed all market data are
             valid
         :return: tuple consisting of objects related to EUR OIS discounting
-            curve: QuantLib.PiecewiseFlatForward,
-                   QuantLib.YieldTermStructureHandle
-                   QuantLib.RelinkableYieldTermStructureHandle
+            curve: ql.PiecewiseFlatForward,
+                   ql.YieldTermStructureHandle
+                   ql.RelinkableYieldTermStructureHandle
         """
-        calendar = QuantLib.TARGET()
+        calendar = ql.TARGET()
         settlementDays = 2
 
         todaysDate = quotes_date
-        QuantLib.Settings.instance().evaluationDate = todaysDate
+        ql.Settings.instance().evaluationDate = todaysDate
 
         todays_Eonia_quote = -0.00341
 
         # market quotes
         # deposits, key structure as (settlement_days_number, number_of_units_
         # for_maturity, unit)
-        deposits = {(0, 1, QuantLib.Days): todays_Eonia_quote}
+        deposits = {(0, 1, ql.Days): todays_Eonia_quote}
 
-        discounting_yts_handle = QuantLib.RelinkableYieldTermStructureHandle()
-        on_index = QuantLib.Eonia(discounting_yts_handle)
+        discounting_yts_handle = ql.RelinkableYieldTermStructureHandle()
+        on_index = ql.Eonia(discounting_yts_handle)
         on_index.addFixing(todaysDate, todays_Eonia_quote / 100.0)
 
-        ois = {(1, QuantLib.Weeks): -0.342,
-               (1, QuantLib.Months): -0.344,
-               (3, QuantLib.Months): -0.349,
-               (6, QuantLib.Months): -0.363,
-               (1, QuantLib.Years): -0.389}
+        ois = {
+            (1, ql.Weeks): -0.342,
+            (1, ql.Months): -0.344,
+            (3, ql.Months): -0.349,
+            (6, ql.Months): -0.363,
+            (1, ql.Years): -0.389,
+        }
 
         # convert them to Quote objects
         for sett_num, n, unit in deposits.keys():
-            deposits[(sett_num, n, unit)] = \
-                QuantLib.SimpleQuote(deposits[(sett_num, n, unit)] / 100.0)
+            deposits[(sett_num, n, unit)] = ql.SimpleQuote(deposits[(sett_num, n, unit)] / 100.0)
 
         for n, unit in ois.keys():
-            ois[(n, unit)] = QuantLib.SimpleQuote(ois[(n, unit)] / 100.0)
+            ois[(n, unit)] = ql.SimpleQuote(ois[(n, unit)] / 100.0)
 
         # build rate helpers
-        dayCounter = QuantLib.Actual360()
+        dayCounter = ql.Actual360()
         # looping left if somone wants two add more deposits to tests, e.g. T/N
 
-        depositHelpers = [QuantLib.DepositRateHelper(
-            QuantLib.QuoteHandle(deposits[(sett_num, n,
-                                           unit)]),
-            QuantLib.Period(n, unit), sett_num,
-            calendar, QuantLib.ModifiedFollowing,
-            True, dayCounter)
-            for sett_num, n, unit in deposits.keys()]
+        depositHelpers = [
+            ql.DepositRateHelper(
+                ql.QuoteHandle(deposits[(sett_num, n, unit)]),
+                ql.Period(n, unit),
+                sett_num,
+                calendar,
+                ql.ModifiedFollowing,
+                True,
+                dayCounter,
+            )
+            for sett_num, n, unit in deposits.keys()
+        ]
 
-        oisHelpers = [QuantLib.OISRateHelper(settlementDays,
-                                             QuantLib.Period(n, unit),
-                                             QuantLib.QuoteHandle(
-                                                 ois[(n, unit)]),
-                                             on_index,
-                                             discounting_yts_handle)
-                      for n, unit in ois.keys()]
+        oisHelpers = [
+            ql.OISRateHelper(
+                settlementDays, ql.Period(n, unit), ql.QuoteHandle(ois[(n, unit)]), on_index, discounting_yts_handle
+            )
+            for n, unit in ois.keys()
+        ]
 
         rateHelpers = depositHelpers + oisHelpers
 
         # term-structure construction
-        oisSwapCurve = QuantLib.PiecewiseFlatForward(todaysDate, rateHelpers,
-                                                     QuantLib.Actual360())
+        oisSwapCurve = ql.PiecewiseFlatForward(todaysDate, rateHelpers, ql.Actual360())
         oisSwapCurve.enableExtrapolation()
-        return oisSwapCurve, QuantLib.YieldTermStructureHandle(oisSwapCurve), \
-               QuantLib.RelinkableYieldTermStructureHandle(oisSwapCurve)
+        return (
+            oisSwapCurve,
+            ql.YieldTermStructureHandle(oisSwapCurve),
+            ql.RelinkableYieldTermStructureHandle(oisSwapCurve),
+        )
 
     def build_pln_fx_swap_curve(self, base_ccy_yts, fx_swaps, fx_spot):
         """
@@ -159,62 +171,63 @@ class FxSwapRateHelperTest(unittest.TestCase):
         :param fx_spot:
             Float value of fx spot exchange rate.
         :return: tuple consisting of objects related to fx swap implied curve:
-                QuantLib.PiecewiseFlatForward,
-                QuantLib.YieldTermStructureHandle
-                QuantLib.RelinkableYieldTermStructureHandle
-                list of QuantLib.FxSwapRateHelper
+                ql.PiecewiseFlatForward,
+                ql.YieldTermStructureHandle
+                ql.RelinkableYieldTermStructureHandle
+                list of ql.FxSwapRateHelper
         """
         todaysDate = base_ccy_yts.referenceDate()
         # I am not sure if that is required, but I guss it is worth setting
         # up just in case somewhere another thread updates this setting.
-        QuantLib.Settings.instance().evaluationDate = todaysDate
+        ql.Settings.instance().evaluationDate = todaysDate
 
-        calendar = QuantLib.JointCalendar(QuantLib.TARGET(), QuantLib.Poland())
+        calendar = ql.JointCalendar(ql.TARGET(), ql.Poland())
         spot_date_lag = 2
-        trading_calendar = QuantLib.UnitedStates()
+        trading_calendar = ql.UnitedStates()
 
         # build rate helpers
 
-        spotFx = QuantLib.SimpleQuote(fx_spot)
+        spotFx = ql.SimpleQuote(fx_spot)
 
-        fxSwapHelpers = [QuantLib.FxSwapRateHelper(
-            QuantLib.QuoteHandle(
-                QuantLib.SimpleQuote(fx_swaps[(n, unit)])),
-            QuantLib.QuoteHandle(spotFx),
-            QuantLib.Period(n, unit),
-            spot_date_lag,
-            calendar,
-            QuantLib.ModifiedFollowing,
-            True, True,
-            base_ccy_yts,
-            trading_calendar)
-            for n, unit in fx_swaps.keys()]
+        fxSwapHelpers = [
+            ql.FxSwapRateHelper(
+                ql.QuoteHandle(ql.SimpleQuote(fx_swaps[(n, unit)])),
+                ql.QuoteHandle(spotFx),
+                ql.Period(n, unit),
+                spot_date_lag,
+                calendar,
+                ql.ModifiedFollowing,
+                True,
+                True,
+                base_ccy_yts,
+                trading_calendar,
+            )
+            for n, unit in fx_swaps.keys()
+        ]
 
         # term-structure construction
-        fxSwapCurve = QuantLib.PiecewiseFlatForward(todaysDate, fxSwapHelpers,
-                                                    QuantLib.Actual365Fixed())
+        fxSwapCurve = ql.PiecewiseFlatForward(todaysDate, fxSwapHelpers, ql.Actual365Fixed())
         fxSwapCurve.enableExtrapolation()
-        return fxSwapCurve, QuantLib.YieldTermStructureHandle(fxSwapCurve), \
-               QuantLib.RelinkableYieldTermStructureHandle(fxSwapCurve), \
-               fxSwapHelpers
+        return (
+            fxSwapCurve,
+            ql.YieldTermStructureHandle(fxSwapCurve),
+            ql.RelinkableYieldTermStructureHandle(fxSwapCurve),
+            fxSwapHelpers,
+        )
 
     def build_curves(self, quote_date):
         """
         Build all the curves in one call for a specified quote date
 
         :param quote_date: date for which quotes are valid,
-            e.g. QuantLib.Date(26, 8, 2016)
+            e.g. ql.Date(26, 8, 2016)
         """
         self.today = quote_date
-        self.eur_ois_curve, self.eur_ois_handle, self.eur_ois_rel_handle = \
-            self.build_eur_curve(self.today)
+        self.eur_ois_curve, self.eur_ois_handle, self.eur_ois_rel_handle = self.build_eur_curve(self.today)
 
-        self.pln_eur_implied_curve, self.pln_eur_implied_curve_handle, \
-        self.pln_eur_implied_curve_relinkable_handle, \
-        self.eur_pln_fx_swap_helpers = self.build_pln_fx_swap_curve(
-            self.eur_ois_rel_handle,
-            self.fx_swap_quotes,
-            self.fx_spot_quote_EURPLN)
+        self.pln_eur_implied_curve, self.pln_eur_implied_curve_handle, self.pln_eur_implied_curve_relinkable_handle, self.eur_pln_fx_swap_helpers = self.build_pln_fx_swap_curve(
+            self.eur_ois_rel_handle, self.fx_swap_quotes, self.fx_spot_quote_EURPLN
+        )
 
     def testQuote(self):
         """ Testing FxSwapRateHelper.quote()  method. """
@@ -233,12 +246,11 @@ class FxSwapRateHelperTest(unittest.TestCase):
         self.build_curves(self.default_quote_date)
         # Check if still the test date is unchanged, otherwise all other
         # tests here make no sense.
-        self.assertEquals(self.today, QuantLib.Date(26, 8, 2016))
+        self.assertEquals(self.today, ql.Date(26, 8, 2016))
 
         # Hard coded expected maturities of fx swaps
         for n in range(len(self.maturities)):
-            self.assertEquals(self.maturities[n],
-                              self.eur_pln_fx_swap_helpers[n].latestDate())
+            self.assertEquals(self.maturities[n], self.eur_pln_fx_swap_helpers[n].latestDate())
 
     def testImpliedRates(self):
         """
@@ -250,206 +262,196 @@ class FxSwapRateHelperTest(unittest.TestCase):
         #  lists are not messed, probably some ordered maps should be used
         # here while retrieving values from fx_swap_quotes dictionary
         original_quotes = list(self.fx_swap_quotes.values())
-        spot_date = QuantLib.Date(30, 8, 2016)
-        spot_df = self.eur_ois_curve.discount(spot_date) / \
-                  self.pln_eur_implied_curve.discount(spot_date)
+        spot_date = ql.Date(30, 8, 2016)
+        spot_df = self.eur_ois_curve.discount(spot_date) / self.pln_eur_implied_curve.discount(spot_date)
 
         for n in range(len(original_quotes)):
             original_quote = original_quotes[n]
             maturity = self.maturities[n]
             original_forward = self.fx_spot_quote_EURPLN + original_quote
-            curve_impl_forward = self.fx_spot_quote_EURPLN * \
-                                 self.eur_ois_curve.discount(maturity) / \
-                                 self.pln_eur_implied_curve.discount(
-                                     maturity) / spot_df
+            curve_impl_forward = (
+                self.fx_spot_quote_EURPLN
+                * self.eur_ois_curve.discount(maturity)
+                / self.pln_eur_implied_curve.discount(maturity)
+                / spot_df
+            )
 
-            self.assertAlmostEqual(original_forward, curve_impl_forward,
-                                   places=6)
+            self.assertAlmostEqual(original_forward, curve_impl_forward, places=6)
 
     def testFxMarketConventionsForCrossRate(self):
         """
-        Testing if QuantLib.FxSwapRateHelper obeys the fx spot market
+        Testing if ql.FxSwapRateHelper obeys the fx spot market
         conventions for cross rates.
         """
-        today = QuantLib.Date(1, 7, 2016)
-        spot_date = QuantLib.Date(5, 7, 2016)
+        today = ql.Date(1, 7, 2016)
+        spot_date = ql.Date(5, 7, 2016)
         self.build_curves(today)
 
-        us_calendar = QuantLib.UnitedStates()
+        us_calendar = ql.UnitedStates()
 
-        joint_calendar = QuantLib.JointCalendar(QuantLib.TARGET(),
-                                                QuantLib.Poland())
+        joint_calendar = ql.JointCalendar(ql.TARGET(), ql.Poland())
 
-        settlement_calendar = QuantLib.JointCalendar(joint_calendar,
-                                                     us_calendar)
+        settlement_calendar = ql.JointCalendar(joint_calendar, us_calendar)
 
         # Settlement should be on a day where all three centers are operating
         #  and follow EndOfMonth rule
-        maturities = [settlement_calendar.advance(spot_date, n, unit,
-                                                  QuantLib.ModifiedFollowing,
-                                                  True)
-                      for n, unit in self.fx_swap_quotes.keys()]
+        maturities = [
+            settlement_calendar.advance(spot_date, n, unit, ql.ModifiedFollowing, True)
+            for n, unit in self.fx_swap_quotes.keys()
+        ]
 
         for n in range(len(maturities)):
-            self.assertEqual(maturities[n],
-                             self.eur_pln_fx_swap_helpers[n].latestDate())
+            self.assertEqual(maturities[n], self.eur_pln_fx_swap_helpers[n].latestDate())
 
     def testFxMarketConventionsForCrossRateONPeriod(self):
         """
-        Testing if QuantLib.FxSwapRateHelper obeys the fx spot market
+        Testing if ql.FxSwapRateHelper obeys the fx spot market
         conventions for cross rates' ON Period.
         """
-        today = QuantLib.Date(1, 7, 2016)
-        QuantLib.Settings.instance().evaluationDate = today
+        today = ql.Date(1, 7, 2016)
+        ql.Settings.instance().evaluationDate = today
 
-        spot_date = QuantLib.Date(5, 7, 2016)
+        spot_date = ql.Date(5, 7, 2016)
         fwd_points = 4.0
         # critical for ON rate helper
-        on_period = QuantLib.Period('1d')
+        on_period = ql.Period("1d")
         fixing_days = 0
 
         # empty RelinkableYieldTermStructureHandle is sufficient for testing
         # dates
-        base_ccy_yts = QuantLib.RelinkableYieldTermStructureHandle()
+        base_ccy_yts = ql.RelinkableYieldTermStructureHandle()
 
-        us_calendar = QuantLib.UnitedStates()
+        us_calendar = ql.UnitedStates()
 
-        joint_calendar = QuantLib.JointCalendar(QuantLib.TARGET(),
-                                                QuantLib.Poland())
+        joint_calendar = ql.JointCalendar(ql.TARGET(), ql.Poland())
 
         # Settlement should be on a day where all three centers are operating
         #  and follow EndOfMonth rule
-        on_rate_helper = QuantLib.FxSwapRateHelper(
-            QuantLib.QuoteHandle(
-                QuantLib.SimpleQuote(fwd_points)),
-            QuantLib.QuoteHandle(
-                QuantLib.SimpleQuote(self.fx_spot_quote_EURPLN)),
+        on_rate_helper = ql.FxSwapRateHelper(
+            ql.QuoteHandle(ql.SimpleQuote(fwd_points)),
+            ql.QuoteHandle(ql.SimpleQuote(self.fx_spot_quote_EURPLN)),
             on_period,
             fixing_days,
             joint_calendar,
-            QuantLib.ModifiedFollowing,
-            False, True,
+            ql.ModifiedFollowing,
+            False,
+            True,
             base_ccy_yts,
-            us_calendar)
+            us_calendar,
+        )
 
-        self.assertEqual(spot_date,
-                         on_rate_helper.latestDate())
+        self.assertEqual(spot_date, on_rate_helper.latestDate())
 
     def testFxMarketConventionsForCrossRateAdjustedSpotDate(self):
         """
-        Testing if QuantLib.FxSwapRateHelper obeys the fx spot market
+        Testing if ql.FxSwapRateHelper obeys the fx spot market
         conventions
         """
-        today = QuantLib.Date(30, 6, 2016)
-        spot_date = QuantLib.Date(5, 7, 2016)
+        today = ql.Date(30, 6, 2016)
+        spot_date = ql.Date(5, 7, 2016)
         self.build_curves(today)
-        us_calendar = QuantLib.UnitedStates()
-        joint_calendar = QuantLib.JointCalendar(QuantLib.TARGET(),
-                                                QuantLib.Poland())
+        us_calendar = ql.UnitedStates()
+        joint_calendar = ql.JointCalendar(ql.TARGET(), ql.Poland())
 
-        settlement_calendar = QuantLib.JointCalendar(joint_calendar,
-                                                     us_calendar)
+        settlement_calendar = ql.JointCalendar(joint_calendar, us_calendar)
         # Settlement should be on a day where all three centers are operating
         #  and follow EndOfMonth rule
-        maturities = [joint_calendar.advance(spot_date, n, unit,
-                                             QuantLib.ModifiedFollowing,
-                                             True)
-                      for n, unit in self.fx_swap_quotes.keys()]
+        maturities = [
+            joint_calendar.advance(spot_date, n, unit, ql.ModifiedFollowing, True)
+            for n, unit in self.fx_swap_quotes.keys()
+        ]
 
-        maturities = [settlement_calendar.adjust(date)
-                      for date in maturities]
+        maturities = [settlement_calendar.adjust(date) for date in maturities]
 
         for n in range(len(maturities)):
-            self.assertEquals(maturities[n],
-                              self.eur_pln_fx_swap_helpers[n].latestDate())
+            self.assertEquals(maturities[n], self.eur_pln_fx_swap_helpers[n].latestDate())
 
     def testFxMarketConventionsForDatesInEURUSD_ON_Period(self):
         """
-        Testing if QuantLib.FxSwapRateHelper obeys the fx spot market
+        Testing if ql.FxSwapRateHelper obeys the fx spot market
         conventions for EURUSD settlement dates on the ON Period.
         """
-        today = QuantLib.Date(1, 7, 2016)
-        QuantLib.Settings.instance().evaluationDate = today
+        today = ql.Date(1, 7, 2016)
+        ql.Settings.instance().evaluationDate = today
 
-        spot_date = QuantLib.Date(5, 7, 2016)
+        spot_date = ql.Date(5, 7, 2016)
         fwd_points = 4.0
         # critical for ON rate helper
-        on_period = QuantLib.Period('1d')
+        on_period = ql.Period("1d")
         fixing_days = 0
 
         # empty RelinkableYieldTermStructureHandle is sufficient for testing
         # dates
-        base_ccy_yts = QuantLib.RelinkableYieldTermStructureHandle()
+        base_ccy_yts = ql.RelinkableYieldTermStructureHandle()
 
         # In EURUSD, there must be two days to spot date in Target calendar
         # and one day in US, therefore it is sufficient to pass only Target
         # as a base calendar
-        calendar = QuantLib.TARGET()
-        trading_calendar = QuantLib.UnitedStates()
+        calendar = ql.TARGET()
+        trading_calendar = ql.UnitedStates()
 
-        on_rate_helper = QuantLib.FxSwapRateHelper(
-            QuantLib.QuoteHandle(
-                QuantLib.SimpleQuote(fwd_points)),
-            QuantLib.QuoteHandle(
-                QuantLib.SimpleQuote(self.fx_spot_quote_EURUSD)),
+        on_rate_helper = ql.FxSwapRateHelper(
+            ql.QuoteHandle(ql.SimpleQuote(fwd_points)),
+            ql.QuoteHandle(ql.SimpleQuote(self.fx_spot_quote_EURUSD)),
             on_period,
             fixing_days,
             calendar,
-            QuantLib.ModifiedFollowing,
-            False, True,
+            ql.ModifiedFollowing,
+            False,
+            True,
             base_ccy_yts,
-            trading_calendar)
+            trading_calendar,
+        )
 
-        self.assertEqual(spot_date,
-                         on_rate_helper.latestDate())
+        self.assertEqual(spot_date, on_rate_helper.latestDate())
 
     def testFxMarketConventionsForDatesInEURUSD_ShortEnd(self):
         """
-        Testing if QuantLib.FxSwapRateHelper obeys the fx spot market
+        Testing if ql.FxSwapRateHelper obeys the fx spot market
         conventions for EURUSD settlement dates on the 3M tenor.
         """
-        today = QuantLib.Date(1, 7, 2016)
-        QuantLib.Settings.instance().evaluationDate = today
+        today = ql.Date(1, 7, 2016)
+        ql.Settings.instance().evaluationDate = today
 
-        expected_3M_date = QuantLib.Date(5, 10, 2016)
+        expected_3M_date = ql.Date(5, 10, 2016)
         fwd_points = 4.0
         # critical for ON rate helper
-        period = QuantLib.Period('3M')
+        period = ql.Period("3M")
         fixing_days = 2
 
         # empty RelinkableYieldTermStructureHandle is sufficient for testing
         # dates
-        base_ccy_yts = QuantLib.RelinkableYieldTermStructureHandle()
+        base_ccy_yts = ql.RelinkableYieldTermStructureHandle()
 
         # In EURUSD, there must be two days to spot date in Target calendar
         # and one day in US, therefore it is sufficient to pass only Target
         # as a base calendar. Passing joint calendar would result in wrong
         # spot date of the trade
-        calendar = QuantLib.TARGET()
-        trading_calendar = QuantLib.UnitedStates()
+        calendar = ql.TARGET()
+        trading_calendar = ql.UnitedStates()
 
-        rate_helper = QuantLib.FxSwapRateHelper(
-            QuantLib.QuoteHandle(
-                QuantLib.SimpleQuote(fwd_points)),
-            QuantLib.QuoteHandle(
-                QuantLib.SimpleQuote(self.fx_spot_quote_EURUSD)),
+        rate_helper = ql.FxSwapRateHelper(
+            ql.QuoteHandle(ql.SimpleQuote(fwd_points)),
+            ql.QuoteHandle(ql.SimpleQuote(self.fx_spot_quote_EURUSD)),
             period,
             fixing_days,
             calendar,
-            QuantLib.ModifiedFollowing,
-            True, True,
+            ql.ModifiedFollowing,
+            True,
+            True,
             base_ccy_yts,
-            trading_calendar)
+            trading_calendar,
+        )
 
-        self.assertEqual(expected_3M_date,
-                         rate_helper.latestDate())
-    
+        self.assertEqual(expected_3M_date, rate_helper.latestDate())
+
     def tearDown(self):
-        QuantLib.Settings.instance().setEvaluationDate(QuantLib.Date())
+        ql.Settings.instance().setEvaluationDate(ql.Date())
 
-if __name__ == '__main__':
-    print('testing QuantLib ' + QuantLib.__version__)
+
+if __name__ == "__main__":
+    print("testing QuantLib " + ql.__version__)
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(FixedRateBondHelperTest, 'test'))
-    suite.addTest(unittest.makeSuite(FxSwapRateHelperTest, 'test'))
+    suite.addTest(unittest.makeSuite(FixedRateBondHelperTest, "test"))
+    suite.addTest(unittest.makeSuite(FxSwapRateHelperTest, "test"))
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Python/test/slv.py
+++ b/Python/test/slv.py
@@ -15,186 +15,201 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
-import math
 import unittest
 
-from QuantLib import *
+import QuantLib as ql
+
 
 class SlvTest(unittest.TestCase):
-    
     def setUp(self):
-        self.todaysDate = Date(15,May,2019)
-        Settings.instance().evaluationDate = self.todaysDate
-        self.settlementDate = self.todaysDate + Period(2, Days)
-        self.dc = Actual365Fixed()
-        self.riskFreeRate = YieldTermStructureHandle(FlatForward(self.settlementDate, 0.05, self.dc))
-        self.dividendYield = YieldTermStructureHandle(FlatForward(self.settlementDate, 0.025, self.dc))
-        self.underlying = QuoteHandle(SimpleQuote(100.0))
-    
-    def tearDown(self):
-        QuantLib.Settings.instance().setEvaluationDate(QuantLib.Date())
+        self.todaysDate = ql.Date(15, ql.May, 2019)
+        ql.Settings.instance().evaluationDate = self.todaysDate
+        self.settlementDate = self.todaysDate + ql.Period(2, ql.Days)
+        self.dc = ql.Actual365Fixed()
+        self.riskFreeRate = ql.YieldTermStructureHandle(ql.FlatForward(self.settlementDate, 0.05, self.dc))
+        self.dividendYield = ql.YieldTermStructureHandle(ql.FlatForward(self.settlementDate, 0.025, self.dc))
+        self.underlying = ql.QuoteHandle(ql.SimpleQuote(100.0))
 
+    def tearDown(self):
+        ql.Settings.instance().setEvaluationDate(ql.Date())
 
     def constVol(self, vol):
-        return BlackVolTermStructureHandle(
-            BlackConstantVol(self.settlementDate, TARGET(), vol, self.dc)) 
+        return ql.BlackVolTermStructureHandle(ql.BlackConstantVol(self.settlementDate, ql.TARGET(), vol, self.dc))
 
     def testSlvProcess(self):
         """ Testing HestonSLVProcess generation """
-                
-        hestonProcess = HestonProcess(
+
+        hestonProcess = ql.HestonProcess(
+            self.riskFreeRate, self.riskFreeRate, self.underlying, 0.1 * 0.1, 1.0, 0.25 * 0.25, 0.15, -0.75
+        )
+
+        localVol = ql.LocalVolSurface(
+            ql.BlackVolTermStructureHandle(ql.BlackConstantVol(self.settlementDate, ql.TARGET(), 0.10, self.dc)),
             self.riskFreeRate,
             self.riskFreeRate,
             self.underlying,
-            0.1*0.1, 1.0, 0.25*0.25, 0.15, -0.75)
-        
-        localVol = LocalVolSurface(
-            BlackVolTermStructureHandle(
-                BlackConstantVol(self.settlementDate, TARGET(), 0.10, self.dc)),
-            self.riskFreeRate,
-            self.riskFreeRate,
-            self.underlying)
-            
-        hestonSLVProcess = HestonSLVProcess(hestonProcess, localVol)
+        )
 
-        
+        ql.HestonSLVProcess(hestonProcess, localVol)
+
     def testSlvProcessAsBlackScholes(self):
         """ Testing HestonSLVProcess equal to Black-Scholes process """
-        
-        hestonProcess = HestonProcess(
-            self.riskFreeRate,
-            self.dividendYield,
-            self.underlying,
-            0.01, 1.0, 0.01, 1e-4, 0.0)
-        
-        localVol = LocalVolSurface(
-            self.constVol(0.1),
-            self.riskFreeRate,
-            self.dividendYield,
-            self.underlying)
-            
-        exercise = EuropeanExercise(self.todaysDate + Period(1, Years))
-        payoff = PlainVanillaPayoff(Option.Call, self.underlying.value())                                    
-        
-        option = VanillaOption(payoff, exercise)
-        
-        hestonModel = HestonModel(hestonProcess)
-        option.setPricingEngine(FdHestonVanillaEngine(hestonModel, 20, 100, 3))
-        
-        hestonNPV = option.NPV()
-        
-        option.setPricingEngine(
-            AnalyticEuropeanEngine(BlackScholesMertonProcess(
-                self.underlying, self.dividendYield, self.riskFreeRate, self.constVol(0.1)))
-        )
-                
-        bsNPV = option.NPV()
-        
-        self.assertAlmostEqual(hestonNPV, bsNPV, 2, 
-            msg="Unable to reproduce Heston vanilla option price with Black-Scholes process")
-        
-        option.setPricingEngine(
-            FdHestonVanillaEngine(
-                hestonModel, 20, 100, 3, 0, FdmSchemeDesc.Hundsdorfer(), 
-                LocalVolSurface(
-                    self.constVol(2.0),
-                    self.riskFreeRate,
-                    self.dividendYield,
-                    self.underlying)))
-        
-        slvNPV = option.NPV()
-        
-        option.setPricingEngine(
-            AnalyticEuropeanEngine(BlackScholesMertonProcess(
-                self.underlying, self.dividendYield, self.riskFreeRate, self.constVol(0.20)))
-        )
-        
-        bsNPV = option.NPV()
-        
-        self.assertAlmostEqual(slvNPV, bsNPV, 2, 
-            msg="Unable to reproduce Heston plus constant local"
-            "vol option price with Black-Scholes formula")
 
+        hestonProcess = ql.HestonProcess(
+            self.riskFreeRate, self.dividendYield, self.underlying, 0.01, 1.0, 0.01, 1e-4, 0.0
+        )
+
+        exercise = ql.EuropeanExercise(self.todaysDate + ql.Period(1, ql.Years))
+        payoff = ql.PlainVanillaPayoff(ql.Option.Call, self.underlying.value())
+
+        option = ql.VanillaOption(payoff, exercise)
+
+        hestonModel = ql.HestonModel(hestonProcess)
+        option.setPricingEngine(ql.FdHestonVanillaEngine(hestonModel, 20, 100, 3))
+
+        hestonNPV = option.NPV()
+
+        option.setPricingEngine(
+            ql.AnalyticEuropeanEngine(
+                ql.BlackScholesMertonProcess(self.underlying, self.dividendYield, self.riskFreeRate, self.constVol(0.1))
+            )
+        )
+
+        bsNPV = option.NPV()
+
+        self.assertAlmostEqual(
+            hestonNPV, bsNPV, 2, msg="Unable to reproduce Heston vanilla option price with Black-Scholes process"
+        )
+
+        option.setPricingEngine(
+            ql.FdHestonVanillaEngine(
+                hestonModel,
+                20,
+                100,
+                3,
+                0,
+                ql.FdmSchemeDesc.Hundsdorfer(),
+                ql.LocalVolSurface(self.constVol(2.0), self.riskFreeRate, self.dividendYield, self.underlying),
+            )
+        )
+
+        slvNPV = option.NPV()
+
+        option.setPricingEngine(
+            ql.AnalyticEuropeanEngine(
+                ql.BlackScholesMertonProcess(
+                    self.underlying, self.dividendYield, self.riskFreeRate, self.constVol(0.20)
+                )
+            )
+        )
+
+        bsNPV = option.NPV()
+
+        self.assertAlmostEqual(
+            slvNPV,
+            bsNPV,
+            2,
+            msg="Unable to reproduce Heston plus constant local" "vol option price with Black-Scholes formula",
+        )
 
     def testSlvMonteCarloCalibration(self):
         """ Testing Monte-Carlo calibration of a HestonSLVProcess """
-        
-        localVol = LocalVolSurface(
-            self.constVol(0.25),
-            self.riskFreeRate,
-            self.dividendYield,
-            self.underlying)
-        
-        hestonProcess = HestonProcess(
-            self.riskFreeRate,
-            self.dividendYield,
-            self.underlying,
-            0.1*0.1, 5.0, 0.25*0.25, 0.25, -0.75)
 
-        hestonModel = HestonModel(hestonProcess)
+        localVol = ql.LocalVolSurface(self.constVol(0.25), self.riskFreeRate, self.dividendYield, self.underlying)
 
-        exerciseDate = self.todaysDate + Period(1, Months)
-        
-        exercise = EuropeanExercise(exerciseDate)
-        payoff = PlainVanillaPayoff(Option.Call, 1.1*self.underlying.value())                                    
-        
-        option = VanillaOption(payoff, exercise)
-        
-        option.setPricingEngine(
-            AnalyticEuropeanEngine(
-                BlackScholesMertonProcess(
-                    self.underlying,
-                    self.dividendYield,
-                    self.riskFreeRate,
-                    self.constVol(0.25))))
-        
-        bsNPV = option.NPV()
-        
-        option.setPricingEngine(
-            FdHestonVanillaEngine(
-                hestonModel, 25, 100, 50, 0, 
-                FdmSchemeDesc.Hundsdorfer(), 
-                HestonSLVMCModel(
-                    localVol,
-                    hestonModel,
-                    MTBrownianGeneratorFactory(1234),
-                    exerciseDate, 91).leverageFunction()))
-                 
-        slvNPV = option.NPV()
-
-        self.assertAlmostEqual(slvNPV, bsNPV, 2, 
-            msg="Unable to reproduce HestonSLV option price"
-            " with Black-Scholes formula based on MC calibration.")
-        
-        fdmParams = HestonSLVFokkerPlanckFdmParams(
-            201, 401, 200, 30, 2.0, 0, 2,
-            0.1, 1e-4, 10000,
-            1e-5, 1e-5, 0.0000025, 1.0, 0.1, 0.9, 1e-5,
-            FdmHestonGreensFct.Gaussian,
-            FdmSquareRootFwdOp.Log,
-            FdmSchemeDesc.Hundsdorfer()
+        hestonProcess = ql.HestonProcess(
+            self.riskFreeRate, self.dividendYield, self.underlying, 0.1 * 0.1, 5.0, 0.25 * 0.25, 0.25, -0.75
         )
-        
+
+        hestonModel = ql.HestonModel(hestonProcess)
+
+        exerciseDate = self.todaysDate + ql.Period(1, ql.Months)
+
+        exercise = ql.EuropeanExercise(exerciseDate)
+        payoff = ql.PlainVanillaPayoff(ql.Option.Call, 1.1 * self.underlying.value())
+
+        option = ql.VanillaOption(payoff, exercise)
+
         option.setPricingEngine(
-            FdHestonVanillaEngine(
-                hestonModel, 25, 100, 50, 0, 
-                FdmSchemeDesc.Hundsdorfer(), 
-                HestonSLVFDMModel(
-                    localVol,
-                    hestonModel,
-                    exerciseDate,
-                    fdmParams).leverageFunction()))
-                 
+            ql.AnalyticEuropeanEngine(
+                ql.BlackScholesMertonProcess(
+                    self.underlying, self.dividendYield, self.riskFreeRate, self.constVol(0.25)
+                )
+            )
+        )
+
+        bsNPV = option.NPV()
+
+        option.setPricingEngine(
+            ql.FdHestonVanillaEngine(
+                hestonModel,
+                25,
+                100,
+                50,
+                0,
+                ql.FdmSchemeDesc.Hundsdorfer(),
+                ql.HestonSLVMCModel(
+                    localVol, hestonModel, ql.MTBrownianGeneratorFactory(1234), exerciseDate, 91
+                ).leverageFunction(),
+            )
+        )
+
         slvNPV = option.NPV()
-        
-        self.assertAlmostEqual(slvNPV, bsNPV, 2, 
-            msg="Unable to reproduce HestonSLV option price"
-            " with Black-Scholes formula based on FDM calibration.")
-        
-if __name__ == '__main__':
-    print('testing QuantLib ' + QuantLib.__version__)
+
+        self.assertAlmostEqual(
+            slvNPV,
+            bsNPV,
+            2,
+            msg="Unable to reproduce HestonSLV option price" " with Black-Scholes formula based on MC calibration.",
+        )
+
+        fdmParams = ql.HestonSLVFokkerPlanckFdmParams(
+            201,
+            401,
+            200,
+            30,
+            2.0,
+            0,
+            2,
+            0.1,
+            1e-4,
+            10000,
+            1e-5,
+            1e-5,
+            0.0000025,
+            1.0,
+            0.1,
+            0.9,
+            1e-5,
+            ql.FdmHestonGreensFct.Gaussian,
+            ql.FdmSquareRootFwdOp.Log,
+            ql.FdmSchemeDesc.Hundsdorfer(),
+        )
+
+        option.setPricingEngine(
+            ql.FdHestonVanillaEngine(
+                hestonModel,
+                25,
+                100,
+                50,
+                0,
+                ql.FdmSchemeDesc.Hundsdorfer(),
+                ql.HestonSLVFDMModel(localVol, hestonModel, exerciseDate, fdmParams).leverageFunction(),
+            )
+        )
+
+        slvNPV = option.NPV()
+
+        self.assertAlmostEqual(
+            slvNPV,
+            bsNPV,
+            2,
+            msg="Unable to reproduce HestonSLV option price" " with Black-Scholes formula based on FDM calibration.",
+        )
+
+
+if __name__ == "__main__":
+    print("testing QuantLib " + ql.__version__)
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(SlvTest,'test'))
+    suite.addTest(unittest.makeSuite(SlvTest, "test"))
     unittest.TextTestRunner(verbosity=2).run(suite)
-   
-        

--- a/Python/test/solvers1d.py
+++ b/Python/test/solvers1d.py
@@ -16,66 +16,80 @@
 """
 
 import unittest
-from QuantLib import *
+import QuantLib as ql
+
 
 class Foo:
-    def __call__(self,x):
-        return x*x-1.0
-    def derivative(self,x):
-        return 2.0*x
+    def __call__(self, x):
+        return x * x - 1.0
+
+    def derivative(self, x):
+        return 2.0 * x
+
 
 class Solver1DTest(unittest.TestCase):
     def runTest(self):
         "Testing 1-D solvers"
-        for factory in [Brent,Bisection,FalsePosition,Ridder,Secant]:
+        for factory in [ql.Brent, ql.Bisection, ql.FalsePosition, ql.Ridder, ql.Secant]:
             solver = factory()
             for accuracy in [1.0e-4, 1.0e-6, 1.0e-8]:
-                root = solver.solve(lambda x:x*x-1.0,
-                                    accuracy,1.5,0.1)
-                if not (abs(root-1.0)<accuracy):
-                    self.fail("""
+                root = solver.solve(lambda x: x * x - 1.0, accuracy, 1.5, 0.1)
+                if not (abs(root - 1.0) < accuracy):
+                    self.fail(
+                        """
 %(factory)s
     solve():
     expected:         1.0
     calculated root:  %(root)g
     accuracy:         %(accuracy)s
-                          """ % locals())
-                root = solver.solve(lambda x:x*x-1.0,
-                                    accuracy,1.5,0.0,1.0)
-                if not (abs(root-1.0)<accuracy):
-                    self.fail("""
+                          """
+                        % locals()
+                    )
+                root = solver.solve(lambda x: x * x - 1.0, accuracy, 1.5, 0.0, 1.0)
+                if not (abs(root - 1.0) < accuracy):
+                    self.fail(
+                        """
 %(factory)s
     bracketed solve():
     expected:         1.0
     calculated root:  %(root)g
     accuracy:         %(accuracy)s
-                          """ % locals())
-        for factory in [Newton,NewtonSafe]:
+                          """
+                        % locals()
+                    )
+        for factory in [ql.Newton, ql.NewtonSafe]:
             solver = factory()
             for accuracy in [1.0e-4, 1.0e-6, 1.0e-8]:
-                root = solver.solve(Foo(),accuracy,1.5,0.1)
-                if not (abs(root-1.0)<accuracy):
-                    self.fail("""
+                root = solver.solve(Foo(), accuracy, 1.5, 0.1)
+                if not (abs(root - 1.0) < accuracy):
+                    self.fail(
+                        """
 %(factory)s
     solve():
     expected:         1.0
     calculated root:  %(root)g
     accuracy:         %(accuracy)s
-                          """ % locals())
-                root = solver.solve(Foo(),accuracy,1.5,0.0,1.0)
-                if not (abs(root-1.0)<accuracy):
-                    self.fail("""
+                          """
+                        % locals()
+                    )
+                root = solver.solve(Foo(), accuracy, 1.5, 0.0, 1.0)
+                if not (abs(root - 1.0) < accuracy):
+                    self.fail(
+                        """
 %(factory)s
     bracketed solve():
     expected:         1.0
     calculated root:  %(root)g
     accuracy:         %(accuracy)s
-                          """ % locals())
-            
+                          """
+                        % locals()
+                    )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     import QuantLib
-    print('testing QuantLib ' + QuantLib.__version__)
+
+    print("testing QuantLib " + QuantLib.__version__)
     suite = unittest.TestSuite()
     suite.addTest(Solver1DTest())
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Python/test/termstructures.py
+++ b/Python/test/termstructures.py
@@ -16,70 +16,79 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
-from QuantLib import *
+import QuantLib as ql
 import unittest
 
 flag = None
+
+
 def raiseFlag():
     global flag
     flag = 1
 
+
 class TermStructureTest(unittest.TestCase):
     def setUp(self):
-        self.calendar = TARGET()
-        today = self.calendar.adjust(Date.todaysDate())
+        self.calendar = ql.TARGET()
+        today = self.calendar.adjust(ql.Date.todaysDate())
         self.settlementDays = 2
-        settlement = self.calendar.advance(today,self.settlementDays,Days)
+        settlement = self.calendar.advance(today, self.settlementDays, ql.Days)
         deposits = [
-            DepositRateHelper(
-                QuoteHandle(SimpleQuote(rate/100)),
-                Period(n, units), self.settlementDays,
-                self.calendar, ModifiedFollowing,
-                False, Actual360())
-            for (n,units,rate) in [ (1, Months, 4.581),
-                                    (2, Months, 4.573),
-                                    (3, Months, 4.557),
-                                    (6, Months, 4.496),
-                                    (9, Months, 4.490) ]
+            ql.DepositRateHelper(
+                ql.QuoteHandle(ql.SimpleQuote(rate / 100)),
+                ql.Period(n, units),
+                self.settlementDays,
+                self.calendar,
+                ql.ModifiedFollowing,
+                False,
+                ql.Actual360(),
+            )
+            for (n, units, rate) in [
+                (1, ql.Months, 4.581),
+                (2, ql.Months, 4.573),
+                (3, ql.Months, 4.557),
+                (6, ql.Months, 4.496),
+                (9, ql.Months, 4.490),
+            ]
         ]
         swaps = [
-            SwapRateHelper(
-                QuoteHandle(SimpleQuote(rate/100)),
-                Period(years, Years), self.calendar,
-                Annual, Unadjusted, Thirty360(), Euribor6M())
-            for (years,rate) in [ ( 1, 4.54),
-                                  ( 5, 4.99),
-                                  (10, 5.47),
-                                  (20, 5.89),
-                                  (30, 5.96) ]
+            ql.SwapRateHelper(
+                ql.QuoteHandle(ql.SimpleQuote(rate / 100)),
+                ql.Period(years, ql.Years),
+                self.calendar,
+                ql.Annual,
+                ql.Unadjusted,
+                ql.Thirty360(),
+                ql.Euribor6M(),
+            )
+            for (years, rate) in [(1, 4.54), (5, 4.99), (10, 5.47), (20, 5.89), (30, 5.96)]
         ]
 
-        self.termStructure = PiecewiseFlatForward(settlement,
-                                                  deposits+swaps,
-                                                  Actual360())
+        self.termStructure = ql.PiecewiseFlatForward(settlement, deposits + swaps, ql.Actual360())
 
     def testImpliedObs(self):
         "Testing observability of implied term structure"
         global flag
         flag = None
-        h = RelinkableYieldTermStructureHandle()
+        h = ql.RelinkableYieldTermStructureHandle()
         settlement = self.termStructure.referenceDate()
-        new_settlement = self.calendar.advance(settlement,3,Years)
-        implied = ImpliedTermStructure(h,new_settlement)
-        obs = Observer(raiseFlag)
+        new_settlement = self.calendar.advance(settlement, 3, ql.Years)
+        implied = ql.ImpliedTermStructure(h, new_settlement)
+        obs = ql.Observer(raiseFlag)
         obs.registerWith(implied)
         h.linkTo(self.termStructure)
         if not flag:
             self.fail("Observer was not notified of term structure change")
+
     def testFSpreadedObs(self):
         "Testing observability of forward-spreaded term structure"
         global flag
         flag = None
-        me = SimpleQuote(0.01)
-        mh = QuoteHandle(me)
-        h = RelinkableYieldTermStructureHandle()
-        spreaded = ForwardSpreadedTermStructure(h,mh)
-        obs = Observer(raiseFlag)
+        me = ql.SimpleQuote(0.01)
+        mh = ql.QuoteHandle(me)
+        h = ql.RelinkableYieldTermStructureHandle()
+        spreaded = ql.ForwardSpreadedTermStructure(h, mh)
+        obs = ql.Observer(raiseFlag)
         obs.registerWith(spreaded)
         h.linkTo(self.termStructure)
         if not flag:
@@ -88,15 +97,16 @@ class TermStructureTest(unittest.TestCase):
         me.setValue(0.005)
         if not flag:
             self.fail("Observer was not notified of spread change")
+
     def testZSpreadedObs(self):
         "Testing observability of zero-spreaded term structure"
         global flag
         flag = None
-        me = SimpleQuote(0.01)
-        mh = QuoteHandle(me)
-        h = RelinkableYieldTermStructureHandle()
-        spreaded = ZeroSpreadedTermStructure(h,mh)
-        obs = Observer(raiseFlag)
+        me = ql.SimpleQuote(0.01)
+        mh = ql.QuoteHandle(me)
+        h = ql.RelinkableYieldTermStructureHandle()
+        spreaded = ql.ZeroSpreadedTermStructure(h, mh)
+        obs = ql.Observer(raiseFlag)
         obs.registerWith(spreaded)
         h.linkTo(self.termStructure)
         if not flag:
@@ -107,9 +117,10 @@ class TermStructureTest(unittest.TestCase):
             self.fail("Observer was not notified of spread change")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import QuantLib
-    print('testing QuantLib ' + QuantLib.__version__)
+
+    print("testing QuantLib " + QuantLib.__version__)
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(TermStructureTest,'test'))
+    suite.addTest(unittest.makeSuite(TermStructureTest, "test"))
     unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
It blocks linting tools such as flake, and it's commonly considered bad practice.