### PR TITLE
Expose localVolatility method of GBS-process to SWIG

### DIFF
--- a/SWIG/stochasticprocess.i
+++ b/SWIG/stochasticprocess.i
@@ -104,6 +104,7 @@ class GeneralizedBlackScholesProcess : public StochasticProcess1D {
       Handle<YieldTermStructure> dividendYield();
       Handle<YieldTermStructure> riskFreeRate();
       Handle<BlackVolTermStructure> blackVolatility();
+      Handle<LocalVolTermStructure> localVolatility();
 };
 
 %{


### PR DESCRIPTION
GeneralizedBlackScholesProcess internally calculates a local volatility surface, which is exposed by public method localVolatility(), but can't be accessed from SWIG. This would be helpful for debugging (ie. what is the surface that my process is using?).