### PR TITLE
Map `pair<Size,Size>` to `pair<unsigned int, unsigned int>` for 32-bit compatibility

### DIFF
--- a/SWIG/vectors.i
+++ b/SWIG/vectors.i
@@ -49,10 +49,9 @@ namespace std {
     %template(DoublePair) pair<double,double>;
     %template(DoublePairVector) vector<pair<double,double> >;
     %template(PairDoubleVector) pair<vector<double>,vector<double> >;
+    %template(UnsignedIntPair) pair<unsigned int,unsigned int>;
 
 #if !defined(SWIGR)
-    %template(SizePair) pair<Size,Size>;
-
     %template(NodePair) pair<Date,double>;
     %template(NodeVector) vector<pair<Date,double> >;
 #endif

--- a/SWIG/volatilities.i
+++ b/SWIG/volatilities.i
@@ -586,12 +586,18 @@ class SwaptionVolatilityMatrix : public SwaptionVolatilityDiscrete {
         }
     }
     
-#if !defined(SWIGR)
-    std::pair<Size,Size> locate(const Date& optionDate,
-                                const Period& swapTenor) const;
-    std::pair<Size,Size> locate(Time optionTime,
-                                Time swapLength) const;
-#endif
+    %extend {
+        std::pair<unsigned int, unsigned int> locate(const Date& optionDate,
+                                                     const Period& swapTenor) const {
+            auto sizes = self->locate(optionDate, swapTenor);
+            return { (unsigned int)sizes.first, (unsigned int)sizes.second };
+        }
+        std::pair<unsigned int, unsigned int> locate(Time optionTime,
+                                                     Time swapLength) const {
+            auto sizes = self->locate(optionTime, swapLength);
+            return { (unsigned int)sizes.first, (unsigned int)sizes.second };
+        }
+    }
 
     VolatilityType volatilityType() const;
 };


### PR DESCRIPTION
The change in #477 was not working at least on 32-bit Windows.