### PR TITLE
export overnight index futures

### DIFF
--- a/SWIG/futures.i
+++ b/SWIG/futures.i
@@ -26,4 +26,7 @@ struct Futures {
     enum Type { IMM, ASX };
 };
 
+struct NettingType {
+    enum Type { Averaging, Compounding };
+};
 #endif

--- a/SWIG/futures.i
+++ b/SWIG/futures.i
@@ -27,7 +27,12 @@ struct Futures {
     enum Type { IMM, ASX };
 };
 
+class OvernightIndexFuture {
+  private:
+    OvernightIndexFuture();
+  public:
+    enum NettingType { Averaging, Compounding };
+};
 
-enum NettingType { Averaging, Compounding };
 
 #endif

--- a/SWIG/futures.i
+++ b/SWIG/futures.i
@@ -20,13 +20,14 @@
 
 %{
 using QuantLib::Futures;
+using QuantLib::OvernightIndexFuture;
 %}
 
 struct Futures {
     enum Type { IMM, ASX };
 };
 
-struct NettingType {
-    enum Type { Averaging, Compounding };
-};
+
+enum NettingType { Averaging, Compounding };
+
 #endif

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -43,6 +43,7 @@ using QuantLib::FixedRateBondHelper;
 using QuantLib::OISRateHelper;
 using QuantLib::DatedOISRateHelper;
 using QuantLib::FxSwapRateHelper;
+using QuantLib::OvernightIndexFutureRateHelper;
 %}
 
 struct Pillar {
@@ -323,6 +324,17 @@ class FxSwapRateHelper : public RateHelper {
             const Calendar& tradingCalendar = Calendar());
 };
 
+%shared_ptr(OvernightIndexFutureRateHelper)
+class OvernightIndexFutureRateHelper : public RateHelper {
+  public:
+    OvernightIndexFutureRateHelper(
+            const Handle<Quote>& price,
+            const Date& valueDate,
+            const Date& maturityDate,
+            const boost::shared_ptr<OvernightIndex>& index,
+            const Handle<Quote>& convexityAdjustment = Handle<Quote>(),
+            Futures::Type type = NettingType::Compounding);
+};
 
 // allow use of RateHelper vectors
 #if defined(SWIGCSHARP)

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -333,8 +333,9 @@ class OvernightIndexFutureRateHelper : public RateHelper {
             const Date& maturityDate,
             const boost::shared_ptr<OvernightIndex>& index,
             const Handle<Quote>& convexityAdjustment = Handle<Quote>(),
-            Futures::Type type = NettingType::Compounding);
+            OvernightIndexFuture::NettingType type = OvernightIndexFuture::Compounding);
 };
+
 
 // allow use of RateHelper vectors
 #if defined(SWIGCSHARP)


### PR DESCRIPTION
 QL has C++ implementation of overnight index futures for use in curve building, but it's not exposed to Python version.

There is an error with the way NettingType is declared that I would like some help with.

Thanks!