### PR TITLE
Expose VolDeltaQuote's public methods in SWIG

### DIFF
--- a/SWIG/options.i
+++ b/SWIG/options.i
@@ -1966,6 +1966,11 @@ class DeltaVolQuote : public Quote {
                   DeltaVolQuote::DeltaType deltaType,
                   Time maturity,
                   DeltaVolQuote::AtmType atmType);
+
+    Real delta() const;
+    Time maturity() const;
+    AtmType atmType() const;
+    DeltaType deltaType() const;
 };
 
 %template(DeltaVolQuoteHandle) Handle<DeltaVolQuote>;


### PR DESCRIPTION
This will allow creation of vol surfaces from just a list of DeltaVolQuote objects