### PR TITLE
 Remove `ZeroCouponSwap`'s `startDate()` and `maturityDate()`

### DIFF
--- a/SWIG/swap.i
+++ b/SWIG/swap.i
@@ -51,8 +51,8 @@ class Swap : public Instrument {
          const std::vector<ext::shared_ptr<CashFlow> >& secondLeg);
     Swap(const std::vector<Leg>& legs,
          const std::vector<bool>& payer);
-    virtual Date startDate() const;
-    virtual Date maturityDate() const;
+    Date startDate() const;
+    Date maturityDate() const;
     const Leg & leg(Size i);
     Real legNPV(Size j) const;
     Real legBPS(Size k) const;


### PR DESCRIPTION
After https://github.com/lballabio/QuantLib/pull/1167 this would be the next logical step for the `SWIG`-interface from the `C#` perspective.

It changes
```csharp
public new Date ZeroCouponSwap.startDate() {...}
```
to
```csharp
public override Date ZeroCouponSwap.startDate() {...}
```
which is what we want in `C#`: [Difference between new and override](https://stackoverflow.com/a/1399151).

However currently we are not using `virtual` in the `SWIG`-interface, at least I have not found them in e.g. `observer.i`, `instrument.i` or `indexes.i` where I would expect them to be use.

Another possibility is to remove

https://github.com/lballabio/QuantLib-SWIG/blob/30119c83eb1c9bcbec7b64bc20d3a26f8e2214cf/SWIG/swap.i#L535-L536

in `ZeroCouponSwap`. I guess the `virtual` in `virtual Date Swap.startDate() const;` on the `C++` side would do the trick. However I have not tested it.

Any thoughts why there is no `virtual` used in the `SWIG`-interface? Was it not fully supported in earlier versions or does it have side effects on other (scripting) languages I am not aware of?


