### PR TITLE
Use normalized period to generate hash

### DIFF
--- a/CSharp/examples/Times/Times.cs
+++ b/CSharp/examples/Times/Times.cs
@@ -197,9 +197,6 @@ namespace TimesTest
 
             #endregion
 
-            Console.WriteLine("test Period.ToString()");
-            testCase(tenor01Y.ToString() == tenor12M.ToString());
-
             Console.WriteLine("test Period.GetHashCode()");
             testCase(tenor01Y.GetHashCode() == tenor12M.GetHashCode());
 

--- a/SWIG/date.i
+++ b/SWIG/date.i
@@ -183,7 +183,7 @@ enum Frequency {
   }
 
   public override int GetHashCode() {
-    return ToString().GetHashCode();
+    return normalized().ToString().GetHashCode();
   }
 
   public int CompareTo(object obj) {
@@ -275,6 +275,7 @@ class Period {
     Integer length() const;
     TimeUnit units() const;
     Frequency frequency() const;
+    Period normalized() const;
     %extend {
         Period(const std::string& str) {
             return new Period(PeriodParser::parse(str));
@@ -340,7 +341,7 @@ class Period {
     #if defined(SWIGPYTHON)
     %pythoncode %{
     def __hash__(self):
-        return hash(str(self))
+        return hash(str(self.normalized()))
     %}
     #endif
 };

--- a/SWIG/ql.i
+++ b/SWIG/ql.i
@@ -30,7 +30,7 @@
 %{
 #include <ql/quantlib.hpp>
 
-#if QL_HEX_VERSION < 0x01250000
+#if QL_HEX_VERSION < 0x01260000
     #error using an old version of QuantLib, please update
 #endif
 


### PR DESCRIPTION
This assigns the same hash in Python and C# to `Period` instances that compare equal (such as 12M and 1Y, or 7D and 1W).

See https://github.com/lballabio/QuantLib/pull/1326 and https://github.com/lballabio/QuantLib/pull/1332.
