### PR TITLE
Allow passing compounding and frequency to `FixedRateLeg`

### DIFF
--- a/Python/test/QuantLibTestSuite.py
+++ b/Python/test/QuantLibTestSuite.py
@@ -26,7 +26,10 @@ from marketelements import MarketElementTest
 from integrals import IntegralTest
 from solvers1d import Solver1DTest
 from termstructures import TermStructureTest
-from bonds import FixedRateBondTest, FixedRateBondKwargsTest
+from bonds import (
+    FixedRateBondTest,
+    FixedRateBondKwargsTest,
+    AmortizingFixedRateBondTest)
 from ratehelpers import (
     FixedRateBondHelperTest,
     FxSwapRateHelperTest,
@@ -73,6 +76,7 @@ def test():
     suite.addTest(unittest.makeSuite(TermStructureTest, 'test'))
     suite.addTest(unittest.makeSuite(FixedRateBondTest, 'test'))
     suite.addTest(unittest.makeSuite(FixedRateBondKwargsTest, 'test'))
+    suite.addTest(unittest.makeSuite(AmortizingFixedRateBondTest, 'test'))
     suite.addTest(unittest.makeSuite(FixedRateBondHelperTest, 'test'))
     suite.addTest(unittest.makeSuite(CmsTest, 'test'))
     suite.addTest(unittest.makeSuite(AssetSwapTest, 'test'))

--- a/Python/test/bonds.py
+++ b/Python/test/bonds.py
@@ -257,10 +257,109 @@ class FixedRateBondKwargsTest(unittest.TestCase):
         )
         self.check_construction(bond)
 
+class AmortizingFixedRateBondTest(unittest.TestCase):
+    def test_interest_rates(self):
+        # see AmortizingBondTest::testBrazilianAmortizingFixedRateBond
+        # in the C++ test suite
+
+        nominals = [
+            1000       	, 983.33300000, 966.66648898, 950.00019204,
+            933.33338867, 916.66685434, 900.00001759, 883.33291726,
+            866.66619177, 849.99933423, 833.33254728, 816.66589633,
+            799.99937871, 783.33299165, 766.66601558, 749.99946306,
+            733.33297499, 716.66651646, 699.99971995, 683.33272661,
+            666.66624140, 649.99958536, 633.33294599, 616.66615618,
+            599.99951997, 583.33273330, 566.66633377, 549.99954356,
+            533.33290739, 516.66625403, 499.99963400, 483.33314619,
+            466.66636930, 449.99984658, 433.33320226, 416.66634063,
+            399.99968700, 383.33290004, 366.66635221, 349.99953317,
+            333.33290539, 316.66626012, 299.99948151, 283.33271031,
+            266.66594695, 249.99932526, 233.33262024, 216.66590450,
+            199.99931312, 183.33277035, 166.66617153, 149.99955437,
+            133.33295388, 116.66633464,  99.99973207,  83.33307672,
+             66.66646137,  49.99984602,  33.33324734,  16.66662367
+        ]
+
+        expected_amortizations = [
+            16.66700000, 16.66651102, 16.66629694, 16.66680337,
+            16.66653432, 16.66683675, 16.66710033, 16.66672548,
+            16.66685753, 16.66678695, 16.66665095, 16.66651761,
+            16.66638706, 16.66697606, 16.66655251, 16.66648807,
+            16.66645852, 16.66679651, 16.66699333, 16.66648520,
+            16.66665604, 16.66663937, 16.66678981, 16.66663620,
+            16.66678667, 16.66639952, 16.66679021, 16.66663617,
+            16.66665336, 16.66662002, 16.66648780, 16.66677688,
+            16.66652271, 16.66664432, 16.66686163, 16.66665363,
+            16.66678696, 16.66654783, 16.66681904, 16.66662777,
+            16.66664527, 16.66677860, 16.66677119, 16.66676335,
+            16.66662168, 16.66670502, 16.66671573, 16.66659137,
+            16.66654276, 16.66659882, 16.66661715, 16.66660049,
+            16.66661924, 16.66660257, 16.66665534, 16.66661534,
+            16.66661534, 16.66659867, 16.66662367, 16.66662367
+        ]
+
+        expected_coupons = [
+            5.97950399, 4.85474255, 5.27619136, 5.18522454,
+            5.33753111, 5.24221882, 4.91231709, 4.59116258,
+            4.73037674, 4.63940686, 4.54843737, 3.81920094,
+            4.78359948, 3.86733691, 4.38439657, 4.09359456,
+            4.00262671, 4.28531030, 3.82068947, 3.55165259,
+            3.46502778, 3.71720657, 3.62189368, 2.88388676,
+            3.58769952, 2.72800044, 3.38838360, 3.00196900,
+            2.91100034, 3.08940793, 2.59877059, 2.63809514,
+            2.42551945, 2.45615766, 2.59111761, 1.94857222,
+            2.28751141, 1.79268582, 2.19248291, 1.81913832,
+            1.90625855, 1.89350716, 1.48110584, 1.62031828,
+            1.38600825, 1.23425366, 1.39521333, 1.06968563,
+            1.03950542, 1.00065409, 0.90968563, 0.81871706,
+            0.79726493, 0.63678002, 0.57187676, 0.49829046,
+            0.32913418, 0.27290565, 0.19062560, 0.08662552
+        ]
+
+        settlementDays = 0
+        issueDate = ql.Date(2, ql.March, 2020)
+        maturityDate = ql.Date(2, ql.March, 2025)
+
+        schedule = ql.Schedule(issueDate,
+                               maturityDate,
+                               ql.Period(ql.Monthly),
+                               ql.Brazil(ql.Brazil.Settlement),
+                               ql.Unadjusted,
+                               ql.Unadjusted,
+                               ql.DateGeneration.Backward,
+                               False)
+
+        coupons = ql.FixedRateLeg(
+            schedule,
+            nominals = nominals,
+            couponRates = [0.0675],
+            dayCount = ql.Business252(ql.Brazil()),
+            compounding = ql.Compounded,
+            compoundingFrequency = ql.Annual,
+            paymentAdjustment = ql.Following,
+        )
+
+        bond = ql.Bond(
+            settlementDays,
+            schedule.calendar(),
+            issueDate,
+            coupons
+        )
+
+        tolerance = 1.0e-6
+        cashflows = bond.cashflows()
+
+        self.assertEqual(len(cashflows), 2 * len(nominals))
+
+        for k in range(len(nominals)):
+            self.assertEqual(round(expected_coupons[k], 5),  round(cashflows[2*k].amount(), 5))
+            self.assertEqual(round(expected_amortizations[k], 5), round(cashflows[2*k+1].amount(), 5))
+
 
 if __name__ == "__main__":
     print("testing QuantLib " + ql.__version__)
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(FixedRateBondTest, "test"))
     suite.addTest(unittest.makeSuite(FixedRateBondKwargsTest, "test"))
+    suite.addTest(unittest.makeSuite(AmortizingFixedRateBondTest, "test"))
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Python/test/bonds.py
+++ b/Python/test/bonds.py
@@ -346,7 +346,6 @@ class AmortizingFixedRateBondTest(unittest.TestCase):
             coupons
         )
 
-        tolerance = 1.0e-6
         cashflows = bond.cashflows()
 
         self.assertEqual(len(cashflows), 2 * len(nominals))

--- a/SWIG/cashflows.i
+++ b/SWIG/cashflows.i
@@ -638,10 +638,12 @@ Leg _FixedRateLeg(const Schedule& schedule,
                   BusinessDayConvention exCouponConvention = Unadjusted,
                   bool exCouponEndOfMonth = false,
                   const Calendar& paymentCalendar = Calendar(),
-                  const Natural paymentLag = 0) {
+                  const Natural paymentLag = 0,
+                  Compounding comp = Simple,
+                  Frequency freq = Annual) {
     return QuantLib::FixedRateLeg(schedule)
         .withNotionals(nominals)
-        .withCouponRates(couponRates,dayCount)
+        .withCouponRates(couponRates, dayCount, comp, freq)
         .withPaymentAdjustment(paymentAdjustment)
         .withPaymentCalendar(paymentCalendar.empty() ? schedule.calendar() : paymentCalendar)
         .withPaymentLag(paymentLag)
@@ -667,7 +669,9 @@ Leg _FixedRateLeg(const Schedule& schedule,
                   BusinessDayConvention exCouponConvention = Unadjusted,
                   bool exCouponEndOfMonth = false,
                   const Calendar& paymentCalendar = Calendar(),
-                  Natural paymentLag = 0);
+                  Natural paymentLag = 0,
+                  Compounding compounding = Simple,
+                  Frequency compoundingFrequency = Annual);
 
 %{
 Leg _IborLeg(const std::vector<Real>& nominals,


### PR DESCRIPTION
This might fix #520.