### PR TITLE
fix linkTo method

### DIFF
--- a/.build/r.build
+++ b/.build/r.build
@@ -9,4 +9,5 @@ echo 'CXX=clang++' >> ~/.R/Makevars
 && make -C R \
 && R CMD INSTALL ./R.Rcheck/QuantLib \
 && echo Test curves.R && Rscript ./R/demo/curves.R \
-&& echo Test european-option.R && Rscript ./R/demo/european-option.R
+&& echo Test european-option.R && Rscript ./R/demo/european-option.R \
+&& echo Test bonds.R && Rscript ./R/demo/bonds.R

--- a/R/demo/bonds.R
+++ b/R/demo/bonds.R
@@ -236,25 +236,11 @@ invisible(setCouponPricer(Bond_cashflows(floatingRateBond), pricer))
 
 
 ## Yield curve bootstrapping
-if (FALSE) {
-  # equivalent to the method in else
-  invisible(forecastingTermStructure$linkTo(depoSwapTermStructure))
-  invisible(discountingTermStructure$linkTo(bondDiscountingTermStructure))
-} else {
-  # equivalent to the previous method
-  invisible(RelinkableYieldTermStructureHandle_linkTo(forecastingTermStructure, depoSwapTermStructure))
-  invisible(RelinkableYieldTermStructureHandle_linkTo(discountingTermStructure, bondDiscountingTermStructure))
-}
-
+invisible(RelinkableYieldTermStructureHandle_linkTo(forecastingTermStructure, depoSwapTermStructure))
+invisible(RelinkableYieldTermStructureHandle_linkTo(discountingTermStructure, bondDiscountingTermStructure))
 
 ## We are using the depo & swap curve to estimate the future Libor rates
-if (FALSE) {
-  # equivalent to the method in else
-  liborTermStructure$linkTo(depoSwapTermStructure)
-} else {
-  # equivalent to the previous method
-  invisible(RelinkableYieldTermStructureHandle_linkTo(liborTermStructure, depoSwapTermStructure))
-}
+invisible(RelinkableYieldTermStructureHandle_linkTo(liborTermStructure, depoSwapTermStructure))
 
 ##
 df <- data.frame(zeroCoupon=c(Instrument_NPV(zeroCouponBond),

--- a/R/demo/bonds.R
+++ b/R/demo/bonds.R
@@ -149,7 +149,6 @@ discountingTermStructure <- RelinkableYieldTermStructureHandle()
 ## the one used for forward rate forecasting
 forecastingTermStructure <- RelinkableYieldTermStructureHandle()
 
-
 ########################################
 ##        BONDS TO BE PRICED           #
 ########################################
@@ -237,11 +236,25 @@ invisible(setCouponPricer(Bond_cashflows(floatingRateBond), pricer))
 
 
 ## Yield curve bootstrapping
-invisible(RelinkableQuoteHandle_linkTo(forecastingTermStructure, depoSwapTermStructure))
-invisible(RelinkableQuoteHandle_linkTo(discountingTermStructure, bondDiscountingTermStructure))
+if (FALSE) {
+  # equivalent to the method in else
+  invisible(forecastingTermStructure$linkTo(depoSwapTermStructure))
+  invisible(discountingTermStructure$linkTo(bondDiscountingTermStructure))
+} else {
+  # equivalent to the previous method
+  invisible(RelinkableYieldTermStructureHandle_linkTo(forecastingTermStructure, depoSwapTermStructure))
+  invisible(RelinkableYieldTermStructureHandle_linkTo(discountingTermStructure, bondDiscountingTermStructure))
+}
+
 
 ## We are using the depo & swap curve to estimate the future Libor rates
-invisible(RelinkableQuoteHandle_linkTo(liborTermStructure, depoSwapTermStructure))
+if (FALSE) {
+  # equivalent to the method in else
+  liborTermStructure$linkTo(depoSwapTermStructure)
+} else {
+  # equivalent to the previous method
+  invisible(RelinkableYieldTermStructureHandle_linkTo(liborTermStructure, depoSwapTermStructure))
+}
 
 ##
 df <- data.frame(zeroCoupon=c(Instrument_NPV(zeroCouponBond),


### PR DESCRIPTION
Hallo,
`RelinkableQuoteHandle_linkTo` is the wrong method for re-linking a `RelinkableYieldTermStructureHandle`.
the code should use either `RelinkableYieldTermStructureHandle_linkTo` or simply invoke the `$linkTo` method.
I put both of them in the code, with a comment specifying they are equivalent.

Thanks

