### PR TITLE
Export Gaussian1dCapFloorEngine to Python

### DIFF
--- a/SWIG/gaussian1dmodel.i
+++ b/SWIG/gaussian1dmodel.i
@@ -229,9 +229,7 @@ class Gaussian1dCapFloorEngine : public PricingEngine {
                              const bool extrapolatePayoff = true,
                              const bool flatPayoffExtrapolation = false,
                              const Handle<YieldTermStructure> &discountCurve =
-                                                           Handle<YieldTermStructure>(),
-                             const Gaussian1dCapFloorEngine::Probabilities probabilities =
-                                                        Gaussian1dCapFloorEngine::None);
+                                                           Handle<YieldTermStructure>();
 };
 
 %shared_ptr(Gaussian1dSwaptionEngine)

--- a/SWIG/gaussian1dmodel.i
+++ b/SWIG/gaussian1dmodel.i
@@ -225,7 +225,7 @@ class Gaussian1dCapFloorEngine : public PricingEngine {
                              const bool extrapolatePayoff = true,
                              const bool flatPayoffExtrapolation = false,
                              const Handle<YieldTermStructure> &discountCurve =
-                                                           Handle<YieldTermStructure>();
+                                                           Handle<YieldTermStructure>());
 };
 
 %shared_ptr(Gaussian1dSwaptionEngine)

--- a/SWIG/gaussian1dmodel.i
+++ b/SWIG/gaussian1dmodel.i
@@ -219,11 +219,7 @@ using QuantLib::Gaussian1dFloatFloatSwaptionEngine;
 
 %shared_ptr(Gaussian1dCapFloorEngine)
 class Gaussian1dCapFloorEngine : public PricingEngine {
-//    #if defined(SWIGPYTHON)
-//    %rename(NoProb) None;
-//    #endif
-//  public:
-//    enum Probabilities { None, Naive, Digital };
+  public:
     Gaussian1dCapFloorEngine(const ext::shared_ptr<Gaussian1dModel> &model,
                              const int integrationPoints = 64, const Real stddevs = 7.0,
                              const bool extrapolatePayoff = true,

--- a/SWIG/gaussian1dmodel.i
+++ b/SWIG/gaussian1dmodel.i
@@ -210,11 +210,29 @@ class MarkovFunctional : public Gaussian1dModel {
 // Pricing Engines
 
 %{
+using QuantLib::Gaussian1dCapFloorEngine;
 using QuantLib::Gaussian1dSwaptionEngine;
 using QuantLib::Gaussian1dJamshidianSwaptionEngine;
 using QuantLib::Gaussian1dNonstandardSwaptionEngine;
 using QuantLib::Gaussian1dFloatFloatSwaptionEngine;
 %}
+
+%shared_ptr(Gaussian1dCapFloorEngine)
+class Gaussian1dCapFloorEngine : public PricingEngine {
+//    #if defined(SWIGPYTHON)
+//    %rename(NoProb) None;
+//    #endif
+//  public:
+//    enum Probabilities { None, Naive, Digital };
+    Gaussian1dCapFloorEngine(const ext::shared_ptr<Gaussian1dModel> &model,
+                             const int integrationPoints = 64, const Real stddevs = 7.0,
+                             const bool extrapolatePayoff = true,
+                             const bool flatPayoffExtrapolation = false,
+                             const Handle<YieldTermStructure> &discountCurve =
+                                                           Handle<YieldTermStructure>(),
+                             const Gaussian1dCapFloorEngine::Probabilities probabilities =
+                                                        Gaussian1dCapFloorEngine::None);
+};
 
 %shared_ptr(Gaussian1dSwaptionEngine)
 class Gaussian1dSwaptionEngine : public PricingEngine {


### PR DESCRIPTION
This is my first attempt to export new functionality to Python using SWIG interface. I exported Gaussian1d (aka HW1F) engine for pricing caps.