### PR TITLE
Use uniform naming for exported handle

### DIFF
--- a/SWIG/volatilities.i
+++ b/SWIG/volatilities.i
@@ -175,7 +175,8 @@ class YoYOptionletVolatilitySurface : public VolatilityTermStructure {
 };
 
 %template(YoYOptionletVolatilitySurfaceHandle) Handle<YoYOptionletVolatilitySurface>;
-%template(RelinkableYoYOptionletVolatilitySurface) RelinkableHandle<YoYOptionletVolatilitySurface>;
+%template(RelinkableYoYOptionletVolatilitySurfaceHandle) RelinkableHandle<YoYOptionletVolatilitySurface>;
+deprecate_feature(RelinkableYoYOptionletVolatilitySurface, RelinkableYoYOptionletVolatilitySurfaceHandle);
 
 
 %{


### PR DESCRIPTION
The old name is still available in Python as deprecated.  Currently we have no way to do so in other languages.