### PR TITLE
expose kruger interpolation using zero rates

### DIFF
--- a/SWIG/interpolation.i
+++ b/SWIG/interpolation.i
@@ -181,6 +181,12 @@ class MonotonicLogCubic : public QuantLib::LogCubic {
                          QuantLib::CubicInterpolation::SecondDerivative, 0.0,
                          QuantLib::CubicInterpolation::SecondDerivative, 0.0) {}
 };
+
+class KrugerCubicInterpolation : public Cubic {
+  public:
+    KrugerCubicInterpolation()
+    : Cubic(QuantLib::CubicInterpolation::Kruger) {}
+};
 %}
 
 struct BackwardFlat {};
@@ -192,7 +198,7 @@ struct MonotonicCubic {};
 struct DefaultLogCubic {};
 struct MonotonicLogCubic {};
 struct SplineCubic {};
-
+struct KrugerCubicInterpolation {};
 
 %{
 using QuantLib::RichardsonExtrapolation;

--- a/SWIG/interpolation.i
+++ b/SWIG/interpolation.i
@@ -168,6 +168,12 @@ class SplineCubic : public Cubic {
             QuantLib::CubicInterpolation::SecondDerivative, 0.0) {}
 };
 
+class Kruger : public Cubic {
+  public:
+    Kruger()
+    : Cubic(QuantLib::CubicInterpolation::Kruger) {}
+};
+
 class DefaultLogCubic : public QuantLib::LogCubic {
   public:
     DefaultLogCubic()
@@ -182,10 +188,12 @@ class MonotonicLogCubic : public QuantLib::LogCubic {
                          QuantLib::CubicInterpolation::SecondDerivative, 0.0) {}
 };
 
-class Kruger : public Cubic {
+class KrugerLog : public QuantLib::LogCubic {
   public:
-    Kruger()
-    : Cubic(QuantLib::CubicInterpolation::Kruger) {}
+    KrugerLog()
+    : QuantLib::LogCubic(QuantLib::CubicInterpolation::Kruger, false,
+                         QuantLib::CubicInterpolation::SecondDerivative, 0.0,
+                         QuantLib::CubicInterpolation::SecondDerivative, 0.0) {}
 };
 %}
 
@@ -199,6 +207,7 @@ struct DefaultLogCubic {};
 struct MonotonicLogCubic {};
 struct SplineCubic {};
 struct Kruger {};
+struct KrugerLog {};
 
 %{
 using QuantLib::RichardsonExtrapolation;

--- a/SWIG/interpolation.i
+++ b/SWIG/interpolation.i
@@ -182,9 +182,9 @@ class MonotonicLogCubic : public QuantLib::LogCubic {
                          QuantLib::CubicInterpolation::SecondDerivative, 0.0) {}
 };
 
-class KrugerCubicInterpolation : public Cubic {
+class Kruger : public Cubic {
   public:
-    KrugerCubicInterpolation()
+    Kruger()
     : Cubic(QuantLib::CubicInterpolation::Kruger) {}
 };
 %}
@@ -198,7 +198,7 @@ struct MonotonicCubic {};
 struct DefaultLogCubic {};
 struct MonotonicLogCubic {};
 struct SplineCubic {};
-struct KrugerCubicInterpolation {};
+struct Kruger {};
 
 %{
 using QuantLib::RichardsonExtrapolation;

--- a/SWIG/piecewiseyieldcurve.i
+++ b/SWIG/piecewiseyieldcurve.i
@@ -130,6 +130,6 @@ export_piecewise_curve(PiecewiseLinearZero,ZeroYield,Linear);
 export_piecewise_curve(PiecewiseCubicZero,ZeroYield,Cubic);
 export_piecewise_curve(PiecewiseLogCubicDiscount,Discount,MonotonicLogCubic);
 export_piecewise_curve(PiecewiseSplineCubicDiscount,Discount,SplineCubic);
-export_piecewise_curve(PiecewiseKrugerZero,ZeroYield,KrugerCubicInterpolation);
+export_piecewise_curve(PiecewiseKrugerZero,ZeroYield,Kruger);
 
 #endif

--- a/SWIG/piecewiseyieldcurve.i
+++ b/SWIG/piecewiseyieldcurve.i
@@ -131,5 +131,6 @@ export_piecewise_curve(PiecewiseCubicZero,ZeroYield,Cubic);
 export_piecewise_curve(PiecewiseLogCubicDiscount,Discount,MonotonicLogCubic);
 export_piecewise_curve(PiecewiseSplineCubicDiscount,Discount,SplineCubic);
 export_piecewise_curve(PiecewiseKrugerZero,ZeroYield,Kruger);
+export_piecewise_curve(PiecewiseKrugerLogDiscount,Discount,KrugerLog);
 
 #endif

--- a/SWIG/piecewiseyieldcurve.i
+++ b/SWIG/piecewiseyieldcurve.i
@@ -130,6 +130,6 @@ export_piecewise_curve(PiecewiseLinearZero,ZeroYield,Linear);
 export_piecewise_curve(PiecewiseCubicZero,ZeroYield,Cubic);
 export_piecewise_curve(PiecewiseLogCubicDiscount,Discount,MonotonicLogCubic);
 export_piecewise_curve(PiecewiseSplineCubicDiscount,Discount,SplineCubic);
-
+export_piecewise_curve(PiecewiseKrugerZero,ZeroYield,KrugerCubicInterpolation);
 
 #endif


### PR DESCRIPTION
Not sure about the naming convention of KrugerCubicInterpolation. We tried KrugerCubic but there was an error with an object already being named that.