### PR TITLE
Don't use deprecated `std::unary_function` in wrappers

### DIFF
--- a/SWIG/functions.i
+++ b/SWIG/functions.i
@@ -153,7 +153,7 @@ class UnaryFunctionDelegate {
     }
 };
 
-class UnaryFunction : public std::unary_function<Real, Real> {
+class UnaryFunction {
   public:
     UnaryFunction(UnaryFunctionDelegate* delegate)
     : delegate_(delegate) { }

--- a/SWIG/functions.i
+++ b/SWIG/functions.i
@@ -290,7 +290,7 @@ class UnaryFunctionDelegate {
     };
 };
 
-class UnaryFunction : public std::unary_function<Real, Real> {
+class UnaryFunction {
   public:
     UnaryFunction(UnaryFunctionDelegate* delegate)
     : delegate_(delegate) { }


### PR DESCRIPTION
I try to build csharp interface. An error occurred in the process of building with c++17.

The error was because c++17 no longer supports unary_function.