### PR TITLE
Remove UnsignedIntVector.

### DIFF
--- a/CSharp/csharp/NQuantLib.csproj
+++ b/CSharp/csharp/NQuantLib.csproj
@@ -958,6 +958,7 @@
     <Compile Include="SimpsonIntegral.cs" />
     <Compile Include="Singapore.cs" />
     <Compile Include="SITCurrency.cs" />
+    <Compile Include="SizeVector.cs" />
     <Compile Include="SKKCurrency.cs" />
     <Compile Include="Slovakia.cs" />
     <Compile Include="SmileSection.cs" />
@@ -1058,7 +1059,6 @@
     <Compile Include="UniformRandomSequenceGenerator.cs" />
     <Compile Include="UnitedKingdom.cs" />
     <Compile Include="UnitedStates.cs" />
-    <Compile Include="UnsignedIntVector.cs" />
     <Compile Include="UpfrontCdsHelper.cs" />
     <Compile Include="UpRounding.cs" />
     <Compile Include="USCPI.cs" />

--- a/SWIG/montecarlo.i
+++ b/SWIG/montecarlo.i
@@ -173,29 +173,14 @@ public:
   std::vector<Real> leftWeight()   const;
   std::vector<Real> rightWeight()  const;
   std::vector<Real> stdDeviation() const;
+  std::vector<Size> bridgeIndex()  const;
+  std::vector<Size> leftIndex()    const;
+  std::vector<Size> rightIndex()   const;
   %extend{
     std::vector<Real> transform(const std::vector<Real> &input){
       std::vector<Real> outp(input.size());
       $self->transform(input.begin(),input.end(),outp.begin());
       return outp;
-    }
-    std::vector<unsigned int> bridgeIndex() const{
-    	const std::vector<Size> &tmp = $self->bridgeIndex();
-    	std::vector<unsigned int> outp(tmp.size());
-    	std::copy(tmp.begin(), tmp.end(), outp.begin());
-    	return outp;
-    }
-    std::vector<unsigned int> leftIndex() const{
-    	const std::vector<Size> &tmp = $self->leftIndex();
-    	std::vector<unsigned int> outp(tmp.size());
-    	std::copy(tmp.begin(), tmp.end(), outp.begin());
-    	return outp;
-    }
-    std::vector<unsigned int> rightIndex() const{
-    	const std::vector<Size> &tmp = $self->rightIndex();
-    	std::vector<unsigned int> outp(tmp.size());
-    	std::copy(tmp.begin(), tmp.end(), outp.begin());
-    	return outp;
     }
   }
 };

--- a/SWIG/randomnumbers.i
+++ b/SWIG/randomnumbers.i
@@ -194,9 +194,9 @@ class SobolRsg {
     Size dimension() const;
     void skipTo(Size n);
     %extend{
-      std::vector<unsigned int> nextInt32Sequence(){
+      std::vector<Size> nextInt32Sequence(){
         const std::vector<boost::uint_least32_t> &tmp = $self->nextInt32Sequence();
-        std::vector<unsigned int> outp(tmp.size());
+        std::vector<Size> outp(tmp.size());
         std::copy(tmp.begin(),tmp.end(),outp.begin());
         return outp;
       }

--- a/SWIG/vectors.i
+++ b/SWIG/vectors.i
@@ -32,7 +32,6 @@ SWIG_STD_VECTOR_ENHANCED( std::pair<Date,double> )
 namespace std {
 
     %template(IntVector) vector<int>;
-    %template(UnsignedIntVector) vector<unsigned int>;
     %template(DoubleVector) vector<double>;
     %template(StrVector) vector<std::string>;
     %template(BoolVector) vector<bool>;


### PR DESCRIPTION
This prevents conflicts with SizeVector on 32-bit platforms.

Fixes #246. 