### PR TITLE
Inflation unit tests

### DIFF
--- a/Python/test/QuantLibTestSuite.py
+++ b/Python/test/QuantLibTestSuite.py
@@ -41,6 +41,7 @@ from americanquantooption import AmericanQuantoOptionTest
 from extrapolation import ExtrapolationTest
 from fdm import FdmTest
 from gjrgarch import GJRGARCHEngineTest, GJRGARCHCalibrationTest
+from inflation import InflationTest
 
 
 def test():
@@ -75,6 +76,7 @@ def test():
     suite.addTest(unittest.makeSuite(FdmTest, 'test'))
     suite.addTest(unittest.makeSuite(GJRGARCHEngineTest, "test"))
     suite.addTest(unittest.makeSuite(GJRGARCHCalibrationTest, "test"))
+    suite.addTest(unittest.makeSuite(InflationTest, "test"))
 
     result = unittest.TextTestRunner(verbosity=2).run(suite)
 

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -1,5 +1,5 @@
 """
- Copyright (C) 2020 tbd
+ Copyright (C) 2020 Marcin Rybacki
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -330,7 +330,6 @@ class InflationTest(unittest.TestCase):
                               base_index=swap_base_fixing,
                               expected_base_index=expected_swap_base_index,
                               tolerance=EPSILON)
-
         self.assertAlmostEquals(
             first=swap_base_fixing,
             second=expected_swap_base_index,
@@ -366,7 +365,6 @@ class InflationTest(unittest.TestCase):
                               base_fixing=curve_base_fixing,
                               expected_base_fixing=expected_curve_base_fixing,
                               tolerance=EPSILON)
-
         self.assertAlmostEquals(
             first=curve_base_fixing,
             second=expected_curve_base_fixing,
@@ -427,7 +425,6 @@ class InflationTest(unittest.TestCase):
                               actual_payment=actual_inf_leg_payment,
                               expected_payment=expected_inf_leg_payment,
                               tolerance=EPSILON)
-
         self.assertAlmostEquals(
             first=actual_inf_leg_payment,
             second=expected_inf_leg_payment,
@@ -497,7 +494,6 @@ class InflationTest(unittest.TestCase):
                               actual_payment=actual_inf_leg_payment,
                               expected_payment=expected_inf_leg_payment,
                               tolerance=EPSILON)
-
         self.assertAlmostEquals(
             first=actual_inf_leg_payment,
             second=expected_inf_leg_payment,

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -180,7 +180,7 @@ def interpolate_historic_index(
 
 class InflationTest(unittest.TestCase):
     def setUp(self):
-        ql.Settings.instance().setEvaluationDate(VALUATION_DATE)
+        ql.Settings.instance().evaluationDate = VALUATION_DATE
         self.inflation_ts_handle = ql.RelinkableZeroInflationTermStructureHandle()
         self.nominal_ts_handle = ql.RelinkableYieldTermStructureHandle()
         self.nominal_ts_handle.linkTo(

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -1,0 +1,464 @@
+"""
+ Copyright (C) 2020 tbd
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+"""
+
+import unittest
+import QuantLib as ql
+
+from typing import List, Tuple
+
+
+UK_NOMINAL_DATA = [
+    (ql.Date(26, ql.November, 2009), 0.475),
+    (ql.Date(2, ql.December, 2009), 0.47498),
+    (ql.Date(29, ql.December, 2009), 0.49988),
+    (ql.Date(25, ql.February, 2010), 0.59955),
+    (ql.Date(18, ql.March, 2010), 0.65361),
+    (ql.Date(25, ql.May, 2010), 0.82830),
+    (ql.Date(16, ql.September, 2010), 0.78960),
+    (ql.Date(16, ql.December, 2010), 0.93762),
+    (ql.Date(17, ql.March, 2011), 1.12037),
+    (ql.Date(16, ql.June, 2011), 1.31308),
+    (ql.Date(22, ql.September, 2011), 1.52011),
+    (ql.Date(25, ql.November, 2011), 1.78399),
+    (ql.Date(26, ql.November, 2012), 2.41170),
+    (ql.Date(25, ql.November, 2013), 2.83935),
+    (ql.Date(25, ql.November, 2014), 3.12888),
+    (ql.Date(25, ql.November, 2015), 3.34298),
+    (ql.Date(25, ql.November, 2016), 3.50632),
+    (ql.Date(27, ql.November, 2017), 3.63666),
+    (ql.Date(26, ql.November, 2018), 3.74723),
+    (ql.Date(25, ql.November, 2019), 3.83988),
+    (ql.Date(25, ql.November, 2021), 4.00508),
+    (ql.Date(25, ql.November, 2024), 4.16042),
+    (ql.Date(26, ql.November, 2029), 4.15577),
+    (ql.Date(27, ql.November, 2034), 4.04933),
+    (ql.Date(25, ql.November, 2039), 3.95217),
+    (ql.Date(25, ql.November, 2049), 3.80932),
+    (ql.Date(25, ql.November, 2059), 3.80849),
+    (ql.Date(25, ql.November, 2069), 3.72677),
+    (ql.Date(27, ql.November, 2079), 3.63082)]
+
+EU_NOMINAL_DATA = [(ql.Date(28, ql.October, 2018), 0.475),
+                   (ql.Date(28, ql.October, 2019), 0.47498),
+                   (ql.Date(28, ql.October, 2020), 0.49988)]
+
+UK_FIXING_DATA = [
+    (ql.Date(20, ql.July, 2007), 206.1),
+    (ql.Date(20, ql.August, 2007), 207.3),
+    (ql.Date(20, ql.September, 2007), 208.0),
+    (ql.Date(22, ql.October, 2007), 208.9),
+    (ql.Date(20, ql.November, 2007), 209.7),
+    (ql.Date(20, ql.December, 2007), 210.9),
+    (ql.Date(21, ql.January, 2008), 209.8),
+    (ql.Date(20, ql.February, 2008), 211.4),
+    (ql.Date(20, ql.March, 2008), 212.1),
+    (ql.Date(21, ql.April, 2008), 214.0),
+    (ql.Date(20, ql.May, 2008), 215.1),
+    (ql.Date(21, ql.June, 2008), 216.8),
+    (ql.Date(20, ql.August, 2008), 216.5),
+    (ql.Date(22, ql.September, 2008), 217.2),
+    (ql.Date(20, ql.October, 2008), 218.4),
+    (ql.Date(20, ql.November, 2008), 217.7),
+    (ql.Date(22, ql.December, 2008), 216.0),
+    (ql.Date(20, ql.January, 2009), 212.9),
+    (ql.Date(20, ql.February, 2009), 210.1),
+    (ql.Date(20, ql.March, 2009), 211.4),
+    (ql.Date(20, ql.April, 2009), 211.3),
+    (ql.Date(20, ql.May, 2009), 211.5),
+    (ql.Date(22, ql.June, 2009), 212.8),
+    (ql.Date(20, ql.July, 2009), 213.4),
+    (ql.Date(20, ql.August, 2009), 213.4),
+    (ql.Date(21, ql.September, 2009), 213.4)]
+
+EU_FIXING_DATA = [(ql.Date(1, ql.June, 2018), 103.76),
+                  (ql.Date(1, ql.July, 2018), 103.41),
+                  (ql.Date(1, ql.August, 2018), 103.58)]
+
+EU_ZERO_COUPON_DATA = [(ql.Date(28, ql.September, 2019), 3.0495),
+                       (ql.Date(28, ql.September, 2020), 2.93),
+                       (ql.Date(28, ql.September, 2021), 2.9795)]
+
+UK_ZERO_COUPON_DATA = [
+    (ql.Date(25, ql.November, 2010), 3.0495),
+    (ql.Date(25, ql.November, 2011), 2.93),
+    (ql.Date(26, ql.November, 2012), 2.9795),
+    (ql.Date(25, ql.November, 2013), 3.029),
+    (ql.Date(25, ql.November, 2014), 3.1425),
+    (ql.Date(25, ql.November, 2015), 3.211),
+    (ql.Date(25, ql.November, 2016), 3.2675),
+    (ql.Date(25, ql.November, 2017), 3.3625),
+    (ql.Date(25, ql.November, 2018), 3.405),
+    (ql.Date(25, ql.November, 2019), 3.48),
+    (ql.Date(25, ql.November, 2021), 3.576),
+    (ql.Date(25, ql.November, 2024), 3.649),
+    (ql.Date(26, ql.November, 2029), 3.751),
+    (ql.Date(27, ql.November, 2034), 3.77225),
+    (ql.Date(25, ql.November, 2039), 3.77),
+    (ql.Date(25, ql.November, 2049), 3.734),
+    (ql.Date(25, ql.November, 2059), 3.714)]
+
+
+def create_inflation_helper(
+    inflation_data: Tuple[ql.Date, float],
+    inflation_index: ql.ZeroInflationIndex,
+    observation_lag: ql.Period,
+    calendar: ql.Calendar,
+    business_day_convention,
+    day_counter: ql.DayCounter,
+    discount_curve_handle: ql.YieldTermStructureHandle
+) -> ql.ZeroCouponInflationSwapHelper:
+    maturity = inflation_data[0]
+    quote = ql.QuoteHandle(ql.SimpleQuote(inflation_data[1] / 100.0))
+    return ql.ZeroCouponInflationSwapHelper(
+        quote,
+        observation_lag,
+        maturity,
+        calendar,
+        business_day_convention,
+        day_counter,
+        inflation_index,
+        discount_curve_handle)
+
+
+def build_nominal_term_structure(
+        nominal_data: List[Tuple[ql.Date, float]]) -> ql.YieldTermStructure:
+    nominal_dc = ql.Actual365Fixed()
+    dates = [x[0] for x in nominal_data]
+    rates = [x[1] for x in nominal_data]
+    return ql.ZeroCurve(dates, rates, nominal_dc)
+
+
+def build_ukrpi_index(
+        fixing_data: List[Tuple[ql.Date, float]],
+        inflation_crv_handle: ql.ZeroInflationTermStructureHandle,
+        interpolated: bool = False) -> ql.ZeroInflationIndex:
+    # uk rpi index fixing data
+    index = ql.UKRPI(interpolated, inflation_crv_handle)
+    for x in fixing_data:
+        # force override in case of multiple use
+        index.addFixing(x[0], x[1], True)
+
+    return index
+
+
+def build_hicp_index(
+        fixing_data: List[Tuple[ql.Date, float]],
+        inflation_crv_handle: ql.ZeroInflationTermStructureHandle,
+        interpolated: bool = False) -> ql.ZeroInflationIndex:
+    # uk rpi index fixing data
+    index = ql.EUHICP(interpolated, inflation_crv_handle)
+    for x in fixing_data:
+        index.addFixing(x[0], x[1], True)
+
+    return index
+
+
+SEASONAL = {ql.January: 1.0, ql.February: 1.01, ql.March: 1.011,
+            ql.April: 1.009, ql.May: 1.008, ql.June: 1.012,
+            ql.July: 1.0078, ql.August: 1.006,
+            ql.September: 1.0085, ql.October: 1.0096,
+            ql.November: 1.0067, ql.December: 1.0055}
+
+
+def construct_seasonality(evaluation_date: ql.Date) -> ql.Seasonality:
+    frequency = ql.Monthly
+    seasonality_base_date = ql.Date(1, ql.January, evaluation_date.year())
+    factors = list(SEASONAL.values())
+    return ql.MultiplicativePriceSeasonality(
+        seasonality_base_date, frequency, factors)
+
+
+def get_seasonality_factor(d: ql.Date):
+    return SEASONAL[d.month()]
+
+
+def build_inflation_term_structure(
+        reference_date: ql.Date,
+        zero_coupon_data: List[Tuple[ql.Date, float]],
+        inflation_index: ql.ZeroInflationIndex,
+        nominal_term_structure_handle: ql.YieldTermStructureHandle,
+        observation_lag: ql.Period,
+        include_seasonality: bool = False) -> ql.ZeroInflationTermStructure:
+    calendar = ql.TARGET()
+    payment_convention = ql.ModifiedFollowing
+    day_counter = ql.ActualActual()
+    helpers = [create_inflation_helper(x,
+                                       inflation_index,
+                                       observation_lag,
+                                       calendar,
+                                       payment_convention,
+                                       day_counter,
+                                       nominal_term_structure_handle)
+               for x in zero_coupon_data]
+    base_zero_rate = zero_coupon_data[0][1] / 100.0
+    cpi_term_structure = ql.PiecewiseZeroInflation(
+        reference_date,
+        calendar,
+        day_counter,
+        observation_lag,
+        inflation_index.frequency(),
+        inflation_index.interpolated(),
+        base_zero_rate,
+        nominal_term_structure_handle,
+        helpers)
+    if include_seasonality:
+        seasonality = construct_seasonality(reference_date)
+        cpi_term_structure.setSeasonality(seasonality)
+    return cpi_term_structure
+
+
+def create_inflation_swap(
+        index: ql.ZeroInflationIndex,
+        start_date: ql.Date,
+        end_date: ql.Date,
+        rate: float,
+        observation_lag: ql.Period) -> ql.ZeroCouponInflationSwap:
+    payer = ql.ZeroCouponInflationSwap.Payer
+    calendar = ql.UnitedKingdom()
+    payment_convention = ql.ModifiedFollowing
+    day_counter = ql.ActualActual()
+    nominal = 1.e6
+    return ql.ZeroCouponInflationSwap(payer, nominal, start_date,
+                                      end_date, calendar, payment_convention,
+                                      day_counter, rate, index,
+                                      observation_lag)
+
+
+class InflationTest(unittest.TestCase):
+    def test_fom_indexation_without_seasonality(self):
+        """Testing first of month indexation without seasonality"""
+
+        today = ql.Date(25, ql.November, 2009)
+        ql.Settings.instance().setEvaluationDate(today)
+
+        # Nominal term structure handle
+        nominal_ts_handle = ql.RelinkableYieldTermStructureHandle()
+        nominal_ts = build_nominal_term_structure(UK_NOMINAL_DATA)
+        nominal_ts_handle.linkTo(nominal_ts)
+        discount_engine = ql.DiscountingSwapEngine(nominal_ts_handle)
+
+        # Inflation curve handle
+        inflation_ts_handle = ql.RelinkableZeroInflationTermStructureHandle()
+        inflation_index = build_ukrpi_index(
+            UK_FIXING_DATA, inflation_ts_handle)
+        observation_lag = ql.Period(2, ql.Months)
+        inflation_ts = build_inflation_term_structure(
+            today,
+            UK_ZERO_COUPON_DATA,
+            inflation_index,
+            nominal_ts_handle,
+            observation_lag)
+        inflation_ts_handle.linkTo(inflation_ts)
+
+        # Create par inflation swap
+        zciis = create_inflation_swap(
+            inflation_index, today, ql.Date(25, ql.November, 2059),
+            0.03714, observation_lag)
+        zciis.setPricingEngine(discount_engine)
+
+        # Check whether swap prices to par
+        self.assertTrue(
+            abs(zciis.NPV() < 1.e-5),
+            msg="Failed to price zero coupon inflation swap to par.")
+
+        inflation_cf = ql.as_indexed_cash_flow(
+            zciis.inflationLeg()[0])
+
+        # Obtaining base index for the inflation swap
+        swap_base_d = inflation_cf.baseDate()
+        swap_base_index = inflation_index.fixing(swap_base_d)
+
+        # Replicate fixing projection
+        fixing_d = inflation_cf.fixingDate()
+        ts_base_d = inflation_ts.baseDate()
+        ts_base_index = inflation_index.fixing(ts_base_d)
+
+        # Apply FOM indexation rule
+        effective_fixing_d = ql.Date(
+            1, fixing_d.month(), fixing_d.year())
+        fraction = inflation_ts.dayCounter().yearFraction(
+            ts_base_d, effective_fixing_d)
+        t = inflation_ts.timeFromReference(effective_fixing_d)
+        zero_rate = inflation_ts.zeroRate(t)
+
+        expected_fixing = ts_base_index * (
+            1.0 + zero_rate)**fraction
+
+        expected_inf_leg_payment = (
+            expected_fixing / swap_base_index - 1.0) * inflation_cf.notional()
+        actual_inf_leg_payment = inflation_cf.amount()
+        self.assertAlmostEquals(
+            first=actual_inf_leg_payment,
+            second=expected_inf_leg_payment,
+            delta=1.e-10,
+            msg="Failed to replicate the inflation leg expected flow.")
+
+    def test_linear_indexation_without_seasonality(self):
+        """Testing linear indexation without seasonality"""
+
+        today = ql.Date(25, ql.November, 2009)
+        ql.Settings.instance().setEvaluationDate(today)
+
+        # Nominal term structure handle
+        nominal_ts_handle = ql.RelinkableYieldTermStructureHandle()
+        nominal_ts = build_nominal_term_structure(UK_NOMINAL_DATA)
+        nominal_ts_handle.linkTo(nominal_ts)
+        discount_engine = ql.DiscountingSwapEngine(nominal_ts_handle)
+
+        # Inflation curve handle
+        inflation_ts_handle = ql.RelinkableZeroInflationTermStructureHandle()
+        index = build_ukrpi_index(
+            UK_FIXING_DATA, inflation_ts_handle, interpolated=True)
+        observation_lag = ql.Period(3, ql.Months)
+        inflation_ts = build_inflation_term_structure(
+            today, UK_ZERO_COUPON_DATA, index, nominal_ts_handle, observation_lag)
+        inflation_ts_handle.linkTo(inflation_ts)
+
+        # Create par inflation swap
+        zciis = create_inflation_swap(
+            index,
+            ql.Date(25, ql.April, 2009),
+            ql.Date(25, ql.November, 2059),
+            0.038,
+            observation_lag)
+        zciis.setPricingEngine(discount_engine)
+
+        inflation_cf = ql.as_indexed_cash_flow(
+            zciis.inflationLeg()[0])
+
+        # Replicate base index for the inflation swap
+        def interpolate_historic_index(fixing_date: ql.Date):
+            f_d = ql.Date(1, fixing_date.month(), fixing_date.year())
+            s_d = ql.Date.endOfMonth(fixing_date) + 1
+            slope = (fixing_date - f_d) / (
+                (s_d + observation_lag) - (f_d + observation_lag))
+            return index.fixing(f_d) + slope * (
+                index.fixing(s_d) - index.fixing(f_d))
+
+        swap_base_d = inflation_cf.baseDate()
+        swap_base_index = index.fixing(swap_base_d)
+        expected_swap_base_index = interpolate_historic_index(swap_base_d)
+        self.assertAlmostEquals(
+            first=swap_base_index,
+            second=expected_swap_base_index,
+            msg="Failed to replicate the base index on the inflation swap.")
+
+        # Replicate projected swap fixing
+        fixing_d = inflation_cf.fixingDate()
+
+        ts_base_d = inflation_ts.baseDate()
+        ts_base_index = index.fixing(ts_base_d)
+        expected_ts_base_index = interpolate_historic_index(ts_base_d)
+        self.assertAlmostEquals(
+            first=ts_base_index,
+            second=expected_ts_base_index,
+            msg="Failed to replicate the base index on the inflation curve.")
+
+        # Apply linear indexation rule
+        fraction = inflation_ts.dayCounter().yearFraction(
+            ts_base_d, fixing_d)
+        t = inflation_ts.timeFromReference(fixing_d)
+        zero_rate = inflation_ts.zeroRate(t)
+
+        expected_fixing = ts_base_index * (
+            1.0 + zero_rate)**fraction
+
+        # Assert inflation leg projected amount
+        expected_inf_leg_payment = (
+            expected_fixing / swap_base_index - 1.0) * inflation_cf.notional()
+        actual_inf_leg_payment = inflation_cf.amount()
+        self.assertAlmostEquals(
+            first=actual_inf_leg_payment,
+            second=expected_inf_leg_payment,
+            delta=1.e-10,
+            msg="Failed to replicate the inflation leg expected flow.")
+
+    def test_linear_indexation_with_seasonality(self):
+        """Testing linear indexation with seasonality"""
+
+        today = ql.Date(25, ql.November, 2009)
+        ql.Settings.instance().setEvaluationDate(today)
+
+        # Nominal term structure handle
+        nominal_ts_handle = ql.RelinkableYieldTermStructureHandle()
+        nominal_ts = build_nominal_term_structure(UK_NOMINAL_DATA)
+        nominal_ts_handle.linkTo(nominal_ts)
+        discount_engine = ql.DiscountingSwapEngine(nominal_ts_handle)
+
+        # Inflation curve handle
+        inflation_ts_handle = ql.RelinkableZeroInflationTermStructureHandle()
+        inflation_index = build_ukrpi_index(
+            UK_FIXING_DATA, inflation_ts_handle, interpolated=True)
+        observation_lag = ql.Period(3, ql.Months)
+        inflation_ts = build_inflation_term_structure(
+            today,
+            UK_ZERO_COUPON_DATA,
+            inflation_index,
+            nominal_ts_handle,
+            observation_lag,
+            include_seasonality=True)
+        inflation_ts_handle.linkTo(inflation_ts)
+
+        # Create par inflation swap
+        zciis = create_inflation_swap(
+            inflation_index,
+            ql.Date(25, ql.April, 2009),
+            ql.Date(25, ql.November, 2059),
+            0.037,
+            observation_lag)
+        zciis.setPricingEngine(discount_engine)
+
+        inflation_cf = ql.as_indexed_cash_flow(
+            zciis.inflationLeg()[0])
+
+        # Obtaining base index for the inflation swap
+        swap_base_d = inflation_cf.baseDate()
+        swap_base_index = inflation_index.fixing(swap_base_d)
+
+        # Replicate fixing projection
+        fixing_d = inflation_cf.fixingDate()
+        ts_base_d = inflation_ts.baseDate()
+        ts_base_index = inflation_index.fixing(ts_base_d)
+
+        # Apply linear indexation rule
+        fraction = inflation_ts.dayCounter().yearFraction(
+            ts_base_d, fixing_d)
+        t = inflation_ts.timeFromReference(fixing_d)
+        zero_rate = inflation_ts.zeroRate(t)
+
+        # Calculate seasonality adjustment
+        seasonality_b = get_seasonality_factor(ts_base_d)
+        seasonality_f = get_seasonality_factor(fixing_d)
+
+        expected_fixing = ts_base_index * (
+            seasonality_f / seasonality_b) * (1.0 + zero_rate)**fraction
+
+        expected_inf_leg_payment = (
+            expected_fixing / swap_base_index - 1.0) * inflation_cf.notional()
+        actual_inf_leg_payment = inflation_cf.amount()
+        self.assertAlmostEquals(
+            first=actual_inf_leg_payment,
+            second=expected_inf_leg_payment,
+            delta=1.e-10,
+            msg="Failed to replicate the inflation leg expected flow.")
+
+
+if __name__ == '__main__':
+    print('testing QuantLib ' + ql.__version__)
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(InflationTest, 'test'))
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -169,8 +169,10 @@ def interpolate_historic_index(
         inflation_idx, fixing_date, observation_lag=OBSERVATION_LAG):
     first_dt = ql.Date(1, fixing_date.month(), fixing_date.year())
     second_dt = ql.Date.endOfMonth(fixing_date) + 1
-    slope = (fixing_date - first_dt) / (
+    slope_numerator = fixing_date - first_dt
+    slope_denominator = (
         (second_dt + observation_lag) - (first_dt + observation_lag))
+    slope = float(slope_numerator) / float(slope_denominator)
     return inflation_idx.fixing(first_dt) + slope * (
         inflation_idx.fixing(second_dt) - inflation_idx.fixing(first_dt))
 

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -18,8 +18,6 @@
 import unittest
 import QuantLib as ql
 
-from typing import List, Tuple
-
 
 EPSILON = 1.e-9
 

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -190,7 +190,6 @@ class InflationTest(unittest.TestCase):
     def test_par_swap_pricing_fom_indexation_without_seasonality(self):
         """Testing pricing of par inflation swap for First-Of-Month indexation"""
 
-        # Inflation curve handle
         inflation_idx = build_hicp_index(
             EU_FIXING_DATA, self.inflation_ts_handle)
         inflation_ts = build_inflation_term_structure(
@@ -231,7 +230,6 @@ class InflationTest(unittest.TestCase):
 
     def test_inflation_leg_payment_fom_indexation_without_seasonality(self):
         """Testing inflation leg payment for First-Of-Month indexation"""
-        # Inflation curve handle
         inflation_idx = build_hicp_index(
             EU_FIXING_DATA, self.inflation_ts_handle)
         inflation_ts = build_inflation_term_structure(
@@ -251,24 +249,24 @@ class InflationTest(unittest.TestCase):
         inflation_cf = ql.as_indexed_cashflow(
             zciis.inflationLeg()[0])
         # Obtaining base index for the inflation swap
-        swap_base_d = inflation_cf.baseDate()
-        swap_base_index = inflation_idx.fixing(swap_base_d)
+        swap_base_dt = inflation_cf.baseDate()
+        swap_base_fixing = inflation_idx.fixing(swap_base_dt)
         # Replicate fixing projection
-        fixing_d = inflation_cf.fixingDate()
-        ts_base_d = inflation_ts.baseDate()
-        ts_base_index = inflation_idx.fixing(ts_base_d)
+        fixing_dt = inflation_cf.fixingDate()
+        ts_base_dt = inflation_ts.baseDate()
+        ts_base_fixing = inflation_idx.fixing(ts_base_dt)
         # Apply FOM indexation rule
         effective_fixing_d = ql.Date(
-            1, fixing_d.month(), fixing_d.year())
+            1, fixing_dt.month(), fixing_dt.year())
         fraction = inflation_ts.dayCounter().yearFraction(
-            ts_base_d, effective_fixing_d)
+            ts_base_dt, effective_fixing_d)
         t = inflation_ts.timeFromReference(effective_fixing_d)
         zero_rate = inflation_ts.zeroRate(t)
-        expected_fixing = ts_base_index * (
+        expected_fixing = ts_base_fixing * (
             1.0 + zero_rate)**fraction
 
         expected_inflation_leg_payment = (
-            expected_fixing / swap_base_index - 1.0) * inflation_cf.notional()
+            expected_fixing / swap_base_fixing - 1.0) * inflation_cf.notional()
         actual_inflation_leg_payment = inflation_cf.amount()
 
         fail_msg = """ Failed to replicate inflation leg payment
@@ -470,22 +468,22 @@ class InflationTest(unittest.TestCase):
         swap_base_index = inflation_idx.fixing(swap_base_d)
 
         # Replicate fixing projection
-        fixing_d = inflation_cf.fixingDate()
-        ts_base_d = inflation_ts.baseDate()
-        ts_base_index = inflation_idx.fixing(ts_base_d)
+        fixing_dt = inflation_cf.fixingDate()
+        ts_base_dt = inflation_ts.baseDate()
+        ts_base_fixing = inflation_idx.fixing(ts_base_dt)
 
         # Apply linear indexation rule
         fraction = inflation_ts.dayCounter().yearFraction(
-            ts_base_d, fixing_d)
-        t = inflation_ts.timeFromReference(fixing_d)
+            ts_base_dt, fixing_dt)
+        t = inflation_ts.timeFromReference(fixing_dt)
         zero_rate = inflation_ts.zeroRate(t)
 
         # Calculate seasonality adjustment
         # Not that multiplicative seasonality is applied
-        seasonality_b = get_seasonality_factor(ts_base_d)
-        seasonality_f = get_seasonality_factor(fixing_d)
+        seasonality_b = get_seasonality_factor(ts_base_dt)
+        seasonality_f = get_seasonality_factor(fixing_dt)
 
-        expected_fixing = ts_base_index * (
+        expected_fixing = ts_base_fixing * (
             seasonality_f / seasonality_b) * (1.0 + zero_rate)**fraction
 
         expected_inf_leg_payment = (

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -342,7 +342,7 @@ class InflationTest(unittest.TestCase):
             msg=fail_msg)
 
     def test_inflation_curve_base_fixing(self):
-        """Testing inflation curve base fixing"""
+        """Testing inflation curve base fixing for linear indexation"""
 
         inflation_idx = build_hicp_index(
             EU_FIXING_DATA, self.inflation_ts_handle, interpolated=True)
@@ -352,6 +352,7 @@ class InflationTest(unittest.TestCase):
             inflation_idx,
             self.nominal_ts_handle)
         self.inflation_ts_handle.linkTo(inflation_ts)
+        
         curve_base_dt = inflation_ts.baseDate()
         curve_base_fixing = inflation_idx.fixing(curve_base_dt)
         expected_curve_base_fixing = interpolate_historic_index(

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -275,7 +275,7 @@ class InflationTest(unittest.TestCase):
             abs(zciis.NPV() < 1.e-5),
             msg="Failed to price zero coupon inflation swap to par.")
 
-        inflation_cf = ql.as_indexed_cash_flow(
+        inflation_cf = ql.as_indexed_cashflow(
             zciis.inflationLeg()[0])
 
         # Obtaining base index for the inflation swap
@@ -337,7 +337,7 @@ class InflationTest(unittest.TestCase):
             observation_lag)
         zciis.setPricingEngine(discount_engine)
 
-        inflation_cf = ql.as_indexed_cash_flow(
+        inflation_cf = ql.as_indexed_cashflow(
             zciis.inflationLeg()[0])
 
         # Replicate base index for the inflation swap
@@ -422,7 +422,7 @@ class InflationTest(unittest.TestCase):
             observation_lag)
         zciis.setPricingEngine(discount_engine)
 
-        inflation_cf = ql.as_indexed_cash_flow(
+        inflation_cf = ql.as_indexed_cashflow(
             zciis.inflationLeg()[0])
 
         # Obtaining base index for the inflation swap

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -198,7 +198,6 @@ class InflationTest(unittest.TestCase):
             self.nominal_ts_handle)
         self.inflation_ts_handle.linkTo(inflation_ts)
 
-        # Create par inflation swap
         zciis = create_inflation_swap(
             inflation_idx,
             VALUATION_DATE,
@@ -410,7 +409,6 @@ class InflationTest(unittest.TestCase):
         expected_fixing = curve_base_fixing * (
             1.0 + zero_rate)**fraction
 
-        # Assert inflation leg projected amount
         swap_base_fixing = inflation_idx.fixing(inflation_cf.baseDate())
         expected_inf_leg_payment = (
             expected_fixing / swap_base_fixing - 1.0) * inflation_cf.notional()

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -37,7 +37,8 @@ EUR_BEI_SWAP_RATES = [(ql.Period(1, ql.Years), 0.0301),
                       (ql.Period(5, ql.Years), 0.0315),
                       (ql.Period(10, ql.Years), 0.0355)]
 
-# TODO: Include source.
+# Source: 
+# https://ec.europa.eu/eurostat/web/products-datasets/-/teicp240.
 EU_FIXING_DATA = [(ql.Date(1, ql.April, 2018), 103.11),
                   (ql.Date(1, ql.May, 2018), 103.64),
                   (ql.Date(1, ql.June, 2018), 103.76),

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -205,7 +205,6 @@ class InflationTest(unittest.TestCase):
             0.0355)
         zciis.setPricingEngine(self.discount_engine)
         npv = zciis.NPV()
-
         # Check whether swap prices to par
         fail_msg = """ Failed to price zero coupon inflation swap to par:
                             index: {inflation_idx}
@@ -459,22 +458,18 @@ class InflationTest(unittest.TestCase):
 
         inflation_cf = ql.as_indexed_cashflow(
             zciis.inflationLeg()[0])
-
         # Obtaining base index for the inflation swap
         swap_base_dt = inflation_cf.baseDate()
         swap_base_fixing = inflation_idx.fixing(swap_base_dt)
-
         # Replicate fixing projection
         fixing_dt = inflation_cf.fixingDate()
         ts_base_dt = inflation_ts.baseDate()
         ts_base_fixing = inflation_idx.fixing(ts_base_dt)
-
         # Apply linear indexation rule
         fraction = inflation_ts.dayCounter().yearFraction(
             ts_base_dt, fixing_dt)
         t = inflation_ts.timeFromReference(fixing_dt)
         zero_rate = inflation_ts.zeroRate(t)
-
         # Calculate seasonality adjustment
         # Not that multiplicative seasonality is applied
         seasonality_base_dt = get_seasonality_factor(ts_base_dt)

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -95,7 +95,6 @@ def build_hicp_index(
     for x in fixing_data:
         # force override in case of multiple use
         index.addFixing(x[0], x[1], True)
-
     return index
 
 
@@ -106,9 +105,9 @@ SEASONAL = {ql.January: 1.0, ql.February: 1.01, ql.March: 1.011,
             ql.November: 1.0067, ql.December: 1.0055}
 
 
-def construct_seasonality(evaluation_date):
+def construct_seasonality(reference_date):
     frequency = ql.Monthly
-    seasonality_base_date = ql.Date(1, ql.January, evaluation_date.year())
+    seasonality_base_date = ql.Date(1, ql.January, reference_date.year())
     factors = list(SEASONAL.values())
     return ql.MultiplicativePriceSeasonality(
         seasonality_base_date, frequency, factors)
@@ -225,7 +224,7 @@ class InflationTest(unittest.TestCase):
                               expected_npv=0.0,
                               tolerance=EPSILON)
         self.assertTrue(
-            abs(npv < EPSILON),
+            abs(npv) < EPSILON,
             msg=fail_msg)
 
     def test_inflation_leg_payment_fom_indexation_without_seasonality(self):

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -37,7 +37,7 @@ EUR_BEI_SWAP_RATES = [(ql.Period(1, ql.Years), 0.0301),
                       (ql.Period(5, ql.Years), 0.0315),
                       (ql.Period(10, ql.Years), 0.0355)]
 
-#TODO: Include source.
+# TODO: Include source.
 EU_FIXING_DATA = [(ql.Date(1, ql.April, 2018), 103.11),
                   (ql.Date(1, ql.May, 2018), 103.64),
                   (ql.Date(1, ql.June, 2018), 103.76),
@@ -57,13 +57,13 @@ OBSERVATION_LAG = ql.Period(3, ql.Months)
 
 def create_inflation_helper(
         reference_date,
-        inflation_data: Tuple[ql.Period, float],
-        inflation_index: ql.ZeroInflationIndex,
-        observation_lag: ql.Period,
-        calendar: ql.Calendar,
+        inflation_data,
+        inflation_index,
+        observation_lag,
+        calendar,
         business_day_convention,
-        day_counter: ql.DayCounter,
-        discount_curve_handle: ql.YieldTermStructureHandle):
+        day_counter,
+        discount_curve_handle):
     maturity = CAL.advance(reference_date, inflation_data[0])
     quote = ql.QuoteHandle(ql.SimpleQuote(inflation_data[1]))
     return ql.ZeroCouponInflationSwapHelper(
@@ -79,7 +79,7 @@ def create_inflation_helper(
 
 def build_nominal_term_structure(
         reference_date,
-        nominal_data: List[Tuple[ql.Date, float]]) -> ql.YieldTermStructure:
+        nominal_data):
     nominal_dc = ql.Actual365Fixed()
     dates = [CAL.advance(reference_date, x[0]) for x in nominal_data]
     rates = [x[1] for x in nominal_data]
@@ -87,9 +87,9 @@ def build_nominal_term_structure(
 
 
 def build_hicp_index(
-        fixing_data: List[Tuple[ql.Date, float]],
-        inflation_crv_handle: ql.ZeroInflationTermStructureHandle,
-        interpolated: bool = False) -> ql.ZeroInflationIndex:
+        fixing_data,
+        inflation_crv_handle,
+        interpolated=False):
     index = ql.EUHICP(interpolated, inflation_crv_handle)
     for x in fixing_data:
         # force override in case of multiple use
@@ -105,7 +105,7 @@ SEASONAL = {ql.January: 1.0, ql.February: 1.01, ql.March: 1.011,
             ql.November: 1.0067, ql.December: 1.0055}
 
 
-def construct_seasonality(evaluation_date: ql.Date) -> ql.Seasonality:
+def construct_seasonality(evaluation_date):
     frequency = ql.Monthly
     seasonality_base_date = ql.Date(1, ql.January, evaluation_date.year())
     factors = list(SEASONAL.values())
@@ -113,17 +113,17 @@ def construct_seasonality(evaluation_date: ql.Date) -> ql.Seasonality:
         seasonality_base_date, frequency, factors)
 
 
-def get_seasonality_factor(d: ql.Date):
+def get_seasonality_factor(d):
     return SEASONAL[d.month()]
 
 
 def build_inflation_term_structure(
-        reference_date: ql.Date,
-        zero_coupon_data: List[Tuple[ql.Period, float]],
-        inflation_index: ql.ZeroInflationIndex,
-        nominal_term_structure_handle: ql.YieldTermStructureHandle,
-        observation_lag: ql.Period,
-        include_seasonality: bool = False) -> ql.ZeroInflationTermStructure:
+        reference_date,
+        zero_coupon_data,
+        inflation_index,
+        nominal_term_structure_handle,
+        observation_lag,
+        include_seasonality=False):
     helpers = [create_inflation_helper(reference_date,
                                        x,
                                        inflation_index,
@@ -151,11 +151,11 @@ def build_inflation_term_structure(
 
 
 def create_inflation_swap(
-        index: ql.ZeroInflationIndex,
-        start_date: ql.Date,
-        end_date: ql.Date,
-        rate: float,
-        observation_lag: ql.Period,
+        index,
+        start_date,
+        end_date,
+        rate,
+        observation_lag,
         nominal=1.e6,
         payer=ql.ZeroCouponInflationSwap.Payer):
     return ql.ZeroCouponInflationSwap(
@@ -246,10 +246,10 @@ class InflationTest(unittest.TestCase):
         inflation_idx = build_hicp_index(
             EU_FIXING_DATA, self.inflation_ts_handle, interpolated=True)
         inflation_ts = build_inflation_term_structure(
-            VALUATION_DATE, 
-            EUR_BEI_SWAP_RATES, 
-            inflation_idx, 
-            self.nominal_ts_handle, 
+            VALUATION_DATE,
+            EUR_BEI_SWAP_RATES,
+            inflation_idx,
+            self.nominal_ts_handle,
             OBSERVATION_LAG)
         self.inflation_ts_handle.linkTo(inflation_ts)
 
@@ -363,7 +363,7 @@ class InflationTest(unittest.TestCase):
         expected_inf_leg_payment = (
             expected_fixing / swap_base_index - 1.0) * inflation_cf.notional()
         actual_inf_leg_payment = inflation_cf.amount()
-        #TODO: improve error messages
+        # TODO: improve error messages
         self.assertAlmostEquals(
             first=actual_inf_leg_payment,
             second=expected_inf_leg_payment,

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -206,14 +206,12 @@ class InflationTest(unittest.TestCase):
         # Check whether swap prices to par
         fail_msg = """ Failed to price zero coupon inflation swap to par:
                             index: {inflation_idx}
-                            start date : {start_date}
                             end date: {end_date}
                             observation lag: {observation_lag}
                             npv: {npv}
                             expected npv: {expected_npv}
                             tolerance: {tolerance}
                    """.format(inflation_idx=inflation_idx.familyName(),
-                              start_date=zciis.startDate(),
                               end_date=zciis.maturityDate(),
                               observation_lag=OBSERVATION_LAG,
                               npv=npv,
@@ -268,14 +266,12 @@ class InflationTest(unittest.TestCase):
         fail_msg = """ Failed to replicate inflation leg payment
                        for First-Of-Month indexation:
                             index: {inflation_idx}
-                            start date : {start_date}
                             end date: {end_date}
                             observation lag: {observation_lag}
                             inflation leg payment: {actual_payment}
                             replicated payment: {expected_payment}
                             tolerance: {tolerance}
                    """.format(inflation_idx=inflation_idx.familyName(),
-                              start_date=zciis.startDate(),
                               end_date=zciis.maturityDate(),
                               observation_lag=OBSERVATION_LAG,
                               actual_payment=actual_inflation_leg_payment,
@@ -317,14 +313,12 @@ class InflationTest(unittest.TestCase):
         fail_msg = """ Failed to replicate inflation swap base index fixing
                        for linear indexation:
                             index: {inflation_idx}
-                            start date : {start_date}
                             end date: {end_date}
                             observation lag: {observation_lag}
                             base index fixing: {base_index}
                             replicated base index fixing: {expected_base_index}
                             tolerance: {tolerance}
                    """.format(inflation_idx=inflation_idx.familyName(),
-                              start_date=zciis.startDate(),
                               end_date=zciis.maturityDate(),
                               observation_lag=OBSERVATION_LAG,
                               base_index=swap_base_fixing,
@@ -409,17 +403,14 @@ class InflationTest(unittest.TestCase):
             expected_fixing / swap_base_fixing - 1.0) * inflation_cf.notional()
         actual_inf_leg_payment = inflation_cf.amount()
 
-        fail_msg = """ Failed to replicate inflation leg payment
-                       for linear indexation:
+        fail_msg = """ Failed to replicate inflation leg payment for linear indexation:
                             index: {inflation_idx}
-                            start date : {start_date}
                             end date: {end_date}
                             observation lag: {observation_lag}
                             inflation leg payment: {actual_payment}
                             replicated payment: {expected_payment}
                             tolerance: {tolerance}
                    """.format(inflation_idx=inflation_idx.familyName(),
-                              start_date=zciis.startDate(),
                               end_date=zciis.maturityDate(),
                               observation_lag=OBSERVATION_LAG,
                               actual_payment=actual_inf_leg_payment,
@@ -481,14 +472,12 @@ class InflationTest(unittest.TestCase):
         fail_msg = """ Failed to replicate inflation leg payment
                        for linear indexation and seasonality:
                             index: {inflation_idx}
-                            start date : {start_date}
                             end date: {end_date}
                             observation lag: {observation_lag}
                             inflation leg payment: {actual_payment}
                             replicated payment: {expected_payment}
                             tolerance: {tolerance}
                    """.format(inflation_idx=inflation_idx.familyName(),
-                              start_date=zciis.startDate(),
                               end_date=zciis.maturityDate(),
                               observation_lag=OBSERVATION_LAG,
                               actual_payment=actual_inf_leg_payment,

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -389,7 +389,6 @@ class InflationTest(unittest.TestCase):
             self.nominal_ts_handle)
         self.inflation_ts_handle.linkTo(inflation_ts)
 
-        # Create inflation swap
         zciis = create_inflation_swap(
             inflation_idx,
             ql.Date(24, ql.August, 2018),
@@ -401,10 +400,10 @@ class InflationTest(unittest.TestCase):
             zciis.inflationLeg()[0])
         # Replicate projected swap fixing
         # Apply linear indexation rule
-        fixing_d = inflation_cf.fixingDate()
+        fixing_dt = inflation_cf.fixingDate()
         fraction = inflation_ts.dayCounter().yearFraction(
-            inflation_ts.baseDate(), fixing_d)
-        t = inflation_ts.timeFromReference(fixing_d)
+            inflation_ts.baseDate(), fixing_dt)
+        t = inflation_ts.timeFromReference(fixing_dt)
         zero_rate = inflation_ts.zeroRate(t)
 
         curve_base_fixing = inflation_idx.fixing(inflation_ts.baseDate())

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -21,108 +21,51 @@ import QuantLib as ql
 from typing import List, Tuple
 
 
-UK_NOMINAL_DATA = [
-    (ql.Date(26, ql.November, 2009), 0.475),
-    (ql.Date(2, ql.December, 2009), 0.47498),
-    (ql.Date(29, ql.December, 2009), 0.49988),
-    (ql.Date(25, ql.February, 2010), 0.59955),
-    (ql.Date(18, ql.March, 2010), 0.65361),
-    (ql.Date(25, ql.May, 2010), 0.82830),
-    (ql.Date(16, ql.September, 2010), 0.78960),
-    (ql.Date(16, ql.December, 2010), 0.93762),
-    (ql.Date(17, ql.March, 2011), 1.12037),
-    (ql.Date(16, ql.June, 2011), 1.31308),
-    (ql.Date(22, ql.September, 2011), 1.52011),
-    (ql.Date(25, ql.November, 2011), 1.78399),
-    (ql.Date(26, ql.November, 2012), 2.41170),
-    (ql.Date(25, ql.November, 2013), 2.83935),
-    (ql.Date(25, ql.November, 2014), 3.12888),
-    (ql.Date(25, ql.November, 2015), 3.34298),
-    (ql.Date(25, ql.November, 2016), 3.50632),
-    (ql.Date(27, ql.November, 2017), 3.63666),
-    (ql.Date(26, ql.November, 2018), 3.74723),
-    (ql.Date(25, ql.November, 2019), 3.83988),
-    (ql.Date(25, ql.November, 2021), 4.00508),
-    (ql.Date(25, ql.November, 2024), 4.16042),
-    (ql.Date(26, ql.November, 2029), 4.15577),
-    (ql.Date(27, ql.November, 2034), 4.04933),
-    (ql.Date(25, ql.November, 2039), 3.95217),
-    (ql.Date(25, ql.November, 2049), 3.80932),
-    (ql.Date(25, ql.November, 2059), 3.80849),
-    (ql.Date(25, ql.November, 2069), 3.72677),
-    (ql.Date(27, ql.November, 2079), 3.63082)]
+EPSILON = 1.e-9
 
-EU_NOMINAL_DATA = [(ql.Date(28, ql.October, 2018), 0.475),
-                   (ql.Date(28, ql.October, 2019), 0.47498),
-                   (ql.Date(28, ql.October, 2020), 0.49988)]
+# Hypothetical market data
+EUR_ZERO_RATES = [(ql.Period(1, ql.Days), 0.0048),
+                  (ql.Period(1, ql.Years), 0.0048),
+                  (ql.Period(2, ql.Years), 0.00475),
+                  (ql.Period(3, ql.Years), 0.005),
+                  (ql.Period(5, ql.Years), 0.0055),
+                  (ql.Period(10, ql.Years), 0.007)]
 
-UK_FIXING_DATA = [
-    (ql.Date(20, ql.July, 2007), 206.1),
-    (ql.Date(20, ql.August, 2007), 207.3),
-    (ql.Date(20, ql.September, 2007), 208.0),
-    (ql.Date(22, ql.October, 2007), 208.9),
-    (ql.Date(20, ql.November, 2007), 209.7),
-    (ql.Date(20, ql.December, 2007), 210.9),
-    (ql.Date(21, ql.January, 2008), 209.8),
-    (ql.Date(20, ql.February, 2008), 211.4),
-    (ql.Date(20, ql.March, 2008), 212.1),
-    (ql.Date(21, ql.April, 2008), 214.0),
-    (ql.Date(20, ql.May, 2008), 215.1),
-    (ql.Date(21, ql.June, 2008), 216.8),
-    (ql.Date(20, ql.August, 2008), 216.5),
-    (ql.Date(22, ql.September, 2008), 217.2),
-    (ql.Date(20, ql.October, 2008), 218.4),
-    (ql.Date(20, ql.November, 2008), 217.7),
-    (ql.Date(22, ql.December, 2008), 216.0),
-    (ql.Date(20, ql.January, 2009), 212.9),
-    (ql.Date(20, ql.February, 2009), 210.1),
-    (ql.Date(20, ql.March, 2009), 211.4),
-    (ql.Date(20, ql.April, 2009), 211.3),
-    (ql.Date(20, ql.May, 2009), 211.5),
-    (ql.Date(22, ql.June, 2009), 212.8),
-    (ql.Date(20, ql.July, 2009), 213.4),
-    (ql.Date(20, ql.August, 2009), 213.4),
-    (ql.Date(21, ql.September, 2009), 213.4)]
+EUR_BEI_SWAP_RATES = [(ql.Period(1, ql.Years), 0.0301),
+                      (ql.Period(2, ql.Years), 0.0299),
+                      (ql.Period(3, ql.Years), 0.0305),
+                      (ql.Period(5, ql.Years), 0.0315),
+                      (ql.Period(10, ql.Years), 0.0355)]
 
-EU_FIXING_DATA = [(ql.Date(1, ql.June, 2018), 103.76),
+#TODO: Include source.
+EU_FIXING_DATA = [(ql.Date(1, ql.April, 2018), 103.11),
+                  (ql.Date(1, ql.May, 2018), 103.64),
+                  (ql.Date(1, ql.June, 2018), 103.76),
                   (ql.Date(1, ql.July, 2018), 103.41),
                   (ql.Date(1, ql.August, 2018), 103.58)]
 
-EU_ZERO_COUPON_DATA = [(ql.Date(28, ql.September, 2019), 3.0495),
-                       (ql.Date(28, ql.September, 2020), 2.93),
-                       (ql.Date(28, ql.September, 2021), 2.9795)]
+CAL = ql.TARGET()
 
-UK_ZERO_COUPON_DATA = [
-    (ql.Date(25, ql.November, 2010), 3.0495),
-    (ql.Date(25, ql.November, 2011), 2.93),
-    (ql.Date(26, ql.November, 2012), 2.9795),
-    (ql.Date(25, ql.November, 2013), 3.029),
-    (ql.Date(25, ql.November, 2014), 3.1425),
-    (ql.Date(25, ql.November, 2015), 3.211),
-    (ql.Date(25, ql.November, 2016), 3.2675),
-    (ql.Date(25, ql.November, 2017), 3.3625),
-    (ql.Date(25, ql.November, 2018), 3.405),
-    (ql.Date(25, ql.November, 2019), 3.48),
-    (ql.Date(25, ql.November, 2021), 3.576),
-    (ql.Date(25, ql.November, 2024), 3.649),
-    (ql.Date(26, ql.November, 2029), 3.751),
-    (ql.Date(27, ql.November, 2034), 3.77225),
-    (ql.Date(25, ql.November, 2039), 3.77),
-    (ql.Date(25, ql.November, 2049), 3.734),
-    (ql.Date(25, ql.November, 2059), 3.714)]
+DAY_COUNTER = ql.ActualActual()
+
+BDC = ql.ModifiedFollowing
+
+VALUATION_DATE = CAL.adjust(ql.Date(10, ql.September, 2018))
+
+OBSERVATION_LAG = ql.Period(3, ql.Months)
 
 
 def create_inflation_helper(
-    inflation_data: Tuple[ql.Date, float],
-    inflation_index: ql.ZeroInflationIndex,
-    observation_lag: ql.Period,
-    calendar: ql.Calendar,
-    business_day_convention,
-    day_counter: ql.DayCounter,
-    discount_curve_handle: ql.YieldTermStructureHandle
-) -> ql.ZeroCouponInflationSwapHelper:
-    maturity = inflation_data[0]
-    quote = ql.QuoteHandle(ql.SimpleQuote(inflation_data[1] / 100.0))
+        reference_date,
+        inflation_data: Tuple[ql.Period, float],
+        inflation_index: ql.ZeroInflationIndex,
+        observation_lag: ql.Period,
+        calendar: ql.Calendar,
+        business_day_convention,
+        day_counter: ql.DayCounter,
+        discount_curve_handle: ql.YieldTermStructureHandle):
+    maturity = CAL.advance(reference_date, inflation_data[0])
+    quote = ql.QuoteHandle(ql.SimpleQuote(inflation_data[1]))
     return ql.ZeroCouponInflationSwapHelper(
         quote,
         observation_lag,
@@ -135,33 +78,21 @@ def create_inflation_helper(
 
 
 def build_nominal_term_structure(
+        reference_date,
         nominal_data: List[Tuple[ql.Date, float]]) -> ql.YieldTermStructure:
     nominal_dc = ql.Actual365Fixed()
-    dates = [x[0] for x in nominal_data]
+    dates = [CAL.advance(reference_date, x[0]) for x in nominal_data]
     rates = [x[1] for x in nominal_data]
     return ql.ZeroCurve(dates, rates, nominal_dc)
-
-
-def build_ukrpi_index(
-        fixing_data: List[Tuple[ql.Date, float]],
-        inflation_crv_handle: ql.ZeroInflationTermStructureHandle,
-        interpolated: bool = False) -> ql.ZeroInflationIndex:
-    # uk rpi index fixing data
-    index = ql.UKRPI(interpolated, inflation_crv_handle)
-    for x in fixing_data:
-        # force override in case of multiple use
-        index.addFixing(x[0], x[1], True)
-
-    return index
 
 
 def build_hicp_index(
         fixing_data: List[Tuple[ql.Date, float]],
         inflation_crv_handle: ql.ZeroInflationTermStructureHandle,
         interpolated: bool = False) -> ql.ZeroInflationIndex:
-    # uk rpi index fixing data
     index = ql.EUHICP(interpolated, inflation_crv_handle)
     for x in fixing_data:
+        # force override in case of multiple use
         index.addFixing(x[0], x[1], True)
 
     return index
@@ -188,27 +119,25 @@ def get_seasonality_factor(d: ql.Date):
 
 def build_inflation_term_structure(
         reference_date: ql.Date,
-        zero_coupon_data: List[Tuple[ql.Date, float]],
+        zero_coupon_data: List[Tuple[ql.Period, float]],
         inflation_index: ql.ZeroInflationIndex,
         nominal_term_structure_handle: ql.YieldTermStructureHandle,
         observation_lag: ql.Period,
         include_seasonality: bool = False) -> ql.ZeroInflationTermStructure:
-    calendar = ql.TARGET()
-    payment_convention = ql.ModifiedFollowing
-    day_counter = ql.ActualActual()
-    helpers = [create_inflation_helper(x,
+    helpers = [create_inflation_helper(reference_date,
+                                       x,
                                        inflation_index,
                                        observation_lag,
-                                       calendar,
-                                       payment_convention,
-                                       day_counter,
+                                       CAL,
+                                       BDC,
+                                       DAY_COUNTER,
                                        nominal_term_structure_handle)
                for x in zero_coupon_data]
-    base_zero_rate = zero_coupon_data[0][1] / 100.0
+    base_zero_rate = zero_coupon_data[0][1]
     cpi_term_structure = ql.PiecewiseZeroInflation(
         reference_date,
-        calendar,
-        day_counter,
+        CAL,
+        DAY_COUNTER,
         observation_lag,
         inflation_index.frequency(),
         inflation_index.interpolated(),
@@ -226,53 +155,57 @@ def create_inflation_swap(
         start_date: ql.Date,
         end_date: ql.Date,
         rate: float,
-        observation_lag: ql.Period) -> ql.ZeroCouponInflationSwap:
-    payer = ql.ZeroCouponInflationSwap.Payer
-    calendar = ql.UnitedKingdom()
-    payment_convention = ql.ModifiedFollowing
-    day_counter = ql.ActualActual()
-    nominal = 1.e6
-    return ql.ZeroCouponInflationSwap(payer, nominal, start_date,
-                                      end_date, calendar, payment_convention,
-                                      day_counter, rate, index,
-                                      observation_lag)
+        observation_lag: ql.Period,
+        nominal=1.e6,
+        payer=ql.ZeroCouponInflationSwap.Payer):
+    return ql.ZeroCouponInflationSwap(
+        payer,
+        nominal,
+        start_date,
+        end_date,
+        CAL,
+        BDC,
+        DAY_COUNTER,
+        rate,
+        index,
+        observation_lag)
 
 
 class InflationTest(unittest.TestCase):
+    def setUp(self):
+        ql.Settings.instance().setEvaluationDate(VALUATION_DATE)
+        self.inflation_ts_handle = ql.RelinkableZeroInflationTermStructureHandle()
+        self.nominal_ts_handle = ql.RelinkableYieldTermStructureHandle()
+        self.nominal_ts_handle.linkTo(
+            build_nominal_term_structure(VALUATION_DATE, EUR_ZERO_RATES))
+        self.discount_engine = ql.DiscountingSwapEngine(self.nominal_ts_handle)
+
     def test_fom_indexation_without_seasonality(self):
         """Testing first of month indexation without seasonality"""
 
-        today = ql.Date(25, ql.November, 2009)
-        ql.Settings.instance().setEvaluationDate(today)
-
-        # Nominal term structure handle
-        nominal_ts_handle = ql.RelinkableYieldTermStructureHandle()
-        nominal_ts = build_nominal_term_structure(UK_NOMINAL_DATA)
-        nominal_ts_handle.linkTo(nominal_ts)
-        discount_engine = ql.DiscountingSwapEngine(nominal_ts_handle)
-
         # Inflation curve handle
-        inflation_ts_handle = ql.RelinkableZeroInflationTermStructureHandle()
-        inflation_index = build_ukrpi_index(
-            UK_FIXING_DATA, inflation_ts_handle)
-        observation_lag = ql.Period(2, ql.Months)
+        inflation_idx = build_hicp_index(
+            EU_FIXING_DATA, self.inflation_ts_handle)
         inflation_ts = build_inflation_term_structure(
-            today,
-            UK_ZERO_COUPON_DATA,
-            inflation_index,
-            nominal_ts_handle,
-            observation_lag)
-        inflation_ts_handle.linkTo(inflation_ts)
+            VALUATION_DATE,
+            EUR_BEI_SWAP_RATES,
+            inflation_idx,
+            self.nominal_ts_handle,
+            OBSERVATION_LAG)
+        self.inflation_ts_handle.linkTo(inflation_ts)
 
         # Create par inflation swap
         zciis = create_inflation_swap(
-            inflation_index, today, ql.Date(25, ql.November, 2059),
-            0.03714, observation_lag)
-        zciis.setPricingEngine(discount_engine)
+            inflation_idx,
+            VALUATION_DATE,
+            CAL.advance(VALUATION_DATE, ql.Period(10, ql.Years)),
+            0.0355,
+            OBSERVATION_LAG)
+        zciis.setPricingEngine(self.discount_engine)
 
         # Check whether swap prices to par
         self.assertTrue(
-            abs(zciis.NPV() < 1.e-5),
+            abs(zciis.NPV() < EPSILON),
             msg="Failed to price zero coupon inflation swap to par.")
 
         inflation_cf = ql.as_indexed_cashflow(
@@ -280,12 +213,12 @@ class InflationTest(unittest.TestCase):
 
         # Obtaining base index for the inflation swap
         swap_base_d = inflation_cf.baseDate()
-        swap_base_index = inflation_index.fixing(swap_base_d)
+        swap_base_index = inflation_idx.fixing(swap_base_d)
 
         # Replicate fixing projection
         fixing_d = inflation_cf.fixingDate()
         ts_base_d = inflation_ts.baseDate()
-        ts_base_index = inflation_index.fixing(ts_base_d)
+        ts_base_index = inflation_idx.fixing(ts_base_d)
 
         # Apply FOM indexation rule
         effective_fixing_d = ql.Date(
@@ -304,38 +237,30 @@ class InflationTest(unittest.TestCase):
         self.assertAlmostEquals(
             first=actual_inf_leg_payment,
             second=expected_inf_leg_payment,
-            delta=1.e-10,
+            delta=EPSILON,
             msg="Failed to replicate the inflation leg expected flow.")
 
     def test_linear_indexation_without_seasonality(self):
         """Testing linear indexation without seasonality"""
 
-        today = ql.Date(25, ql.November, 2009)
-        ql.Settings.instance().setEvaluationDate(today)
-
-        # Nominal term structure handle
-        nominal_ts_handle = ql.RelinkableYieldTermStructureHandle()
-        nominal_ts = build_nominal_term_structure(UK_NOMINAL_DATA)
-        nominal_ts_handle.linkTo(nominal_ts)
-        discount_engine = ql.DiscountingSwapEngine(nominal_ts_handle)
-
-        # Inflation curve handle
-        inflation_ts_handle = ql.RelinkableZeroInflationTermStructureHandle()
-        index = build_ukrpi_index(
-            UK_FIXING_DATA, inflation_ts_handle, interpolated=True)
-        observation_lag = ql.Period(3, ql.Months)
+        inflation_idx = build_hicp_index(
+            EU_FIXING_DATA, self.inflation_ts_handle, interpolated=True)
         inflation_ts = build_inflation_term_structure(
-            today, UK_ZERO_COUPON_DATA, index, nominal_ts_handle, observation_lag)
-        inflation_ts_handle.linkTo(inflation_ts)
+            VALUATION_DATE, 
+            EUR_BEI_SWAP_RATES, 
+            inflation_idx, 
+            self.nominal_ts_handle, 
+            OBSERVATION_LAG)
+        self.inflation_ts_handle.linkTo(inflation_ts)
 
-        # Create par inflation swap
+        # Create inflation swap
         zciis = create_inflation_swap(
-            index,
-            ql.Date(25, ql.April, 2009),
-            ql.Date(25, ql.November, 2059),
-            0.038,
-            observation_lag)
-        zciis.setPricingEngine(discount_engine)
+            inflation_idx,
+            ql.Date(24, ql.August, 2018),
+            ql.Date(24, ql.August, 2023),
+            0.032,
+            OBSERVATION_LAG)
+        zciis.setPricingEngine(self.discount_engine)
 
         inflation_cf = ql.as_indexed_cashflow(
             zciis.inflationLeg()[0])
@@ -345,23 +270,24 @@ class InflationTest(unittest.TestCase):
             f_d = ql.Date(1, fixing_date.month(), fixing_date.year())
             s_d = ql.Date.endOfMonth(fixing_date) + 1
             slope = (fixing_date - f_d) / (
-                (s_d + observation_lag) - (f_d + observation_lag))
-            return index.fixing(f_d) + slope * (
-                index.fixing(s_d) - index.fixing(f_d))
+                (s_d + OBSERVATION_LAG) - (f_d + OBSERVATION_LAG))
+            return inflation_idx.fixing(f_d) + slope * (
+                inflation_idx.fixing(s_d) - inflation_idx.fixing(f_d))
 
         swap_base_d = inflation_cf.baseDate()
-        swap_base_index = index.fixing(swap_base_d)
+        swap_base_index = inflation_idx.fixing(swap_base_d)
         expected_swap_base_index = interpolate_historic_index(swap_base_d)
         self.assertAlmostEquals(
             first=swap_base_index,
             second=expected_swap_base_index,
+            delta=EPSILON,
             msg="Failed to replicate the base index on the inflation swap.")
 
         # Replicate projected swap fixing
         fixing_d = inflation_cf.fixingDate()
 
         ts_base_d = inflation_ts.baseDate()
-        ts_base_index = index.fixing(ts_base_d)
+        ts_base_index = inflation_idx.fixing(ts_base_d)
         expected_ts_base_index = interpolate_historic_index(ts_base_d)
         self.assertAlmostEquals(
             first=ts_base_index,
@@ -384,55 +310,42 @@ class InflationTest(unittest.TestCase):
         self.assertAlmostEquals(
             first=actual_inf_leg_payment,
             second=expected_inf_leg_payment,
-            delta=1.e-10,
+            delta=EPSILON,
             msg="Failed to replicate the inflation leg expected flow.")
 
     def test_linear_indexation_with_seasonality(self):
         """Testing linear indexation with seasonality"""
 
-        today = ql.Date(25, ql.November, 2009)
-        ql.Settings.instance().setEvaluationDate(today)
-
-        # Nominal term structure handle
-        nominal_ts_handle = ql.RelinkableYieldTermStructureHandle()
-        nominal_ts = build_nominal_term_structure(UK_NOMINAL_DATA)
-        nominal_ts_handle.linkTo(nominal_ts)
-        discount_engine = ql.DiscountingSwapEngine(nominal_ts_handle)
-
-        # Inflation curve handle
-        inflation_ts_handle = ql.RelinkableZeroInflationTermStructureHandle()
-        inflation_index = build_ukrpi_index(
-            UK_FIXING_DATA, inflation_ts_handle, interpolated=True)
-        observation_lag = ql.Period(3, ql.Months)
+        inflation_idx = build_hicp_index(
+            EU_FIXING_DATA, self.inflation_ts_handle, interpolated=True)
         inflation_ts = build_inflation_term_structure(
-            today,
-            UK_ZERO_COUPON_DATA,
-            inflation_index,
-            nominal_ts_handle,
-            observation_lag,
+            VALUATION_DATE,
+            EUR_BEI_SWAP_RATES,
+            inflation_idx,
+            self.nominal_ts_handle,
+            OBSERVATION_LAG,
             include_seasonality=True)
-        inflation_ts_handle.linkTo(inflation_ts)
+        self.inflation_ts_handle.linkTo(inflation_ts)
 
-        # Create par inflation swap
         zciis = create_inflation_swap(
-            inflation_index,
-            ql.Date(25, ql.April, 2009),
-            ql.Date(25, ql.November, 2059),
-            0.037,
-            observation_lag)
-        zciis.setPricingEngine(discount_engine)
+            inflation_idx,
+            ql.Date(25, ql.July, 2018),
+            ql.Date(25, ql.July, 2022),
+            0.03,
+            OBSERVATION_LAG)
+        zciis.setPricingEngine(self.discount_engine)
 
         inflation_cf = ql.as_indexed_cashflow(
             zciis.inflationLeg()[0])
 
         # Obtaining base index for the inflation swap
         swap_base_d = inflation_cf.baseDate()
-        swap_base_index = inflation_index.fixing(swap_base_d)
+        swap_base_index = inflation_idx.fixing(swap_base_d)
 
         # Replicate fixing projection
         fixing_d = inflation_cf.fixingDate()
         ts_base_d = inflation_ts.baseDate()
-        ts_base_index = inflation_index.fixing(ts_base_d)
+        ts_base_index = inflation_idx.fixing(ts_base_d)
 
         # Apply linear indexation rule
         fraction = inflation_ts.dayCounter().yearFraction(
@@ -450,10 +363,11 @@ class InflationTest(unittest.TestCase):
         expected_inf_leg_payment = (
             expected_fixing / swap_base_index - 1.0) * inflation_cf.notional()
         actual_inf_leg_payment = inflation_cf.amount()
+        #TODO: improve error messages
         self.assertAlmostEquals(
             first=actual_inf_leg_payment,
             second=expected_inf_leg_payment,
-            delta=1.e-10,
+            delta=EPSILON,
             msg="Failed to replicate the inflation leg expected flow.")
 
 

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -457,7 +457,7 @@ class InflationTest(unittest.TestCase):
         t = inflation_ts.timeFromReference(fixing_dt)
         zero_rate = inflation_ts.zeroRate(t)
         # Calculate seasonality adjustment
-        # Not that multiplicative seasonality is applied
+        # Note that multiplicative seasonality is applied
         seasonality_base_dt = get_seasonality_factor(ts_base_dt)
         seasonality_fixing_dt = get_seasonality_factor(fixing_dt)
 

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -229,6 +229,7 @@ class InflationTest(unittest.TestCase):
 
     def test_inflation_leg_payment_fom_indexation_without_seasonality(self):
         """Testing inflation leg payment for First-Of-Month indexation"""
+        
         inflation_idx = build_hicp_index(
             EU_FIXING_DATA, self.inflation_ts_handle)
         inflation_ts = build_inflation_term_structure(
@@ -255,11 +256,11 @@ class InflationTest(unittest.TestCase):
         ts_base_dt = inflation_ts.baseDate()
         ts_base_fixing = inflation_idx.fixing(ts_base_dt)
         # Apply FOM indexation rule
-        effective_fixing_d = ql.Date(
+        effective_fixing_dt = ql.Date(
             1, fixing_dt.month(), fixing_dt.year())
         fraction = inflation_ts.dayCounter().yearFraction(
-            ts_base_dt, effective_fixing_d)
-        t = inflation_ts.timeFromReference(effective_fixing_d)
+            ts_base_dt, effective_fixing_dt)
+        t = inflation_ts.timeFromReference(effective_fixing_dt)
         zero_rate = inflation_ts.zeroRate(t)
         expected_fixing = ts_base_fixing * (
             1.0 + zero_rate)**fraction
@@ -302,7 +303,6 @@ class InflationTest(unittest.TestCase):
             self.nominal_ts_handle)
         self.inflation_ts_handle.linkTo(inflation_ts)
 
-        # Create inflation swap
         zciis = create_inflation_swap(
             inflation_idx,
             ql.Date(24, ql.August, 2018),

--- a/Python/test/inflation.py
+++ b/Python/test/inflation.py
@@ -461,8 +461,8 @@ class InflationTest(unittest.TestCase):
             zciis.inflationLeg()[0])
 
         # Obtaining base index for the inflation swap
-        swap_base_d = inflation_cf.baseDate()
-        swap_base_index = inflation_idx.fixing(swap_base_d)
+        swap_base_dt = inflation_cf.baseDate()
+        swap_base_fixing = inflation_idx.fixing(swap_base_dt)
 
         # Replicate fixing projection
         fixing_dt = inflation_cf.fixingDate()
@@ -477,14 +477,15 @@ class InflationTest(unittest.TestCase):
 
         # Calculate seasonality adjustment
         # Not that multiplicative seasonality is applied
-        seasonality_b = get_seasonality_factor(ts_base_dt)
-        seasonality_f = get_seasonality_factor(fixing_dt)
+        seasonality_base_dt = get_seasonality_factor(ts_base_dt)
+        seasonality_fixing_dt = get_seasonality_factor(fixing_dt)
 
         expected_fixing = ts_base_fixing * (
-            seasonality_f / seasonality_b) * (1.0 + zero_rate)**fraction
+            seasonality_fixing_dt / seasonality_base_dt) * (
+                1.0 + zero_rate)**fraction
 
         expected_inf_leg_payment = (
-            expected_fixing / swap_base_index - 1.0) * inflation_cf.notional()
+            expected_fixing / swap_base_fixing - 1.0) * inflation_cf.notional()
         actual_inf_leg_payment = inflation_cf.amount()
 
         fail_msg = """ Failed to replicate inflation leg payment

--- a/Python/test/volatilities.py
+++ b/Python/test/volatilities.py
@@ -167,9 +167,9 @@ LOGNORM_VOL_MATRIX = ql.SwaptionVolatilityMatrix(
 
 
 def build_euribor_swap_idx(
-        projectionCurveHandle):
+        projection_curve_handle):
     return ql.EuriborSwapIsdaFixA(ql.Period(1, ql.Years),
-                                  projectionCurveHandle)
+                                  projection_curve_handle)
 
 
 def build_nominal_term_structure(valuation_date, nominal_quotes):


### PR DESCRIPTION
In this pull request I would like to suggest exposing a few unit tests in Python for zero coupon inflation swaps and the associated (zero inflation) term structure. The point is to show the replication of the payoffs using recently exposed as_indexed_cashflow function, demonstrate how the inflation index is projected under different indexation methods and how seasonality is incorporated. 