### PR TITLE
Exposing Heston analytic forward european pricer to SWIG

### DIFF
--- a/SWIG/options.i
+++ b/SWIG/options.i
@@ -1527,11 +1527,37 @@ class ForwardEuropeanEngine : public PricingEngine {
     ForwardEuropeanEngine(const ext::shared_ptr<GeneralizedBlackScholesProcess>&);
 };
 
+%shared_ptr(QuantoEuropeanEngine)
+class QuantoEuropeanEngine : public PricingEngine {
+  public:
+    QuantoEuropeanEngine(const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+                         const Handle<YieldTermStructure>& foreignRiskFreeRate,
+                         const Handle<BlackVolTermStructure>& exchangeRateVolatility,
+                         const Handle<Quote>& correlation);
+};
+
+%shared_ptr(QuantoForwardEuropeanEngine)
+class QuantoForwardEuropeanEngine : public PricingEngine {
+  public:
+    QuantoForwardEuropeanEngine(const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+                                const Handle<YieldTermStructure>& foreignRiskFreeRate,
+                                const Handle<BlackVolTermStructure>& exchangeRateVolatility,
+                                const Handle<Quote>& correlation);
+};
+
 
 %{
+using QuantLib::AnalyticHestonForwardEuropeanEngine;
 using QuantLib::MCForwardEuropeanBSEngine;
 using QuantLib::MCForwardEuropeanHestonEngine;
 %}
+
+%shared_ptr(AnalyticHestonForwardEuropeanEngine)
+class AnalyticHestonForwardEuropeanEngine : public PricingEngine {
+  public:
+    AnalyticHestonForwardEuropeanEngine(const ext::shared_ptr<HestonProcess>& process,
+                                        Size integrationOrder = 144);
+};
 
 %shared_ptr(MCForwardEuropeanBSEngine<PseudoRandom>);
 %shared_ptr(MCForwardEuropeanBSEngine<LowDiscrepancy>);
@@ -1663,23 +1689,6 @@ class MCForwardEuropeanHestonEngine : public PricingEngine {
 #endif
 
 
-%shared_ptr(QuantoEuropeanEngine)
-class QuantoEuropeanEngine : public PricingEngine {
-  public:
-    QuantoEuropeanEngine(const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
-                         const Handle<YieldTermStructure>& foreignRiskFreeRate,
-                         const Handle<BlackVolTermStructure>& exchangeRateVolatility,
-                         const Handle<Quote>& correlation);
-};
-
-%shared_ptr(QuantoForwardEuropeanEngine)
-class QuantoForwardEuropeanEngine : public PricingEngine {
-  public:
-    QuantoForwardEuropeanEngine(const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
-                                const Handle<YieldTermStructure>& foreignRiskFreeRate,
-                                const Handle<BlackVolTermStructure>& exchangeRateVolatility,
-                                const Handle<Quote>& correlation);
-};
 
 
 %{


### PR DESCRIPTION
Exposing the newly added Heston forward european pricer (https://github.com/lballabio/QuantLib/pull/943) to SWIG.

Also re-uniting the QuantoEuropeanEngines with the ForwardEuropeanEngine, which someone (probably me...) had separated in a recent commit.

This pull request will require a re-build of the testing Docker image before it can pass, as it relies on recently-added QL code. Thanks!!