### PR TITLE
Expose MakeOIS class with special Python support

### DIFF
--- a/CSharp/csharp/NQuantLib.csproj
+++ b/CSharp/csharp/NQuantLib.csproj
@@ -724,6 +724,7 @@
     <Compile Include="LTLCurrency.cs" />
     <Compile Include="LUFCurrency.cs" />
     <Compile Include="LVLCurrency.cs" />
+    <Compile Include="MakeOIS.cs" />
     <Compile Include="MakeSchedule.cs" />
     <Compile Include="MakeVanillaSwap.cs" />
     <Compile Include="MarkovFunctional.cs" />

--- a/Python/test/QuantLibTestSuite.py
+++ b/Python/test/QuantLibTestSuite.py
@@ -27,7 +27,7 @@ from integrals import IntegralTest
 from solvers1d import Solver1DTest
 from termstructures import TermStructureTest
 from bonds import FixedRateBondTest
-from ratehelpers import FixedRateBondHelperTest, FxSwapRateHelperTest
+from ratehelpers import FixedRateBondHelperTest, FxSwapRateHelperTest, OISRateHelperTest
 from cms import CmsTest
 from assetswap import AssetSwapTest
 from capfloor import CapFloorTest
@@ -55,6 +55,7 @@ def test():
     suite.addTest(unittest.makeSuite(FixedRateBondHelperTest, 'test'))
     suite.addTest(unittest.makeSuite(CmsTest, 'test'))
     suite.addTest(unittest.makeSuite(AssetSwapTest, 'test'))
+    suite.addTest(unittest.makeSuite(OISRateHelperTest, "test"))
     suite.addTest(unittest.makeSuite(FxSwapRateHelperTest, 'test'))
     suite.addTest(unittest.makeSuite(CapFloorTest, 'test'))
     suite.addTest(unittest.makeSuite(BlackFormulaTest, 'test'))

--- a/Python/test/ratehelpers.py
+++ b/Python/test/ratehelpers.py
@@ -571,5 +571,6 @@ if __name__ == "__main__":
     print("testing QuantLib " + ql.__version__)
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(FixedRateBondHelperTest, "test"))
+    suite.addTest(unittest.makeSuite(OISRateHelperTest, "test"))
     suite.addTest(unittest.makeSuite(FxSwapRateHelperTest, "test"))
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Python/test/ratehelpers.py
+++ b/Python/test/ratehelpers.py
@@ -109,7 +109,8 @@ class OISRateHelperTest(unittest.TestCase):
 
         # convert them to Quote objects
         for sett_num, n, unit in deposits.keys():
-            deposits[(sett_num, n, unit)] = ql.SimpleQuote(deposits[(sett_num, n, unit)] / 100.0)
+            deposits[(sett_num, n, unit)] = ql.SimpleQuote(
+                deposits[(sett_num, n, unit)] / 100.0)
 
         for n, unit in self.ois.keys():
             self.ois[(n, unit)] = ql.SimpleQuote(self.ois[(n, unit)] / 100.0)
@@ -147,39 +148,19 @@ class OISRateHelperTest(unittest.TestCase):
         self.oisSwapCurve.enableExtrapolation()
         self.discounting_yts_handle.linkTo(self.oisSwapCurve)
 
-    def test_ois_ratehelper_setTermStructure(self):
-        """Test if OISRateHelper.impliedQuote provides original quote from curve"""
-        for key, rate_helper in zip(self.ois.keys(), self.oisHelpers):
-            expected = self.ois[key].value()
-            # This test case is just to prove, that only if we provide
-            # explicitely the curve to the rate helper, the quote can be
-            # calculated
-            rate_helper.setTermStructure(self.oisSwapCurve)
-            # based on bootstrapped_curve
-            calculated = rate_helper.impliedQuote()
-            # I need to run calculation again - it looks as if the update of the
-            # curve was slow - if I don't do that, in the first weekly quote I
-            # get strange result of -0.006840684068403689
-            calculated = rate_helper.impliedQuote()
-            diff = (expected - calculated) * 1E4
-            print("Maturity: {}: diff: {} bps".format(rate_helper.maturityDate(),
-                                                      diff))
-            self.assertAlmostEqual(expected, calculated,
-                                   delta=1e-5,
-                                   msg="Calculated implied quote differes too "
-                                       "much from original market value")
-
     def test_ois_ratehelper_impliedquote(self):
         """Test if OISRateHelper.impliedQuote provides original quote from curve"""
+        # initiate curves - required due to lazy evaluation
+        df = self.discounting_yts_handle.discount(0.0)
+
         for key, rate_helper in zip(self.ois.keys(), self.oisHelpers):
             expected = self.ois[key].value()
             # based on bootstrapped_curve
             calculated = rate_helper.impliedQuote()
             self.assertAlmostEqual(expected, calculated,
-                                   delta=1e-5,
+                                   delta=1e-8,
                                    msg="Calculated implied quote differes too "
                                        "much from original market value")
-
 
 
 class FxSwapRateHelperTest(unittest.TestCase):
@@ -196,7 +177,8 @@ class FxSwapRateHelperTest(unittest.TestCase):
         }
 
         # Valid only for the quote date of ql.Date(26, 8, 2016)
-        self.maturities = [ql.Date(30, 9, 2016), ql.Date(30, 11, 2016), ql.Date(28, 2, 2017), ql.Date(30, 8, 2017)]
+        self.maturities = [ql.Date(30, 9, 2016), ql.Date(30, 11, 2016),
+                           ql.Date(28, 2, 2017), ql.Date(30, 8, 2017)]
 
         self.fx_spot_quote_EURPLN = 4.3
         self.fx_spot_quote_EURUSD = 1.1
@@ -238,7 +220,8 @@ class FxSwapRateHelperTest(unittest.TestCase):
 
         # convert them to Quote objects
         for sett_num, n, unit in deposits.keys():
-            deposits[(sett_num, n, unit)] = ql.SimpleQuote(deposits[(sett_num, n, unit)] / 100.0)
+            deposits[(sett_num, n, unit)] = ql.SimpleQuote(
+                deposits[(sett_num, n, unit)] / 100.0)
 
         for n, unit in ois.keys():
             ois[(n, unit)] = ql.SimpleQuote(ois[(n, unit)] / 100.0)
@@ -262,7 +245,8 @@ class FxSwapRateHelperTest(unittest.TestCase):
 
         oisHelpers = [
             ql.OISRateHelper(
-                settlementDays, ql.Period(n, unit), ql.QuoteHandle(ois[(n, unit)]), on_index, discounting_yts_handle
+                settlementDays, ql.Period(n, unit),
+                ql.QuoteHandle(ois[(n, unit)]), on_index, discounting_yts_handle
             )
             for n, unit in ois.keys()
         ]
@@ -270,7 +254,8 @@ class FxSwapRateHelperTest(unittest.TestCase):
         rateHelpers = depositHelpers + oisHelpers
 
         # term-structure construction
-        oisSwapCurve = ql.PiecewiseFlatForward(todaysDate, rateHelpers, ql.Actual360())
+        oisSwapCurve = ql.PiecewiseFlatForward(todaysDate, rateHelpers,
+                                               ql.Actual360())
         oisSwapCurve.enableExtrapolation()
         return (
             oisSwapCurve,
@@ -323,7 +308,8 @@ class FxSwapRateHelperTest(unittest.TestCase):
         ]
 
         # term-structure construction
-        fxSwapCurve = ql.PiecewiseFlatForward(todaysDate, fxSwapHelpers, ql.Actual365Fixed())
+        fxSwapCurve = ql.PiecewiseFlatForward(todaysDate, fxSwapHelpers,
+                                              ql.Actual365Fixed())
         fxSwapCurve.enableExtrapolation()
         return (
             fxSwapCurve,
@@ -340,10 +326,12 @@ class FxSwapRateHelperTest(unittest.TestCase):
             e.g. ql.Date(26, 8, 2016)
         """
         self.today = quote_date
-        self.eur_ois_curve, self.eur_ois_handle, self.eur_ois_rel_handle = self.build_eur_curve(self.today)
+        self.eur_ois_curve, self.eur_ois_handle, self.eur_ois_rel_handle = self.build_eur_curve(
+            self.today)
 
         self.pln_eur_implied_curve, self.pln_eur_implied_curve_handle, self.pln_eur_implied_curve_relinkable_handle, self.eur_pln_fx_swap_helpers = self.build_pln_fx_swap_curve(
-            self.eur_ois_rel_handle, self.fx_swap_quotes, self.fx_spot_quote_EURPLN
+            self.eur_ois_rel_handle, self.fx_swap_quotes,
+            self.fx_spot_quote_EURPLN
         )
 
     def testQuote(self):
@@ -381,20 +369,22 @@ class FxSwapRateHelperTest(unittest.TestCase):
         # here while retrieving values from fx_swap_quotes dictionary
         original_quotes = list(self.fx_swap_quotes.values())
         spot_date = ql.Date(30, 8, 2016)
-        spot_df = self.eur_ois_curve.discount(spot_date) / self.pln_eur_implied_curve.discount(spot_date)
+        spot_df = self.eur_ois_curve.discount(
+            spot_date) / self.pln_eur_implied_curve.discount(spot_date)
 
         for n in range(len(original_quotes)):
             original_quote = original_quotes[n]
             maturity = self.maturities[n]
             original_forward = self.fx_spot_quote_EURPLN + original_quote
             curve_impl_forward = (
-                self.fx_spot_quote_EURPLN
-                * self.eur_ois_curve.discount(maturity)
-                / self.pln_eur_implied_curve.discount(maturity)
-                / spot_df
+                    self.fx_spot_quote_EURPLN
+                    * self.eur_ois_curve.discount(maturity)
+                    / self.pln_eur_implied_curve.discount(maturity)
+                    / spot_df
             )
 
-            self.assertAlmostEqual(original_forward, curve_impl_forward, places=6)
+            self.assertAlmostEqual(original_forward, curve_impl_forward,
+                                   places=6)
 
     def testFxMarketConventionsForCrossRate(self):
         """
@@ -414,12 +404,14 @@ class FxSwapRateHelperTest(unittest.TestCase):
         # Settlement should be on a day where all three centers are operating
         #  and follow EndOfMonth rule
         maturities = [
-            settlement_calendar.advance(spot_date, n, unit, ql.ModifiedFollowing, True)
+            settlement_calendar.advance(spot_date, n, unit,
+                                        ql.ModifiedFollowing, True)
             for n, unit in self.fx_swap_quotes.keys()
         ]
 
         for n in range(len(maturities)):
-            self.assertEqual(maturities[n], self.eur_pln_fx_swap_helpers[n].latestDate())
+            self.assertEqual(maturities[n],
+                             self.eur_pln_fx_swap_helpers[n].latestDate())
 
     def testFxMarketConventionsForCrossRateONPeriod(self):
         """
@@ -475,14 +467,16 @@ class FxSwapRateHelperTest(unittest.TestCase):
         # Settlement should be on a day where all three centers are operating
         #  and follow EndOfMonth rule
         maturities = [
-            joint_calendar.advance(spot_date, n, unit, ql.ModifiedFollowing, True)
+            joint_calendar.advance(spot_date, n, unit, ql.ModifiedFollowing,
+                                   True)
             for n, unit in self.fx_swap_quotes.keys()
         ]
 
         maturities = [settlement_calendar.adjust(date) for date in maturities]
 
         for n in range(len(maturities)):
-            self.assertEqual(maturities[n], self.eur_pln_fx_swap_helpers[n].latestDate())
+            self.assertEqual(maturities[n],
+                             self.eur_pln_fx_swap_helpers[n].latestDate())
 
     def testFxMarketConventionsForDatesInEURUSD_ON_Period(self):
         """

--- a/Python/test/ratehelpers.py
+++ b/Python/test/ratehelpers.py
@@ -175,8 +175,9 @@ class OISRateHelperTest(unittest.TestCase):
             diff = (quote_rate - calculated_rate) * 1E4
             self.assertAlmostEqual(quote_rate, calculated_rate,
                                    delta=1e-10,
-                                   msg=f"Failed to reprice swap {n} {unit}"
-                                   f" with a npv difference of {diff}bps")
+                                   msg="Failed to reprice swap {n} {unit}"
+                                       " with a npv difference of {diff}bps"
+                                       "".format(n=n, unit=unit, diff=diff))
 
     def test_ois_default_calendar(self):
         """Test if ois built using MakeOIS has proper default calendar

--- a/Python/test/ratehelpers.py
+++ b/Python/test/ratehelpers.py
@@ -166,8 +166,9 @@ class OISRateHelperTest(unittest.TestCase):
         """Test repricing of swaps built with MakeOIS class"""
         expected_npv = 0.0
         for n, unit in self.ois.keys():
+            quote_rate = self.ois.get((n, unit)).value()
             ois = ql.MakeOIS(ql.Period(n, unit), self.on_index,
-                             fixedRate=self.ois.get((n, unit)).value(),
+                             fixedRate=quote_rate,
                              fwdStart=ql.Period(0, ql.Days),
                              nominal=10000,
                              settlementDays=2,
@@ -177,11 +178,12 @@ class OISRateHelperTest(unittest.TestCase):
                              overnightLegSpread=0.0,
                              discountingTermStructure=self.discounting_yts_handle,
                              telescopicValueDates=False)
-            npv = ois.NPV()
-            self.assertAlmostEqual(expected_npv, npv,
-                                   delta=1e-3,
+            calculated_rate = ois.fairRate()
+            diff = (quote_rate - calculated_rate) * 1E4
+            self.assertAlmostEqual(quote_rate, calculated_rate,
+                                   delta=1e-7,
                                    msg=f"Failed to reprice swap {n} {unit}"
-                                   f" with a npv difference of {npv - expected_npv}")
+                                   f" with a npv difference of {diff}bps")
 
 
 class FxSwapRateHelperTest(unittest.TestCase):

--- a/Python/test/ratehelpers.py
+++ b/Python/test/ratehelpers.py
@@ -174,6 +174,7 @@ class OISRateHelperTest(unittest.TestCase):
                              settlementDays=2,
                              paymentFrequency=ql.Annual,
                              paymentAdjustmentConvention=ql.Following,
+                             endOfMonth=False,
                              paymentLag=0,
                              overnightLegSpread=0.0,
                              discountingTermStructure=self.discounting_yts_handle,
@@ -181,7 +182,7 @@ class OISRateHelperTest(unittest.TestCase):
             calculated_rate = ois.fairRate()
             diff = (quote_rate - calculated_rate) * 1E4
             self.assertAlmostEqual(quote_rate, calculated_rate,
-                                   delta=1e-7,
+                                   delta=1e-10,
                                    msg=f"Failed to reprice swap {n} {unit}"
                                    f" with a npv difference of {diff}bps")
 

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -284,7 +284,6 @@ class OISRateHelper : public RateHelper {
             const Period& forwardStart = 0 * Days, 
             const Spread overnightSpread = 0.0);
     boost::shared_ptr<OvernightIndexedSwap> swap();
-    void setTermStructure(YieldTermStructure*);
 };
 
 %shared_ptr(DatedOISRateHelper)

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -284,6 +284,7 @@ class OISRateHelper : public RateHelper {
             const Period& forwardStart = 0 * Days, 
             const Spread overnightSpread = 0.0);
     boost::shared_ptr<OvernightIndexedSwap> swap();
+    void setTermStructure(YieldTermStructure*);
 };
 
 %shared_ptr(DatedOISRateHelper)

--- a/SWIG/swap.i
+++ b/SWIG/swap.i
@@ -39,6 +39,7 @@ using QuantLib::NonstandardSwap;
 using QuantLib::DiscountingSwapEngine;
 using QuantLib::FloatFloatSwap;
 using QuantLib::OvernightIndexedSwap;
+using QuantLib::MakeOIS;
 %}
 
 %shared_ptr(Swap)
@@ -137,7 +138,7 @@ class MakeVanillaSwap {
 
 #if defined(SWIGPYTHON)
 %pythoncode{
-def MakeVanillaSwap(swapTenor,iborIndex,fixedRate,forwardStart,
+def MakeVanillaSwap(swapTenor, iborIndex, fixedRate, forwardStart,
     receiveFixed=None, swapType=None, Nominal=None, settlementDays=None,
     effectiveDate=None, terminationDate=None, dateGenerationRule=None,
     fixedLegTenor=None, fixedLegCalendar=None, fixedLegConvention=None,
@@ -363,5 +364,105 @@ class OvernightIndexedSwap : public Swap {
     const Leg& fixedLeg();
     const Leg& overnightLeg();
 };
+
+#if defined(SWIGPYTHON)
+%rename (_MakeOIS) MakeOIS;
+#endif
+%shared_ptr(MakeOIS)
+class MakeOIS {
+      public:
+        MakeOIS(const Period& swapTenor,
+                const boost::shared_ptr<OvernightIndex>& overnightIndex,
+                Rate fixedRate = Null<Rate>(),
+                const Period& fwdStart = 0*Days);
+
+        %extend{
+            boost::shared_ptr<OvernightIndexedSwap> makeOIS(){
+                return (boost::shared_ptr<OvernightIndexedSwap>)(* $self);
+            }
+        }
+
+        MakeOIS& receiveFixed(bool flag = true);
+        MakeOIS& withType(OvernightIndexedSwap::Type type);
+        MakeOIS& withNominal(Real n);
+        MakeOIS& withSettlementDays(Natural settlementDays);
+        MakeOIS& withEffectiveDate(const Date&);
+        MakeOIS& withTerminationDate(const Date&);
+        MakeOIS& withRule(DateGeneration::Rule r);
+        MakeOIS& withPaymentFrequency(Frequency f);
+        MakeOIS& withPaymentAdjustment(BusinessDayConvention convention);
+        MakeOIS& withPaymentLag(Natural lag);
+        MakeOIS& withPaymentCalendar(const Calendar& cal);
+        MakeOIS& withEndOfMonth(bool flag = true);
+        MakeOIS& withFixedLegDayCount(const DayCounter& dc);
+        MakeOIS& withOvernightLegSpread(Spread sp);
+        MakeOIS& withDiscountingTermStructure(
+                  const Handle<YieldTermStructure>& discountingTermStructure);
+        MakeOIS& withTelescopicValueDates(bool telescopicValueDates);
+        MakeOIS& withPricingEngine(
+                              const boost::shared_ptr<PricingEngine>& engine);
+};
+
+#if defined(SWIGPYTHON)
+%pythoncode{
+def MakeOIS(swapTenor, overnightIndex, fixedRate, fwdStart,
+            receiveFixed=None,
+            swapType=None,
+            nominal=None,
+            settlementDays=None,
+            effectiveDate=None,
+            terminationDate=None,
+            dateGenerationRule=None,
+            paymentFrequency=None,
+            paymentAdjustmentConvention=None,
+            paymentLag=None,
+            paymentCalendar=None,
+            endOfMonth=True,    
+            fixedLegDayCount=None,
+            overnightLegSpread=None,
+            discountingTermStructure=None,
+            telescopicValueDates=None,
+            pricingEngine=None):
+
+    mv = _MakeOIS(swapTenor, overnightIndex, fixedRate, fwdStart)
+    if receiveFixed is not None:
+        mv.receiveFixed(receiveFixed)
+    if swapType is not None:
+        mv.withType(swapType)
+    if nominal is not None:
+        mv.withNominal(nominal)
+    if settlementDays is not None:
+        mv.withSettlementDays(settlementDays)
+    if effectiveDate is not None:
+        mv.withEffectiveDate(effectiveDate)
+    if terminationDate is not None:
+        mv.withTerminationDate(terminationDate)
+    if dateGenerationRule is not None:
+        mv.withRule(dateGenerationRule)
+    if paymentFrequency is not None:
+        mv.withPaymentFrequency(paymentFrequency)
+    if paymentAdjustmentConvention is not None:
+        mv.withPaymentAdjustment(paymentAdjustmentConvention)
+    if paymentLag is not None:
+        mv.withPaymentLag(paymentLag)
+    if paymentCalendar:
+        mv.withPaymentCalendar(paymentCalendar)
+    
+    mv.withEndOfMonth(endOfMonth)
+    
+    if fixedLegDayCount is not None:
+        mv.withFixedLegDayCount(fixedLegDayCount)
+    if overnightLegSpread is not None:
+        mv.withOvernightLegSpread(overnightLegSpread)
+    if discountingTermStructure is not None:
+        mv.withDiscountingTermStructure(discountingTermStructure)
+    if telescopicValueDates is not None:
+        mv.withTelescopicValueDates(telescopicValueDates)
+    if pricingEngine is not None:
+        mv.withPricingEngine(pricingEngine)
+
+    return mv.makeOIS()
+}
+#endif
 
 #endif

--- a/SWIG/swap.i
+++ b/SWIG/swap.i
@@ -405,58 +405,60 @@ class MakeOIS {
 
 #if defined(SWIGPYTHON)
 %pythoncode{
-def MakeOIS(swapTenor, overnightIndex, fixedRate, fwdStart,
-            receiveFixed=None,
-            swapType=None,
-            nominal=None,
-            settlementDays=None,
+def MakeOIS(swapTenor, overnightIndex, fixedRate, fwdStart=Period(0, Days),
+            receiveFixed=True,
+            swapType=OvernightIndexedSwap.Payer,
+            nominal=1.0,
+            settlementDays=2,
             effectiveDate=None,
             terminationDate=None,
-            dateGenerationRule=None,
-            paymentFrequency=None,
-            paymentAdjustmentConvention=None,
-            paymentLag=None,
+            dateGenerationRule=DateGeneration.Backward,
+            paymentFrequency=Annual,
+            paymentAdjustmentConvention=Following,
+            paymentLag=0,
             paymentCalendar=None,
             endOfMonth=True,    
             fixedLegDayCount=None,
-            overnightLegSpread=None,
+            overnightLegSpread=0.0,
             discountingTermStructure=None,
-            telescopicValueDates=None,
+            telescopicValueDates=False,
             pricingEngine=None):
 
     mv = _MakeOIS(swapTenor, overnightIndex, fixedRate, fwdStart)
-    if receiveFixed is not None:
+    
+    if not receiveFixed:
         mv.receiveFixed(receiveFixed)
-    if swapType is not None:
+    if swapType != OvernightIndexedSwap.Payer:
         mv.withType(swapType)
-    if nominal is not None:
+    if nominal != 1.0:
         mv.withNominal(nominal)
-    if settlementDays is not None:
+    if settlementDays != 2:
         mv.withSettlementDays(settlementDays)
     if effectiveDate is not None:
         mv.withEffectiveDate(effectiveDate)
     if terminationDate is not None:
         mv.withTerminationDate(terminationDate)
-    if dateGenerationRule is not None:
-        mv.withRule(dateGenerationRule)
-    if paymentFrequency is not None:
+    if dateGenerationRule != DateGeneration.Backward:
+        mv.withRule(dateGenerationRule)  
+    if paymentFrequency != Annual:
         mv.withPaymentFrequency(paymentFrequency)
-    if paymentAdjustmentConvention is not None:
+    if paymentAdjustmentConvention != Following:
         mv.withPaymentAdjustment(paymentAdjustmentConvention)
-    if paymentLag is not None:
+    if paymentLag != 0:
         mv.withPaymentLag(paymentLag)
-    if paymentCalendar:
+    if paymentCalendar is not None:
         mv.withPaymentCalendar(paymentCalendar)
-    
-    mv.withEndOfMonth(endOfMonth)
-    
+    if not endOfMonth:
+        mv.withEndOfMonth(endOfMonth)
     if fixedLegDayCount is not None:
         mv.withFixedLegDayCount(fixedLegDayCount)
-    if overnightLegSpread is not None:
+    else:
+        mv.withFixedLegDayCount(overnightIndex.dayCounter())
+    if overnightLegSpread != 0.0:
         mv.withOvernightLegSpread(overnightLegSpread)
     if discountingTermStructure is not None:
-        mv.withDiscountingTermStructure(discountingTermStructure)
-    if telescopicValueDates is not None:
+        mv.withDiscountingTermStructure(discountingTermStructure)        
+    if telescopicValueDates:
         mv.withTelescopicValueDates(telescopicValueDates)
     if pricingEngine is not None:
         mv.withPricingEngine(pricingEngine)

--- a/SWIG/swap.i
+++ b/SWIG/swap.i
@@ -368,7 +368,6 @@ class OvernightIndexedSwap : public Swap {
 #if defined(SWIGPYTHON)
 %rename (_MakeOIS) MakeOIS;
 #endif
-%shared_ptr(MakeOIS)
 class MakeOIS {
       public:
         MakeOIS(const Period& swapTenor,


### PR DESCRIPTION
The pull request is related to exposing `setTermStructure` method from OISRateHelper.

By default, I thought, that the test in `test/ratehelpers.py::OISRateHelperTest::test_ois_ratehelper_impliedquote `
will run naturally - the `impliedQuote` method should return the original quote if the curve handle provided to the rate helper is linked to the bootstrapped curve. 
Unfortunately, it does not. It appears, that I need to use `setTermStructure` method, to make the test pass, as it is presented in 
`test/ratehelpers.py::OISRateHelperTest::test_ois_ratehelper_impliedquote `
The odd behavior is that for the first rate helper, I need to run the calculation twice. Otherwise the calculated value is too high. It looks as if the setTermStructure method was running somewhere in the background and calculation was performed on some partial results at the first run.

Any explanation of such behavior will be very welcome.

Regards,
Wojciech