### PR TITLE
Rename Python module to "QuantLib".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Perl/MYMETA.yml
 Perl/MYMETA.json
 Python/QuantLib/quantlib_wrap.cpp
 Python/.cache/
+Python/QuantLib.egg-info
 Python/QuantLib_Python.egg-info
 Python/dist
 R/src/QuantLib.cpp

--- a/Python/setup-old.py
+++ b/Python/setup-old.py
@@ -33,6 +33,5 @@ setup(
     url="http://quantlib.org",
     license="BSD 3-Clause",
     classifiers=classifiers,
-    data_files=["../LICENSE.TXT"],
     install_requires=["QuantLib == 1.17"],
 )

--- a/Python/setup-old.py
+++ b/Python/setup-old.py
@@ -1,0 +1,38 @@
+try:
+    from setuptools import setup
+except:
+    from distutils.core import setup
+
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: BSD License",
+    "Natural Language :: English",
+    "Programming Language :: C++",
+    "Programming Language :: Python",
+    "Topic :: Scientific/Engineering",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+]
+
+setup(
+    name="QuantLib-Python",
+    version="1.17",
+    description="Backward-compatible meta-package for the QuantLib module",
+    long_description="""
+    This module is provided for backward compatibility.
+    Use "pip install QuantLib" instead.
+    """,
+    author="QuantLib Team",
+    author_email="quantlib-users@lists.sourceforge.net",
+    url="http://quantlib.org",
+    license="BSD 3-Clause",
+    classifiers=classifiers,
+    data_files=["../LICENSE.TXT"],
+    install_requires=["QuantLib == 1.17"],
+)

--- a/Python/setup-old.py.in
+++ b/Python/setup-old.py.in
@@ -1,0 +1,38 @@
+try:
+    from setuptools import setup
+except:
+    from distutils.core import setup
+
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: BSD License",
+    "Natural Language :: English",
+    "Programming Language :: C++",
+    "Programming Language :: Python",
+    "Topic :: Scientific/Engineering",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+]
+
+setup(
+    name="QuantLib-Python",
+    version="@PACKAGE_VERSION@",
+    description="Backward-compatible meta-package for the QuantLib module",
+    long_description="""
+    This module is provided for backward compatibility.
+    Use "pip install QuantLib" instead.
+    """,
+    author="QuantLib Team",
+    author_email="quantlib-users@lists.sourceforge.net",
+    url="http://quantlib.org",
+    license="BSD 3-Clause",
+    classifiers=classifiers,
+    data_files=["../LICENSE.TXT"],
+    install_requires=["QuantLib == @PACKAGE_VERSION@"],
+)

--- a/Python/setup-old.py.in
+++ b/Python/setup-old.py.in
@@ -33,6 +33,5 @@ setup(
     url="http://quantlib.org",
     license="BSD 3-Clause",
     classifiers=classifiers,
-    data_files=["../LICENSE.TXT"],
     install_requires=["QuantLib == @PACKAGE_VERSION@"],
 )

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -17,7 +17,7 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
-import os, sys, math, codecs
+import os, sys, math
 from distutils.cmd import Command
 from distutils.command.build_ext import build_ext
 from distutils.command.build import build
@@ -73,8 +73,8 @@ class my_wrap(Command):
         print('Generating Python bindings for QuantLib...')
         swig_version = os.popen("swig -version").read().split()[2]
         major_swig_version = swig_version[0]
-        if major_swig_version < '3':
-           print('Warning: You have SWIG {} installed, but at least SWIG 3.0.1'
+        if major_swig_version < '4':
+           print('Warning: You have SWIG {} installed, but at least SWIG 4.0.1'
                  ' is recommended. \nSome features may not work.'
                  .format(swig_version))
         swig_dir = os.path.join("..","SWIG")
@@ -216,28 +216,24 @@ if os.name == 'posix':
             g['LDSHARED'] = g['CC'] + ' -shared'
     sysconfig._init_posix = my_init_posix
 
-datafiles  = []
-
-# patch distutils if it can't cope with the "classifiers" or
-# "download_url" keywords
-if sys.version < '2.2.3':
-    from distutils.dist import DistributionMetadata
-    DistributionMetadata.classifiers = None
-    DistributionMetadata.download_url = None
-
 classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Environment :: Console',
     'Intended Audience :: Developers',
+    'Intended Audience :: Science/Research',
     'Intended Audience :: End Users/Desktop',
     'License :: OSI Approved :: BSD License',
     'Natural Language :: English',
-    'Operating System :: OS Independent',
+    'Programming Language :: C++',
     'Programming Language :: Python',
     'Topic :: Scientific/Engineering',
+    'Operating System :: Microsoft :: Windows',
+    'Operating System :: POSIX',
+    'Operating System :: Unix',
+    'Operating System :: MacOS',
 ]
 
-setup(name             = "QuantLib-Python",
+setup(name             = "QuantLib",
       version          = "1.17",
       description      = "Python bindings for the QuantLib library",
       long_description = """
@@ -248,14 +244,13 @@ framework for quantitative finance.
       author           = "QuantLib Team",
       author_email     = "quantlib-users@lists.sourceforge.net",
       url              = "http://quantlib.org",
-      license          = codecs.open('../LICENSE.TXT','r+',
-                                     encoding='utf8').read(),
+      license          = "BSD 3-Clause",
       classifiers      = classifiers,
       py_modules       = ['QuantLib.__init__','QuantLib.QuantLib'],
       ext_modules      = [Extension("QuantLib._QuantLib",
                                     ["QuantLib/quantlib_wrap.cpp"])
                          ],
-      data_files       = datafiles,
+      data_files       = ['../LICENSE.TXT'],
       cmdclass         = {'test': test,
                           'wrap': my_wrap,
                           'build': my_build,

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -250,7 +250,7 @@ framework for quantitative finance.
       ext_modules      = [Extension("QuantLib._QuantLib",
                                     ["QuantLib/quantlib_wrap.cpp"])
                          ],
-      data_files       = ['../LICENSE.TXT'],
+      data_files       = [('share/doc/quantlib/', ['../LICENSE.TXT'])],
       cmdclass         = {'test': test,
                           'wrap': my_wrap,
                           'build': my_build,

--- a/Python/setup.py.in
+++ b/Python/setup.py.in
@@ -17,7 +17,7 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
-import os, sys, math, codecs
+import os, sys, math
 from distutils.cmd import Command
 from distutils.command.build_ext import build_ext
 from distutils.command.build import build
@@ -73,8 +73,8 @@ class my_wrap(Command):
         print('Generating Python bindings for QuantLib...')
         swig_version = os.popen("swig -version").read().split()[2]
         major_swig_version = swig_version[0]
-        if major_swig_version < '3':
-           print('Warning: You have SWIG {} installed, but at least SWIG 3.0.1'
+        if major_swig_version < '4':
+           print('Warning: You have SWIG {} installed, but at least SWIG 4.0.1'
                  ' is recommended. \nSome features may not work.'
                  .format(swig_version))
         swig_dir = os.path.join("..","SWIG")
@@ -216,28 +216,24 @@ if os.name == 'posix':
             g['LDSHARED'] = g['CC'] + ' -shared'
     sysconfig._init_posix = my_init_posix
 
-datafiles  = []
-
-# patch distutils if it can't cope with the "classifiers" or
-# "download_url" keywords
-if sys.version < '2.2.3':
-    from distutils.dist import DistributionMetadata
-    DistributionMetadata.classifiers = None
-    DistributionMetadata.download_url = None
-
 classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Environment :: Console',
     'Intended Audience :: Developers',
+    'Intended Audience :: Science/Research',
     'Intended Audience :: End Users/Desktop',
     'License :: OSI Approved :: BSD License',
     'Natural Language :: English',
-    'Operating System :: OS Independent',
+    'Programming Language :: C++',
     'Programming Language :: Python',
     'Topic :: Scientific/Engineering',
+    'Operating System :: Microsoft :: Windows',
+    'Operating System :: POSIX',
+    'Operating System :: Unix',
+    'Operating System :: MacOS',
 ]
 
-setup(name             = "QuantLib-Python",
+setup(name             = "QuantLib",
       version          = "@PACKAGE_VERSION@",
       description      = "Python bindings for the QuantLib library",
       long_description = """
@@ -248,14 +244,13 @@ framework for quantitative finance.
       author           = "QuantLib Team",
       author_email     = "quantlib-users@lists.sourceforge.net",
       url              = "http://quantlib.org",
-      license          = codecs.open('../LICENSE.TXT','r+',
-                                     encoding='utf8').read(),
+      license          = "BSD 3-Clause",
       classifiers      = classifiers,
       py_modules       = ['QuantLib.__init__','QuantLib.QuantLib'],
       ext_modules      = [Extension("QuantLib._QuantLib",
                                     ["QuantLib/quantlib_wrap.cpp"])
                          ],
-      data_files       = datafiles,
+      data_files       = ['../LICENSE.TXT'],
       cmdclass         = {'test': test,
                           'wrap': my_wrap,
                           'build': my_build,

--- a/Python/setup.py.in
+++ b/Python/setup.py.in
@@ -250,7 +250,7 @@ framework for quantitative finance.
       ext_modules      = [Extension("QuantLib._QuantLib",
                                     ["QuantLib/quantlib_wrap.cpp"])
                          ],
-      data_files       = ['../LICENSE.TXT'],
+      data_files       = [('share/doc/quantlib/', ['../LICENSE.TXT'])],
       cmdclass         = {'test': test,
                           'wrap': my_wrap,
                           'build': my_build,

--- a/configure.ac
+++ b/configure.ac
@@ -171,6 +171,7 @@ AC_CONFIG_FILES([
     Java/Makefile
     Python/Makefile
     Python/setup.py
+    Python/setup-old.py
     R/Makefile
     R/DESCRIPTION
     Ruby/Makefile


### PR DESCRIPTION
The "-Python" part was redundant.  For a while, we'll provide a meta-package for backward compatibility.