### PR TITLE
Enable choice of normal volatility for CapHelper.

### DIFF
--- a/SWIG/calibrationhelpers.i
+++ b/SWIG/calibrationhelpers.i
@@ -50,7 +50,7 @@ using QuantLib::HestonModelHelper;
 %shared_ptr(CalibrationHelper)
 class CalibrationHelper {
   public:
-	Real calibrationError();
+    Real calibrationError();
   private:
     CalibrationHelper();
 };
@@ -59,7 +59,7 @@ class CalibrationHelper {
 class BlackCalibrationHelper : public CalibrationHelper {
   public:
     enum CalibrationErrorType { RelativePriceError, PriceError, ImpliedVolError };
-                       
+
     void setPricingEngine(const boost::shared_ptr<PricingEngine>& engine);
     Real marketValue() const;
     virtual Real modelValue() const;
@@ -100,7 +100,7 @@ class SwaptionHelper : public BlackCalibrationHelper {
                       const Real nominal = 1.0,
                       const VolatilityType type = ShiftedLognormal,
                       const Real shift = 0.0);
-    
+
     SwaptionHelper(const Date& exerciseDate, const Period& length,
                       const Handle<Quote>& volatility,
                       const boost::shared_ptr<IborIndex>& index,
@@ -114,7 +114,7 @@ class SwaptionHelper : public BlackCalibrationHelper {
                       const Real nominal = 1.0,
                       const VolatilityType type = ShiftedLognormal,
                       const Real shift = 0.0);
-    
+
     SwaptionHelper(const Date& exerciseDate, const Date& endDate,
                       const Handle<Quote>& volatility,
                       const boost::shared_ptr<IborIndex>& index,
@@ -131,7 +131,7 @@ class SwaptionHelper : public BlackCalibrationHelper {
 
     boost::shared_ptr<VanillaSwap> underlyingSwap() const;
     boost::shared_ptr<Swaption> swaption() const;
-                      
+
     %extend {
         std::vector<Time> times() {
             std::list<Time> l;
@@ -159,15 +159,17 @@ class SwaptionHelper : public BlackCalibrationHelper {
 class CapHelper : public BlackCalibrationHelper {
   public:
     CapHelper(const Period& length,
-                 const Handle<Quote>& volatility,
-                 const boost::shared_ptr<IborIndex>& index,
-                 Frequency fixedLegFrequency,
-                 const DayCounter& fixedLegDayCounter,
-                 bool includeFirstSwaplet,
-                 const Handle<YieldTermStructure>& termStructure,
-                 BlackCalibrationHelper::CalibrationErrorType errorType
-                                = BlackCalibrationHelper::RelativePriceError);
-    %extend {        
+              const Handle<Quote>& volatility,
+              const boost::shared_ptr<IborIndex>& index,
+              Frequency fixedLegFrequency,
+              const DayCounter& fixedLegDayCounter,
+              bool includeFirstSwaplet,
+              const Handle<YieldTermStructure>& termStructure,
+              BlackCalibrationHelper::CalibrationErrorType errorType
+                                = BlackCalibrationHelper::RelativePriceError,
+              const VolatilityType type = ShiftedLognormal,
+              const Real shift = 0.0);
+    %extend {
         std::vector<Time> times() {
             std::list<Time> l;
             self->addTimesTo(l);
@@ -201,7 +203,7 @@ namespace std {
     %template(CalibrationHelperVector)
         vector<boost::shared_ptr<CalibrationHelper> >;
     %template(BlackCalibrationHelperVector)
-        vector<boost::shared_ptr<BlackCalibrationHelper> >;        
+        vector<boost::shared_ptr<BlackCalibrationHelper> >;
 }
 
 // the base class for calibrated models
@@ -223,7 +225,7 @@ class CalibratedModel : public virtual Observable {
         const Constraint& constraint = Constraint(),
         const std::vector<Real>& weights = std::vector<Real>(),
         const std::vector<bool>& fixParameters = std::vector<bool>());
-     
+
     void setParams(const Array& params);
     Real value(const Array& params,
                const std::vector<boost::shared_ptr<CalibrationHelper> >&);


### PR DESCRIPTION
See lballabio/QuantLib#776.

Closes #251.