### PR TITLE
Replace Disposable<T> with T

### DIFF
--- a/SWIG/fdm.i
+++ b/SWIG/fdm.i
@@ -429,15 +429,15 @@ class FdmLinearOpCompositeProxy : public FdmLinearOpComposite {
         Py_XDECREF(pyResult);
     }
 
-    Disposable<Array> apply(const Array& r) const {
+    Array apply(const Array& r) const {
         return apply(r, "apply");        
     }
 
-    Disposable<Array> apply_mixed(const Array& r) const {
+    Array apply_mixed(const Array& r) const {
         return apply(r, "apply_mixed");        
     }
 
-    Disposable<Array> apply_direction(Size direction, const Array& r) const {
+    Array apply_direction(Size direction, const Array& r) const {
         PyObject* pyArray = SWIG_NewPointerObj(
             SWIG_as_voidptr(&r), SWIGTYPE_p_Array, 0);
             
@@ -450,9 +450,7 @@ class FdmLinearOpCompositeProxy : public FdmLinearOpComposite {
         return extractArray(pyResult, "apply_direction");        
     }
 
-    Disposable<Array> solve_splitting(
-        Size direction, const Array& r, Real s) const {
-
+    Array solve_splitting(Size direction, const Array& r, Real s) const {
         PyObject* pyArray = SWIG_NewPointerObj(
             SWIG_as_voidptr(&r), SWIGTYPE_p_Array, 0);
             
@@ -465,7 +463,7 @@ class FdmLinearOpCompositeProxy : public FdmLinearOpComposite {
         return extractArray(pyResult, "solve_splitting");        
     }
 
-    Disposable<Array> preconditioner(const Array& r, Real s) const {
+    Array preconditioner(const Array& r, Real s) const {
         PyObject* pyArray = SWIG_NewPointerObj(
             SWIG_as_voidptr(&r), SWIGTYPE_p_Array, 0);
             
@@ -478,9 +476,7 @@ class FdmLinearOpCompositeProxy : public FdmLinearOpComposite {
     }
 
   private:
-    Disposable<Array> apply(
-        const Array& r, const std::string& methodName) const {
-
+    Array apply(const Array& r, const std::string& methodName) const {
         PyObject* pyArray = SWIG_NewPointerObj(
             SWIG_as_voidptr(&r), SWIGTYPE_p_Array, 0);
             
@@ -554,24 +550,23 @@ class FdmLinearOpCompositeProxy : public FdmLinearOpComposite {
     Size size() const { return delegate_->size(); }
     void setTime(Time t1, Time t2) { delegate_->setTime(t1, t2); }
 
-    Disposable<Array> apply(const Array& r) const {
+    Array apply(const Array& r) const {
         Array retVal = delegate_->apply(r);
         return retVal;
     }
-    Disposable<Array> apply_mixed(const Array& r) const {
+    Array apply_mixed(const Array& r) const {
         Array retVal = delegate_->apply_mixed(r);
         return retVal;
     }        
-    Disposable<Array> apply_direction(Size direction, const Array& r) const {
+    Array apply_direction(Size direction, const Array& r) const {
         Array retVal = delegate_->apply_direction(direction, r);
         return retVal;
     }
-    Disposable<Array> solve_splitting(
-        Size direction, const Array& r, Real s) const {
+    Array solve_splitting(Size direction, const Array& r, Real s) const {
         Array retVal = delegate_->solve_splitting(direction, r, s);
         return retVal;
     }
-    Disposable<Array> preconditioner(const Array& r, Real s) const {
+    Array preconditioner(const Array& r, Real s) const {
         Array retVal = delegate_->preconditioner(r, s);
         return retVal;
     }

--- a/SWIG/functions.i
+++ b/SWIG/functions.i
@@ -25,7 +25,6 @@
 
 %{
 using QuantLib::CostFunction;
-using QuantLib::Disposable;
 %}
 
 #if defined(SWIGPYTHON)
@@ -132,7 +131,7 @@ class PyCostFunction : public CostFunction {
         Py_XDECREF(pyResult);
         return result;
     }
-    Disposable<Array> values(const Array& x) const {
+    Array values(const Array& x) const {
         QL_FAIL("Not implemented");
         // Should be straight forward to copy from a python list
         // to an array
@@ -246,7 +245,7 @@ class JavaCostFunction : public CostFunction {
       return delegate_->value(x);
     }
 
-    virtual Disposable<Array> values(const Array& x) const {
+    virtual Array values(const Array& x) const {
       Array retVal = delegate_->values(x);
       return retVal;
     }
@@ -262,7 +261,7 @@ class JavaCostFunction {
 
     virtual ~JavaCostFunction();
     virtual Real value(const Array& x ) const;
-    virtual Disposable<Array> values(const Array& x) const;
+    virtual Array values(const Array& x) const;
 
   private:
     CostFunctionDelegate* delegate_;
@@ -383,7 +382,7 @@ class DotNetCostFunction : public CostFunction {
       return delegate_->value(x);
     }
 
-    virtual Disposable<Array> values(const Array& x) const {
+    virtual Array values(const Array& x) const {
       Array retVal = delegate_->values(x);
       return retVal;
     }
@@ -399,7 +398,7 @@ class DotNetCostFunction {
 
     virtual ~DotNetCostFunction();
     virtual Real value(const Array& x ) const;
-    virtual Disposable<Array> values(const Array& x) const;
+    virtual Array values(const Array& x) const;
 
   private:
     CostFunctionDelegate* delegate_;

--- a/SWIG/linearalgebra.i
+++ b/SWIG/linearalgebra.i
@@ -651,16 +651,13 @@ class SVD {
 };
 
 %{
-using QuantLib::Disposable;
 using QuantLib::BiCGstab;
 using QuantLib::GMRES;
 %}
 
 #if defined(SWIGPYTHON)
 %{
-Disposable<Array> extractArray(
-    PyObject* source, const std::string& methodName) {
-      
+Array extractArray(PyObject* source, const std::string& methodName) {
     QL_ENSURE(source != NULL,
               "failed to call " + methodName + " on Python object");
 
@@ -707,7 +704,7 @@ class MatrixMultiplicationProxy {
         Py_XDECREF(matrixMult_);    
     }
     
-    Disposable<Array> operator()(const Array& x) const {
+    Array operator()(const Array& x) const {
         PyObject* pyArray = SWIG_NewPointerObj(
             SWIG_as_voidptr(&x), SWIGTYPE_p_Array, 0);
             
@@ -753,7 +750,7 @@ class MatrixMultiplicationProxy {
     MatrixMultiplicationProxy(MatrixMultiplicationDelegate* delegate)
     : delegate_(delegate) {}
     
-    Disposable<Array> operator()(const Array& x) const {
+    Array operator()(const Array& x) const {
         Array retVal = delegate_->apply(x);        
         return retVal;
     }

--- a/SWIG/ode.i
+++ b/SWIG/ode.i
@@ -21,10 +21,6 @@
 %include common.i
 %include functions.i
 
-%{
-using QuantLib::Disposable;
-%}
-
 #if defined(SWIGJAVA) || defined(SWIGCSHARP)
 
 %{
@@ -45,9 +41,7 @@ class OdeFct {
 
     virtual ~OdeFct() { }
 
-    const Disposable<std::vector<Real> > 
-        operator()(Real x, const std::vector<Real>& y) const {
-        
+    const std::vector<Real> operator()(Real x, const std::vector<Real>& y) const {
         std::vector<Real> retVal = delegate_->value(x, y);
         return retVal;
     }
@@ -89,9 +83,7 @@ class OdeFct {
         Py_XDECREF(function_);
     }
     
-    const Disposable<std::vector<Real> > operator()(
-        Real x, const std::vector<Real>& y) const {
-        
+    const std::vector<Real> operator()(Real x, const std::vector<Real>& y) const {
         PyObject* pyY = PyList_New(y.size());
         for (Size i=0; i < y.size(); ++i)
             PyList_SetItem(pyY, i, PyFloat_FromDouble(y[i]));

--- a/SWIG/volatilities.i
+++ b/SWIG/volatilities.i
@@ -1102,9 +1102,9 @@ class CmsMarket{
         Real weightedSpreadError(const Matrix& weights);
         Real weightedSpotNpvError(const Matrix& weights);
         Real weightedFwdNpvError(const Matrix& weights);
-        Disposable<Array> weightedSpreadErrors(const Matrix& weights);
-        Disposable<Array> weightedSpotNpvErrors(const Matrix& weights);
-        Disposable<Array> weightedFwdNpvErrors(const Matrix& weights);
+        Array weightedSpreadErrors(const Matrix& weights);
+        Array weightedSpotNpvErrors(const Matrix& weights);
+        Array weightedFwdNpvErrors(const Matrix& weights);
 };
 
 %{


### PR DESCRIPTION
`Disposable<T>` is deprecated in QuantLib and should be replaced with `T`.