### PR TITLE
Exposing MC forward-start option engines in SWIG

### DIFF
--- a/SWIG/options.i
+++ b/SWIG/options.i
@@ -1522,10 +1522,146 @@ typedef QuantoEngine<ForwardVanillaOption,AnalyticEuropeanEngine> QuantoForwardE
 
 
 %shared_ptr(ForwardEuropeanEngine)
-class ForwardEuropeanEngine: public PricingEngine {
+class ForwardEuropeanEngine : public PricingEngine {
   public:
     ForwardEuropeanEngine(const ext::shared_ptr<GeneralizedBlackScholesProcess>&);
 };
+
+
+%{
+using QuantLib::MCForwardEuropeanBSEngine;
+using QuantLib::MCForwardEuropeanHestonEngine;
+%}
+
+%shared_ptr(MCForwardEuropeanBSEngine<PseudoRandom>);
+%shared_ptr(MCForwardEuropeanBSEngine<LowDiscrepancy>);
+
+template <class RNG>
+class MCForwardEuropeanBSEngine : public PricingEngine {
+    #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
+    %feature("kwargs") MCForwardEuropeanBSEngine;
+    #endif
+  public:
+    %extend {
+        MCForwardEuropeanBSEngine(const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+                                  intOrNull timeSteps = Null<Size>(),
+                                  intOrNull timeStepsPerYear = Null<Size>(),
+                                  bool brownianBridge = false,
+                                  bool antitheticVariate = false,
+                                  intOrNull requiredSamples = Null<Size>(),
+                                  doubleOrNull requiredTolerance = Null<Real>(),
+                                  intOrNull maxSamples = Null<Size>(),
+                                  BigInteger seed = 0) {
+            return new MCForwardEuropeanBSEngine<RNG>(process,
+                                                      timeSteps,
+                                                      timeStepsPerYear,
+                                                      brownianBridge,
+                                                      antitheticVariate,
+                                                      requiredSamples,
+                                                      requiredTolerance,
+                                                      maxSamples,
+                                                      seed);
+        }
+    }
+};
+
+%template(MCPRForwardEuropeanBSEngine) MCForwardEuropeanBSEngine<PseudoRandom>;
+%template(MCLDForwardEuropeanBSEngine) MCForwardEuropeanBSEngine<LowDiscrepancy>;
+
+#if defined(SWIGPYTHON)
+%pythoncode %{
+    def MCForwardEuropeanBSEngine(process,
+                                  traits,
+                                  timeSteps=None,
+                                  timeStepsPerYear=None,
+                                  brownianBridge=False,
+                                  antitheticVariate=False,
+                                  requiredSamples=None,
+                                  requiredTolerance=None,
+                                  maxSamples=None,
+                                  seed=0):
+        traits = traits.lower()
+        if traits == "pr" or traits == "pseudorandom":
+            cls = MCPRForwardEuropeanBSEngine
+        elif traits == "ld" or traits == "lowdiscrepancy":
+            cls = MCLDForwardEuropeanBSEngine
+        else:
+            raise RuntimeError("unknown MC traits: %s" % traits);
+        return cls(process,
+                   timeSteps,
+                   timeStepsPerYear,
+                   brownianBridge,
+                   antitheticVariate,
+                   requiredSamples,
+                   requiredTolerance,
+                   maxSamples,
+                   seed)
+%}
+#endif
+
+
+%shared_ptr(MCForwardEuropeanHestonEngine<PseudoRandom>);
+%shared_ptr(MCForwardEuropeanHestonEngine<LowDiscrepancy>);
+
+template <class RNG>
+class MCForwardEuropeanHestonEngine : public PricingEngine {
+    #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
+    %feature("kwargs") MCForwardEuropeanHestonEngine;
+    #endif
+  public:
+    %extend {
+        MCForwardEuropeanHestonEngine(const ext::shared_ptr<HestonProcess>& process,
+                                      intOrNull timeSteps = Null<Size>(),
+                                      intOrNull timeStepsPerYear = Null<Size>(),
+                                      bool antitheticVariate = false,
+                                      intOrNull requiredSamples = Null<Size>(),
+                                      doubleOrNull requiredTolerance = Null<Real>(),
+                                      intOrNull maxSamples = Null<Size>(),
+                                      BigInteger seed = 0) {
+            return new MCForwardEuropeanHestonEngine<RNG>(process,
+                                                          timeSteps,
+                                                          timeStepsPerYear,
+                                                          antitheticVariate,
+                                                          requiredSamples,
+                                                          requiredTolerance,
+                                                          maxSamples,
+                                                          seed);
+        }
+    }
+};
+
+%template(MCPRForwardEuropeanHestonEngine) MCForwardEuropeanHestonEngine<PseudoRandom>;
+%template(MCLDForwardEuropeanHestonEngine) MCForwardEuropeanHestonEngine<LowDiscrepancy>;
+
+#if defined(SWIGPYTHON)
+%pythoncode %{
+    def MCForwardEuropeanHestonEngine(process,
+                                      traits,
+                                      timeSteps=None,
+                                      timeStepsPerYear=None,
+                                      antitheticVariate=False,
+                                      requiredSamples=None,
+                                      requiredTolerance=None,
+                                      maxSamples=None,
+                                      seed=0):
+        traits = traits.lower()
+        if traits == "pr" or traits == "pseudorandom":
+            cls = MCPRForwardEuropeanHestonEngine
+        elif traits == "ld" or traits == "lowdiscrepancy":
+            cls = MCLDForwardEuropeanHestonEngine
+        else:
+            raise RuntimeError("unknown MC traits: %s" % traits);
+        return cls(process,
+                   timeSteps,
+                   timeStepsPerYear,
+                   antitheticVariate,
+                   requiredSamples,
+                   requiredTolerance,
+                   maxSamples,
+                   seed)
+%}
+#endif
+
 
 %shared_ptr(QuantoEuropeanEngine)
 class QuantoEuropeanEngine : public PricingEngine {


### PR DESCRIPTION
Exposing the recently added Forward-Start MC engines in SWIG.

@lballabio I think I will need to ask for the Docker Image that the tests run on to be re-built, as this depends on a pull that was only recently merged into QuantLib (https://github.com/lballabio/QuantLib/pull/934)