### PR TITLE
Expose additional methods and results for CapFloor 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ Python/QuantLib/quantlib_wrap.cpp
 Python/.cache/
 Python/QuantLib_Python.egg-info
 Python/dist
-.pytest_cache/v/cache/nodeids
 R/src/QuantLib.cpp
 R/makeRData.Rout
 R/src/symbols.rds
@@ -91,8 +90,4 @@ Python/build
 R/R/QuantLib.R
 R/QuantLib.RData
 
-.vscode/launch.json
-.vscode/settings.json
-.vscode/tags
-.vscode/tasks.json
-
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Python/QuantLib/quantlib_wrap.cpp
 Python/.cache/
 Python/QuantLib_Python.egg-info
 Python/dist
+.pytest_cache/v/cache/nodeids
 R/src/QuantLib.cpp
 R/makeRData.Rout
 R/src/symbols.rds
@@ -93,3 +94,5 @@ R/QuantLib.RData
 .vscode/launch.json
 .vscode/settings.json
 .vscode/tags
+.vscode/tasks.json
+

--- a/SWIG/capfloor.i
+++ b/SWIG/capfloor.i
@@ -44,6 +44,7 @@ class CapFloor : public Instrument {
                                  Volatility maxVol = 4.0,
                                  VolatilityType type = ShiftedLognormal,
                                  Real displacement = 0.0) const;
+    enum Type { Cap, Floor, Collar };
     const Leg& floatingLeg() const;
 
     const std::vector<Rate>& capRates();
@@ -51,6 +52,9 @@ class CapFloor : public Instrument {
     Date startDate() const;
     Date maturityDate() const;
 
+    bool isExpired() const;
+    Type type() const;
+    
     Rate atmRate(const YieldTermStructure& discountCurve) const;
 };
 

--- a/SWIG/capfloor.i
+++ b/SWIG/capfloor.i
@@ -52,8 +52,6 @@ class CapFloor : public Instrument {
     const std::vector<Rate>& floorRates();
     Date startDate() const;
     Date maturityDate() const;
-
-    bool isExpired() const;
     Type type() const;
     
     Rate atmRate(const YieldTermStructure& discountCurve) const;
@@ -63,18 +61,16 @@ class CapFloor : public Instrument {
         return self->result<Real>("vega");
       }
       const std::vector<Real> optionletsPrice() {
-        return self->result<std::vector<Real>>("optionletsPrice");
+        return self->result<std::vector<Real> >("optionletsPrice");
       }
       const std::vector<Real> optionletsVega() {
-        return self->result<std::vector<Real>>("optionletsVega");
+        return self->result<std::vector<Real> >("optionletsVega");
       }
       const std::vector<Rate> optionletsAtmForward(){
-        return self->result<std::vector<Real>>("optionletsAtmForward");
+        return self->result<std::vector<Real> >("optionletsAtmForward");
       }
-      // BlackCapFloorEngine will not return the below for CapFloor::Collar
-      // Should there be any error handling for such case?
       const std::vector<Rate> optionletsStdDev(){
-        return self->result<std::vector<Real>>("optionletsStdDev");
+        return self->result<std::vector<Real> >("optionletsStdDev");
       }
     }
 };

--- a/SWIG/capfloor.i
+++ b/SWIG/capfloor.i
@@ -1,6 +1,7 @@
 /*
  Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
  Copyright (C) 2018 Matthias Lungwitz
+ Copyright (C) 2019 Wojciech Ślusarski
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/SWIG/capfloor.i
+++ b/SWIG/capfloor.i
@@ -56,6 +56,26 @@ class CapFloor : public Instrument {
     Type type() const;
     
     Rate atmRate(const YieldTermStructure& discountCurve) const;
+
+    %extend {
+      const Real vega() {
+        return self->result<Real>("vega");
+      }
+      const std::vector<Real> optionletsPrice() {
+        return self->result<std::vector<Real>>("optionletsPrice");
+      }
+      const std::vector<Real> optionletsVega() {
+        return self->result<std::vector<Real>>("optionletsVega");
+      }
+      const std::vector<Rate> optionletsAtmForward(){
+        return self->result<std::vector<Real>>("optionletsAtmForward");
+      }
+      // BlackCapFloorEngine will not return the below for CapFloor::Collar
+      // Should there be any error handling for such case?
+      const std::vector<Rate> optionletsStdDev(){
+        return self->result<std::vector<Real>>("optionletsStdDev");
+      }
+    }
 };
 
 


### PR DESCRIPTION
The request is to expose a few methods/ fields from CapFloor class and its pricing engines:
+ expose isExpired and type methods of CapFloor class
+ expose additional results provided by CapFloor pricing engines

`optionletsStdDev` method is exposed without error handling, which may be required in case of Collar instances (pricing engines do not provide such information). Should this issue be handled in the implementation of this method?

Regards,
Wojtek