### PR TITLE
Exposing NoExceptLocalVolSurface to SWIG

### DIFF
--- a/SWIG/volatilities.i
+++ b/SWIG/volatilities.i
@@ -420,6 +420,29 @@ class LocalVolSurface : public LocalVolTermStructure {
 };
 
 
+
+// no except local vol surface (override bad points - use with care)
+%{
+using QuantLib::NoExceptLocalVolSurface;
+%}
+
+%shared_ptr(NoExceptLocalVolSurface);
+class NoExceptLocalVolSurface : public LocalVolSurface {
+  public:
+    NoExceptLocalVolSurface(const Handle<BlackVolTermStructure>& blackTS,
+                            const Handle<YieldTermStructure>& riskFreeTS,
+                            const Handle<YieldTermStructure>& dividendTS,
+                            const Handle<Quote>& underlying,
+                            Real illegalLocalVolOverwrite);
+    NoExceptLocalVolSurface(const Handle<BlackVolTermStructure>& blackTS,
+                            const Handle<YieldTermStructure>& riskFreeTS,
+                            const Handle<YieldTermStructure>& dividendTS,
+                            Real underlying,
+                            Real illegalLocalVolOverwrite);
+};
+
+
+
 // constant caplet constant term structure
 %{
 using QuantLib::ConstantOptionletVolatility;


### PR DESCRIPTION
NoExceptLocalVolSurface overrides bad points in the underlying local vol surface, which is powerful and would be a useful addition to SWIG.

This can be very dangerous if not used carefully, but is powerful for techniques that break due to non-arb-free vols at extreme moneyness and tenor (eg. FD SLV calibration)