### PR TITLE
Minimal support for `boost::optional<bool>`

### DIFF
--- a/SWIG/common.i
+++ b/SWIG/common.i
@@ -58,6 +58,20 @@ if (PyBool_Check($input) || Py_None == $input)
 else
 	$1 = 0;
 }
+#else
+#if defined(SWIGCSHARP)
+%typemap(cscode) boost::optional<bool> %{
+    public static implicit operator OptionalBool(bool b) => new OptionalBool(b);
+%}
+#endif
+namespace boost {
+    template<class T>
+    class optional {
+      public:
+        optional(T t);
+    };
+}
+%template(OptionalBool) boost::optional<bool>;
 #endif
 
 %{


### PR DESCRIPTION
Python keeps relying on the existing typemaps.

For other languages, we export the class with a constructor taking a bool. For C#, we also define an implicit conversion from bool.