### PR TITLE
Avoids current warnings on MSVC

### DIFF
--- a/SWIG/indexes.i
+++ b/SWIG/indexes.i
@@ -156,7 +156,7 @@ class OvernightIndex : public IborIndex {
                    const Handle<YieldTermStructure>& h =
                                     Handle<YieldTermStructure>());
     %extend {
-        ext::shared_ptr<OvernightIndex> clone(const Handle<YieldTermStructure>& h) {
+        ext::shared_ptr<OvernightIndex> clone(const Handle<YieldTermStructure>& h) const {
             return ext::dynamic_pointer_cast<OvernightIndex>(self->clone(h));
         }
     }

--- a/SWIG/ql.i
+++ b/SWIG/ql.i
@@ -197,3 +197,7 @@ QL_DEPRECATED_DISABLE_WARNING
 %include volatilitymodels.i
 %include zerocurve.i
 %include old_volatility.i
+
+%{
+QL_DEPRECATED_ENABLE_WARNING
+%}

--- a/SWIG/ql.i
+++ b/SWIG/ql.i
@@ -197,7 +197,3 @@ QL_DEPRECATED_DISABLE_WARNING
 %include volatilitymodels.i
 %include zerocurve.i
 %include old_volatility.i
-
-%{
-QL_DEPRECATED_ENABLE_WARNING
-%}

--- a/SWIG/ql.i
+++ b/SWIG/ql.i
@@ -114,6 +114,10 @@
 %rename(Divide)        __div__;
 #endif
 
+%{
+// we do not want to see the deprecated warnings here
+QL_DEPRECATED_DISABLE_WARNING
+%}
 
 %include common.i
 %include vectors.i

--- a/SWIG/swap.i
+++ b/SWIG/swap.i
@@ -51,8 +51,8 @@ class Swap : public Instrument {
          const std::vector<ext::shared_ptr<CashFlow> >& secondLeg);
     Swap(const std::vector<Leg>& legs,
          const std::vector<bool>& payer);
-    Date startDate();
-    Date maturityDate();
+    Date startDate() const;
+    Date maturityDate() const;
     const Leg & leg(Size i);
     Real legNPV(Size j) const;
     Real legBPS(Size k) const;

--- a/SWIG/volatilities.i
+++ b/SWIG/volatilities.i
@@ -661,12 +661,12 @@ class SwaptionVolCube1 : public SwaptionVolatilityCube {
     Matrix marketVolCube() const;
     Matrix volCubeAtmCalibrated() const;
     %extend {
-        ext::shared_ptr<SabrSmileSection> smileSection(Time optionTime, Time swapLength, bool extr = false) {
-            SwaptionVolatilityStructure* base = dynamic_cast<SwaptionVolatilityStructure*>($self);
+        ext::shared_ptr<SabrSmileSection> smileSection(Time optionTime, Time swapLength, bool extr = false) const {
+            SwaptionVolatilityStructure* base = dynamic_cast<SwaptionVolatilityStructure*>(const_cast<SwaptionVolCube1*>($self));
             return ext::dynamic_pointer_cast<SabrSmileSection>(base->smileSection(optionTime, swapLength, extr));
         }
-        ext::shared_ptr<SabrSmileSection> smileSection(const Period& optionTenor, const Period& swapTenor, bool extr = false) {
-            SwaptionVolatilityStructure* base = dynamic_cast<SwaptionVolatilityStructure*>($self);
+        ext::shared_ptr<SabrSmileSection> smileSection(const Period& optionTenor, const Period& swapTenor, bool extr = false) const {
+            SwaptionVolatilityStructure* base = dynamic_cast<SwaptionVolatilityStructure*>(const_cast<SwaptionVolCube1*>($self));
             return ext::dynamic_pointer_cast<SabrSmileSection>(base->smileSection(optionTenor, swapTenor, extr));
         }
     }

--- a/SWIG/volatilities.i
+++ b/SWIG/volatilities.i
@@ -662,11 +662,11 @@ class SwaptionVolCube1 : public SwaptionVolatilityCube {
     Matrix volCubeAtmCalibrated() const;
     %extend {
         ext::shared_ptr<SabrSmileSection> smileSection(Time optionTime, Time swapLength, bool extr = false) const {
-            SwaptionVolatilityStructure* base = dynamic_cast<SwaptionVolatilityStructure*>(const_cast<SwaptionVolCube1*>($self));
+            auto base = dynamic_cast<const SwaptionVolatilityStructure*>($self);
             return ext::dynamic_pointer_cast<SabrSmileSection>(base->smileSection(optionTime, swapLength, extr));
         }
         ext::shared_ptr<SabrSmileSection> smileSection(const Period& optionTenor, const Period& swapTenor, bool extr = false) const {
-            SwaptionVolatilityStructure* base = dynamic_cast<SwaptionVolatilityStructure*>(const_cast<SwaptionVolCube1*>($self));
+            auto base = dynamic_cast<const SwaptionVolatilityStructure*>($self);
             return ext::dynamic_pointer_cast<SabrSmileSection>(base->smileSection(optionTenor, swapTenor, extr));
         }
     }


### PR DESCRIPTION
I have fixed a couple of `const`-ness inconsistencies between inherited classes which produced `C#` warnings like
```
warning CS0108: 'SwaptionVolCube1.smileSection(double, double, bool)'
                 hides inherited member 'SwaptionVolatilityStructure.smileSection(double, double, bool)'. 
                 Use the new keyword if hiding was intended.
```

Also I have disabled all deprecated warnings globally in `SWIG/ql.i`. Not so sure about this one though. On the one hand (currently) there are a lot of deprecated warnings which makes it hard to see other, perhaps more severe warnings which should be fixed. On the other hand they might be useful?!