### PR TITLE
Removing FDShoutEngine from options interface

### DIFF
--- a/SWIG/options.i
+++ b/SWIG/options.i
@@ -889,24 +889,6 @@ class MCDigitalEngine : public PricingEngine {
 // American engines
 
 %{
-using QuantLib::FDShoutEngine;
-using QuantLib::CrankNicolson;
-%}
-
-%shared_ptr(FDShoutEngine<CrankNicolson>);
-
-template <class S>
-class FDShoutEngine : public PricingEngine {
-  public:
-    FDShoutEngine(const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
-                  Size timeSteps = 100, Size gridPoints = 100,
-                  bool timeDependent = false);
-};
-
-%template(FDShoutEngine) FDShoutEngine<CrankNicolson>;
-
-
-%{
 using QuantLib::BaroneAdesiWhaleyApproximationEngine;
 %}
 


### PR DESCRIPTION
Hi!
I tried building the SWIG wrappers for _v1.27-dev_ and noticed that the now deleted FDShoutEngine prevents the library from properly building. This relates to https://github.com/lballabio/QuantLib/pull/1352. All seems to be fine after removing it here as well.

Best,
Fredrik
SEB