### PR TITLE
Makes Period equatable and comparable in C#

### DIFF
--- a/CSharp/Makefile.am
+++ b/CSharp/Makefile.am
@@ -20,9 +20,11 @@ NQuantLib.dll: $(BUILT_SOURCES)
 
 check-local: examples/BermudanSwaption.exe \
              examples/EquityOption.exe \
+             examples/Times.exe \
              examples/libNQuantLibc.so examples/NQuantLib.dll
 	$(MONO) ./examples/BermudanSwaption.exe
 	$(MONO) ./examples/EquityOption.exe
+	$(MONO) ./examples/Times.exe
 
 examples/%.exe: examples/%.cs
 	$(MCS) -nologo -target:exe -out:$@ -reference:NQuantLib.dll $<

--- a/CSharp/QuantLib.sln
+++ b/CSharp/QuantLib.sln
@@ -1,5 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31515.178
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BermudanSwaption", "examples\BermudanSwaption.csproj", "{1BEC49E8-122D-4CC9-9DAC-DD59F551E5E9}"
 	ProjectSection(ProjectDependencies) = postProject
 		{21183104-9963-4D4F-B7E8-C8A6169FD053} = {21183104-9963-4D4F-B7E8-C8A6169FD053}
@@ -22,6 +24,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NQuantLib", "csharp\NQuantL
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NQuantLibc", "cpp\QuantLibWrapper.vcxproj", "{21183104-9963-4D4F-B7E8-C8A6169FD053}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Times", "examples\Times.csproj", "{C93F5204-5BC9-4AB3-AC06-C2CCE166CEBD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
@@ -30,14 +34,6 @@ Global
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{928F98EE-7D50-457F-9304-A6818DCF1079}.Debug|Win32.ActiveCfg = Debug|Win32
-		{928F98EE-7D50-457F-9304-A6818DCF1079}.Debug|Win32.Build.0 = Debug|Win32
-		{928F98EE-7D50-457F-9304-A6818DCF1079}.Debug|x64.ActiveCfg = Debug|x64
-		{928F98EE-7D50-457F-9304-A6818DCF1079}.Debug|x64.Build.0 = Debug|x64
-		{928F98EE-7D50-457F-9304-A6818DCF1079}.Release|Win32.ActiveCfg = Release|Win32
-		{928F98EE-7D50-457F-9304-A6818DCF1079}.Release|Win32.Build.0 = Release|Win32
-		{928F98EE-7D50-457F-9304-A6818DCF1079}.Release|x64.ActiveCfg = Release|x64
-		{928F98EE-7D50-457F-9304-A6818DCF1079}.Release|x64.Build.0 = Release|x64
 		{1BEC49E8-122D-4CC9-9DAC-DD59F551E5E9}.Debug|Win32.ActiveCfg = Debug|Win32
 		{1BEC49E8-122D-4CC9-9DAC-DD59F551E5E9}.Debug|Win32.Build.0 = Debug|Win32
 		{1BEC49E8-122D-4CC9-9DAC-DD59F551E5E9}.Debug|x64.ActiveCfg = Debug|x64
@@ -46,14 +42,6 @@ Global
 		{1BEC49E8-122D-4CC9-9DAC-DD59F551E5E9}.Release|Win32.Build.0 = Release|Win32
 		{1BEC49E8-122D-4CC9-9DAC-DD59F551E5E9}.Release|x64.ActiveCfg = Release|x64
 		{1BEC49E8-122D-4CC9-9DAC-DD59F551E5E9}.Release|x64.Build.0 = Release|x64
-		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Debug|Win32.ActiveCfg = Debug|Win32
-		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Debug|Win32.Build.0 = Debug|Win32
-		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Debug|x64.ActiveCfg = Debug|x64
-		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Debug|x64.Build.0 = Debug|x64
-		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Release|Win32.ActiveCfg = Release|Win32
-		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Release|Win32.Build.0 = Release|Win32
-		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Release|x64.ActiveCfg = Release|x64
-		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Release|x64.Build.0 = Release|x64
 		{1FD947F1-D99E-46FB-8890-04E11E8340C2}.Debug|Win32.ActiveCfg = Debug|Win32
 		{1FD947F1-D99E-46FB-8890-04E11E8340C2}.Debug|Win32.Build.0 = Debug|Win32
 		{1FD947F1-D99E-46FB-8890-04E11E8340C2}.Debug|x64.ActiveCfg = Debug|x64
@@ -70,8 +58,35 @@ Global
 		{EF2AFADF-B632-4E95-BEB5-7B7109A9E4FD}.Release|Win32.Build.0 = Release|Win32
 		{EF2AFADF-B632-4E95-BEB5-7B7109A9E4FD}.Release|x64.ActiveCfg = Release|x64
 		{EF2AFADF-B632-4E95-BEB5-7B7109A9E4FD}.Release|x64.Build.0 = Release|x64
+		{928F98EE-7D50-457F-9304-A6818DCF1079}.Debug|Win32.ActiveCfg = Debug|Win32
+		{928F98EE-7D50-457F-9304-A6818DCF1079}.Debug|Win32.Build.0 = Debug|Win32
+		{928F98EE-7D50-457F-9304-A6818DCF1079}.Debug|x64.ActiveCfg = Debug|x64
+		{928F98EE-7D50-457F-9304-A6818DCF1079}.Debug|x64.Build.0 = Debug|x64
+		{928F98EE-7D50-457F-9304-A6818DCF1079}.Release|Win32.ActiveCfg = Release|Win32
+		{928F98EE-7D50-457F-9304-A6818DCF1079}.Release|Win32.Build.0 = Release|Win32
+		{928F98EE-7D50-457F-9304-A6818DCF1079}.Release|x64.ActiveCfg = Release|x64
+		{928F98EE-7D50-457F-9304-A6818DCF1079}.Release|x64.Build.0 = Release|x64
+		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Debug|Win32.ActiveCfg = Debug|Win32
+		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Debug|Win32.Build.0 = Debug|Win32
+		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Debug|x64.ActiveCfg = Debug|x64
+		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Debug|x64.Build.0 = Debug|x64
+		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Release|Win32.ActiveCfg = Release|Win32
+		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Release|Win32.Build.0 = Release|Win32
+		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Release|x64.ActiveCfg = Release|x64
+		{21183104-9963-4D4F-B7E8-C8A6169FD053}.Release|x64.Build.0 = Release|x64
+		{C93F5204-5BC9-4AB3-AC06-C2CCE166CEBD}.Debug|Win32.ActiveCfg = Debug|Win32
+		{C93F5204-5BC9-4AB3-AC06-C2CCE166CEBD}.Debug|Win32.Build.0 = Debug|Win32
+		{C93F5204-5BC9-4AB3-AC06-C2CCE166CEBD}.Debug|x64.ActiveCfg = Debug|x64
+		{C93F5204-5BC9-4AB3-AC06-C2CCE166CEBD}.Debug|x64.Build.0 = Debug|x64
+		{C93F5204-5BC9-4AB3-AC06-C2CCE166CEBD}.Release|Win32.ActiveCfg = Release|Win32
+		{C93F5204-5BC9-4AB3-AC06-C2CCE166CEBD}.Release|Win32.Build.0 = Release|Win32
+		{C93F5204-5BC9-4AB3-AC06-C2CCE166CEBD}.Release|x64.ActiveCfg = Release|x64
+		{C93F5204-5BC9-4AB3-AC06-C2CCE166CEBD}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D5A8DD18-AC31-4E40-A70A-11339ED8FAE8}
 	EndGlobalSection
 EndGlobal

--- a/CSharp/examples/Times.cs
+++ b/CSharp/examples/Times.cs
@@ -16,7 +16,7 @@
 */
 
 using System;
-using ql=QuantLib;
+using ql = QuantLib;
 
 namespace TimesTest
 {
@@ -28,10 +28,20 @@ namespace TimesTest
         [STAThread]
         static void Main(string[] args)
         {
-            var tenor = new ql.Period("3M");
-            Console.WriteLine(tenor.ToString());
-            Console.WriteLine(tenor.__repr__());
-            Console.WriteLine(tenor.__str__());
+            var tenor01Y = new ql.Period("01Y");
+            var tenor12M = new ql.Period("12M");
+
+            Console.WriteLine($"{tenor01Y}, {tenor01Y.GetHashCode()}");
+            Console.WriteLine($"{tenor12M}, {tenor12M.GetHashCode()}");
+
+            var tenor03M = new ql.Period("03M");
+            var tenor90D = new ql.Period("91D");
+
+            Console.WriteLine(tenor03M.ToString());
+            Console.WriteLine(tenor03M.__repr__());
+            Console.WriteLine(tenor03M.__str__());
+
+            tenor90D.CompareTo(tenor03M);
         }
     }
 }

--- a/CSharp/examples/Times.cs
+++ b/CSharp/examples/Times.cs
@@ -1,0 +1,38 @@
+/*
+ Copyright (C) 2021 Ralf Konrad Eckel
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+using System;
+using ql=QuantLib;
+
+namespace TimesTest
+{
+    class Times
+    {
+        /// <summary>
+        /// The main entry point for the application.
+        /// </summary>
+        [STAThread]
+        static void Main(string[] args)
+        {
+            var tenor = new ql.Period("3M");
+            Console.WriteLine(tenor.ToString());
+            Console.WriteLine(tenor.__repr__());
+            Console.WriteLine(tenor.__str__());
+        }
+    }
+}
+

--- a/CSharp/examples/Times.cs
+++ b/CSharp/examples/Times.cs
@@ -16,6 +16,8 @@
 */
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using ql = QuantLib;
 
 namespace TimesTest
@@ -28,20 +30,50 @@ namespace TimesTest
         [STAThread]
         static void Main(string[] args)
         {
+            var tenor03M = new ql.Period("03M");
+            var tenor06M = new ql.Period("06M");
             var tenor01Y = new ql.Period("01Y");
+            var tenor02Y = new ql.Period("02Y");
+
+            var periods = new List<ql.Period>() { tenor01Y, tenor02Y, tenor06M, tenor03M };
+            periods.Sort();
+
+            Debug.Assert(periods[0] == tenor03M);
+            Debug.Assert(periods[1] == tenor06M);
+            Debug.Assert(periods[2] == tenor01Y);
+            Debug.Assert(periods[3] == tenor02Y);
+
             var tenor12M = new ql.Period("12M");
 
-            Console.WriteLine($"{tenor01Y}, {tenor01Y.GetHashCode()}");
-            Console.WriteLine($"{tenor12M}, {tenor12M.GetHashCode()}");
+            Debug.Assert(tenor03M.CompareTo(tenor12M) < 0);
+            Debug.Assert(tenor06M.CompareTo(tenor12M) < 0);
+            Debug.Assert(tenor01Y.CompareTo(tenor12M) == 0);
+            Debug.Assert(tenor02Y.CompareTo(tenor12M) > 0);
 
-            var tenor03M = new ql.Period("03M");
-            var tenor90D = new ql.Period("91D");
+            Debug.Assert(tenor03M != tenor12M);
+            Debug.Assert(tenor06M != tenor12M);
+            Debug.Assert(tenor01Y == tenor12M);
+            Debug.Assert(tenor02Y != tenor12M);
 
-            Console.WriteLine(tenor03M.ToString());
-            Console.WriteLine(tenor03M.__repr__());
-            Console.WriteLine(tenor03M.__str__());
+            Debug.Assert(tenor01Y.ToString() == tenor12M.ToString());
+            Debug.Assert(tenor01Y.GetHashCode() == tenor12M.GetHashCode());
 
-            tenor90D.CompareTo(tenor03M);
+            var tenor91D = new ql.Period("91D");
+            Func<bool> compare91Dversus03MthrowsApplicationException = () =>
+            {
+                bool hasThrown = false;
+                try
+                {
+                    tenor91D.CompareTo(tenor03M);
+                }
+                catch (System.ApplicationException)
+                {
+                    hasThrown = true;
+                }
+                return hasThrown;
+            };
+
+            Debug.Assert(compare91Dversus03MthrowsApplicationException());
         }
     }
 }

--- a/CSharp/examples/Times.csproj
+++ b/CSharp/examples/Times.csproj
@@ -1,0 +1,137 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="../QuantLib.props" />
+  <PropertyGroup>
+    <ProjectType>Local</ProjectType>
+    <ProductVersion>9.0.21022</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{C93F5204-5BC9-4AB3-AC06-C2CCE166CEBD}</ProjectGuid>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
+    <AssemblyName>Times</AssemblyName>
+    <AssemblyOriginatorKeyFile>
+    </AssemblyOriginatorKeyFile>
+    <DefaultClientScript>JScript</DefaultClientScript>
+    <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
+    <DefaultTargetSchema>IE50</DefaultTargetSchema>
+    <DelaySign>false</DelaySign>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>TimesTest</RootNamespace>
+    <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+    <StartupObject>
+    </StartupObject>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|Win32'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <BaseAddress>285212672</BaseAddress>
+    <FileAlignment>4096</FileAlignment>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|Win32'">
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <BaseAddress>285212672</BaseAddress>
+    <Optimize>true</Optimize>
+    <FileAlignment>4096</FileAlignment>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <BaseAddress>285212672</BaseAddress>
+    <FileAlignment>4096</FileAlignment>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <BaseAddress>285212672</BaseAddress>
+    <Optimize>true</Optimize>
+    <FileAlignment>4096</FileAlignment>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System">
+      <Name>System</Name>
+    </Reference>
+    <Reference Include="System.Data">
+      <Name>System.Data</Name>
+    </Reference>
+    <Reference Include="System.Xml">
+      <Name>System.XML</Name>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Times.cs">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
+      <Visible>False</Visible>
+      <ProductName>Windows Installer 3.1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\csharp\NQuantLib.csproj">
+      <Project>{928f98ee-7d50-457f-9304-a6818dcf1079}</Project>
+      <Name>NQuantLib</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>copy "$(SolutionDir)cpp\bin\$(Platform)\$(Configuration)\NQuantLibc.dll" "$(TargetDir)"</PreBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/SWIG/date.i
+++ b/SWIG/date.i
@@ -7,6 +7,7 @@
  Copyright (C) 2014 Bitquant Research Laboratories (Asia) Ltd.
  Copyright (C) 2015 Klaus Spanderen
  Copyright (C) 2018 Matthias Lungwitz
+ Copyright (C) 2021 Ralf Konrad Eckel
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -174,6 +175,58 @@ enum Frequency {
 
 // time period
 
+#if defined(SWIGCSHARP)
+%typemap(csinterfaces) Period "global::System.IDisposable, global::System.IEquatable<Period>, global::System.IComparable, global::System.IComparable<Period>";
+%typemap(cscode) Period %{
+  public override string ToString() {
+    return this.__str__();
+  }
+
+  public override int GetHashCode() {
+    return ToString().GetHashCode();
+  }
+
+  public int CompareTo(object obj) {
+    if (obj != null && !(obj is Period))
+      throw new global::System.ArgumentException("Object must be of type Period.");
+
+    return CompareTo(obj as Period);
+  }
+
+  public int CompareTo(Period other) {
+    // All instances are greater than null
+    if (object.ReferenceEquals(other, null))
+      return 1;
+    else
+      return Period.compareTo(this, other);
+  }
+
+  public override bool Equals(object obj) {
+    return (obj != null) && (obj is Period) && Equals(obj as Period);
+  }
+
+  public bool Equals(Period other) {
+    return (this == other);
+  }
+
+  public static bool operator==(Period lhs, Period rhs) {
+    var lhsObject = (object)lhs;
+    var rhsObject = (object)rhs;
+    if (lhsObject == null && rhsObject == null)
+      return true;
+    if (lhsObject == null || rhsObject == null)
+      return false;
+
+    return Period.compareTo(lhs, rhs) == 0;
+  }
+
+  public static bool operator!=(Period lhs, Period rhs) {
+    return !(lhs == rhs);
+  }
+%}
+#endif
+
+
 %{
 using QuantLib::Period;
 using QuantLib::PeriodParser;
@@ -242,6 +295,14 @@ class Period {
             return *self < other  ? -1 :
                    *self == other ?  0 :
                                      1;
+        }
+        #endif
+
+        #if defined(SWIGCSHARP)
+        static int compareTo(const Period& lhs, const Period& rhs) {
+            return lhs < rhs  ? -1 :
+                   lhs == rhs ?  0 :
+                                 1;
         }
         #endif
     }

--- a/SWIG/date.i
+++ b/SWIG/date.i
@@ -212,16 +212,47 @@ enum Frequency {
   public static bool operator==(Period lhs, Period rhs) {
     var lhsObject = (object)lhs;
     var rhsObject = (object)rhs;
+
+    // null == null
     if (lhsObject == null && rhsObject == null)
       return true;
+
+    // null != (!null)
     if (lhsObject == null || rhsObject == null)
       return false;
 
-    return Period.compareTo(lhs, rhs) == 0;
+    return lhs.CompareTo(rhs) == 0;
   }
 
   public static bool operator!=(Period lhs, Period rhs) {
     return !(lhs == rhs);
+  }
+
+  public static bool operator<(Period lhs, Period rhs) {
+    var lhsObject = (object)lhs;
+    var rhsObject = (object)rhs;
+
+    // null == null, therefore (null < null) == false
+    if (lhsObject == null && rhsObject == null)
+      return false;
+
+    // All instances are greater than null
+    if (lhsObject == null)
+      return true;
+
+    return lhs.CompareTo(rhs) < 0;
+  }
+
+  public static bool operator<=(Period lhs, Period rhs) {
+    return (lhs < rhs) || (lhs == rhs);
+  }
+
+  public static bool operator>(Period lhs, Period rhs) {
+    return !(lhs <= rhs);
+  }
+
+  public static bool operator>=(Period lhs, Period rhs) {
+    return !(lhs < rhs);
   }
 %}
 #endif


### PR DESCRIPTION
Enables the use of sorting in enumerations or comparing for Periods
```c#
var tenor03M = new Period("03M");
var tenor06M = new Period("06M");
var tenor12M = new Period("12M");
var tenor01Y = new Period("01Y");
var tenor02Y = new Period("02Y");

var periods = new List<Period>() { tenor01Y, tenor02Y, tenor06M, tenor03M };
periods.Sort();

if (tenor12M == tenor01Y) {
    ...
}
```