### PR TITLE
Pull Request for QuantLib-SWIG

### DIFF
--- a/Python/examples/callablebonds.py
+++ b/Python/examples/callablebonds.py
@@ -1,0 +1,73 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: py:light
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# # Callable bonds (Calls)
+#
+# This file is part of QuantLib, a free-software/open-source library
+# for financial quantitative analysts and developers - https://www.quantlib.org/
+#
+# QuantLib is free software: you can redistribute it and/or modify it under the
+# terms of the QuantLib license.  You should have received a copy of the
+# license along with this program; if not, please email
+# <quantlib-dev@lists.sf.net>. The license is also available online at
+# <https://www.quantlib.org/license.shtml>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
+
+import QuantLib as ql
+import numpy as np
+calcDate = ql.Date(16, 8, 2006) 
+ql.Settings.instance().evaluationDate = calcDate
+
+dayCount = ql.ActualActual(ql.ActualActual.Bond)
+rate = 0.0465
+termStructure = ql.FlatForward(calcDate, rate, dayCount, ql.Compounded, ql.Semiannual)
+term_Structure_Handle = ql.RelinkableYieldTermStructureHandle(termStructure)
+
+callabilitySchedule = ql.CallabilitySchedule()
+callPrice = 100.0
+callDate = ql.Date(15, ql.September, 2006); 
+nc = ql.NullCalendar()
+
+# Number of calldates is 24
+for i in range(0, 24):
+    callabilityPrice  = ql.BondPrice(callPrice, ql.BondPrice.Clean)
+    callabilitySchedule.append(ql.Callability(callabilityPrice, ql.Callability.Call, callDate))
+    callDate = nc.advance(callDate, 3, ql.Months)
+
+issueDate = ql.Date(16, ql.September, 2004)
+maturityDate = ql.Date(15, ql.September, 2012)
+calendar = ql.UnitedStates(ql.UnitedStates.GovernmentBond)
+tenor = ql.Period(ql.Quarterly)
+accrualConvention = ql.Unadjusted
+schedule = ql.Schedule(issueDate, maturityDate, tenor, calendar, accrualConvention, accrualConvention, ql.DateGeneration.Backward, False)
+
+settlement_days = 3
+faceAmount = 100
+accrual_daycount = ql.ActualActual(ql.ActualActual.Bond)
+coupon = 0.025
+bond = ql.CallableFixedRateBond(settlement_days, faceAmount, schedule, [coupon], accrual_daycount, ql.Following, faceAmount, issueDate, callabilitySchedule)
+
+def value_bond(a, s, grid_points, bond): 
+    model = ql.HullWhite(term_Structure_Handle, a, s)
+    engine = ql.TreeCallableFixedRateBondEngine(model, grid_points) 
+    bond.setPricingEngine(engine)
+    return bond
+
+value_bond(0.03, 0.15, 40, bond) 
+print("Bond price using clean price: ", bond.cleanPrice())
+print("Bond price using net present value: ", bond.NPV())

--- a/Python/examples/capsfloors.py
+++ b/Python/examples/capsfloors.py
@@ -1,0 +1,73 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: py:light
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# # Caps and Floors
+#
+# This file is part of QuantLib, a free-software/open-source library
+# for financial quantitative analysts and developers - https://www.quantlib.org/
+#
+# QuantLib is free software: you can redistribute it and/or modify it under the
+# terms of the QuantLib license.  You should have received a copy of the
+# license along with this program; if not, please email
+# <quantlib-dev@lists.sf.net>. The license is also available online at
+# <https://www.quantlib.org/license.shtml>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
+
+import QuantLib as ql
+
+calcDate = ql.Date(14, 6, 2016)
+ql.Settings.instance().evaluationDate = calcDate
+
+dates = [ql.Date(14,6,2016), ql.Date(14,9,2016),
+         ql.Date(14,12,2016), ql.Date(14,6,2017),
+         ql.Date(14,6,2019), ql.Date(14,6,2021),
+         ql.Date(15,6,2026), ql.Date(16,6,2031),
+         ql.Date(16,6,2036), ql.Date(14,6,2046)]
+
+yields = [0.000000, 0.006616, 0.007049, 0.007795,
+          0.009599, 0.011203, 0.015068, 0.017583,
+          0.018998, 0.020080]
+
+dayCount = ql.ActualActual(ql.ActualActual.Bond)
+calendar = ql.UnitedStates()
+interpolation = ql.Linear()
+compounding = ql.Compounded
+compoundingFrequency = ql.Annual
+term_structure = ql.ZeroCurve(dates, yields, dayCount, calendar, interpolation, compounding, compoundingFrequency)
+ts_handle = ql.YieldTermStructureHandle(term_structure)
+
+
+start_date = ql.Date(14, 6, 2016)
+end_date = ql.Date(14, 6 , 2026)
+period = ql.Period(3, ql.Months)
+calendar = ql.UnitedStates()
+buss_convention = ql.ModifiedFollowing
+rule = ql.DateGeneration.Forward
+end_of_month = False
+schedule = ql.Schedule(start_date, end_date, period, calendar, buss_convention, buss_convention, rule, end_of_month)
+
+iborIndex = ql.USDLibor(ql.Period(3, ql.Months), ts_handle)
+iborIndex.addFixing(ql.Date(10,6,2016), 0.0065560)
+ibor_leg = ql.IborLeg([1000000], schedule, iborIndex)
+
+strike = 0.02
+cap = ql.Cap(ibor_leg, [strike])
+vols = ql.QuoteHandle(ql.SimpleQuote(0.547295))
+engine = ql.BlackCapFloorEngine(ts_handle, vols)
+cap.setPricingEngine(engine) 
+print("Value of Caps given constant volatility:", cap.NPV())

--- a/Python/examples/treasuryfuturescontracts.py
+++ b/Python/examples/treasuryfuturescontracts.py
@@ -1,0 +1,165 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: py:light
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.4.2
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# # Treasury Futures Contracts
+#
+#
+# This file is part of QuantLib, a free-software/open-source library
+# for financial quantitative analysts and developers - https://www.quantlib.org/
+#
+# QuantLib is free software: you can redistribute it and/or modify it
+# under the terms of the QuantLib license.  You should have received a
+# # copy of the license along with this program; if not, please email
+# <quantlib-dev@lists.sf.net>. The license is also available online at
+# <https://www.quantlib.org/license.shtml>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
+
+#    This example shows how to set up a term structure and then price
+#    some simple bonds. The last part is dedicated to peripherical
+#    computations such as "Yield to Price" or "Price to Yield"
+
+# ### Imports
+import QuantLib as ql
+import math
+
+# ### Global Data
+calendar = ql.UnitedStates()
+businessConvention = ql.ModifiedFollowing
+settlementDays = 0
+daysCount = ql.ActualActual(ql.ActualActual.Bond)
+
+# ### Option on Treasury Futures Contracts
+
+# ### 2-Year Note 
+
+interestRate = 0.003
+calcDate = ql.Date(1,12,2023)
+yieldCurve = ql.FlatForward(calcDate, interestRate, daysCount, ql.Compounded, ql.Continuous)
+
+ql.Settings.instance().evaluationDate = calcDate
+optionMaturityDate = ql.Date(24,12,2025)
+strike = 100
+spot = 125 # spot price is the futures price
+volatility = 20/100.
+optionType = ql.Option.Call
+
+discount = yieldCurve.discount(optionMaturityDate)
+strikepayoff = ql.PlainVanillaPayoff(optionType, strike)
+T = yieldCurve.dayCounter().yearFraction(calcDate, optionMaturityDate)
+
+stddev = volatility*math.sqrt(T)
+
+black = ql.BlackCalculator(strikepayoff, spot, stddev, discount)
+
+print("%-20s: %4.4f" %("Option Price for Treasury Futures Contract (2-Year Note)", black.value() )) 
+print("%-20s: %4.4f" %("Delta", black.delta(spot)))
+print("%-20s: %4.4f" %("Gamma", black.gamma(spot)))
+print("%-20s: %4.4f" %("Theta", black.theta(spot, T))) 
+print("%-20s: %4.4f" %("Vega", black.vega(T)))
+print("%-20s: %4.4f" %("Rho", black.rho( T)))
+
+# ------------------------------------------------------- #
+
+# ### 3-Year Note
+
+interestRate = 0.003
+calcDate = ql.Date(1,12,2023)
+yieldCurve = ql.FlatForward(calcDate, interestRate, daysCount, ql.Compounded, ql.Continuous)
+
+ql.Settings.instance().evaluationDate = calcDate
+optionMaturityDate = ql.Date(24,12,2026)
+strike = 100
+spot = 125 # spot price is the futures price
+volatility = 20/100.
+optionType = ql.Option.Call
+
+discount = yieldCurve.discount(optionMaturityDate)
+strikepayoff = ql.PlainVanillaPayoff(optionType, strike)
+T = yieldCurve.dayCounter().yearFraction(calcDate, optionMaturityDate)
+
+stddev = volatility*math.sqrt(T)
+black = ql.BlackCalculator(strikepayoff, spot, stddev, discount)
+
+print("%-20s: %4.4f" %("Option Price for Treasury Futures Contract (3-Year Note)", black.value() )) 
+print("%-20s: %4.4f" %("Delta", black.delta(spot)))
+print("%-20s: %4.4f" %("Gamma", black.gamma(spot)))
+print("%-20s: %4.4f" %("Theta", black.theta(spot, T))) 
+print("%-20s: %4.4f" %("Vega", black.vega(T)))
+print("%-20s: %4.4f" %("Rho", black.rho( T)))
+
+# ------------------------------------------------------- #
+
+# ### 5-Year Note
+
+interestRate = 0.003
+calcDate = ql.Date(1,12,2023)
+yieldCurve = ql.FlatForward(calcDate, interestRate, daysCount, ql.Compounded, ql.Continuous)
+
+ql.Settings.instance().evaluationDate = calcDate
+optionMaturityDate = ql.Date(24,12,2028)
+strike = 100
+spot = 125 # spot price is the futures price
+volatility = 20/100.
+optionType = ql.Option.Call
+
+discount = yieldCurve.discount(optionMaturityDate)
+strikepayoff = ql.PlainVanillaPayoff(optionType, strike)
+T = yieldCurve.dayCounter().yearFraction(calcDate, optionMaturityDate)
+
+stddev = volatility*math.sqrt(T)
+
+black = ql.BlackCalculator(strikepayoff, spot, stddev, discount)
+
+print("%-20s: %4.4f" %("Option Price for Treasury Futures Contract (5-Year Note)", black.value() )) 
+print("%-20s: %4.4f" %("Delta", black.delta(spot)))
+print("%-20s: %4.4f" %("Gamma", black.gamma(spot)))
+print("%-20s: %4.4f" %("Theta", black.theta(spot, T))) 
+print("%-20s: %4.4f" %("Vega", black.vega(T)))
+print("%-20s: %4.4f" %("Rho", black.rho( T)))
+
+# ------------------------------------------------------- #
+
+# ### 10-Year Note
+
+interestRate = 0.003
+calcDate = ql.Date(1,12,2023)
+yieldCurve = ql.FlatForward(calcDate, interestRate, daysCount, ql.Compounded, ql.Continuous)
+
+ql.Settings.instance().evaluationDate = calcDate
+optionMaturityDate = ql.Date(24,12,2033)
+strike = 100
+spot = 125 # futures price
+volatility = 20/100.
+optionType = ql.Option.Call
+
+discount = yieldCurve.discount(optionMaturityDate)
+strikepayoff = ql.PlainVanillaPayoff(optionType, strike)
+T = yieldCurve.dayCounter().yearFraction(calcDate, optionMaturityDate)
+
+stddev = volatility*math.sqrt(T)
+black = ql.BlackCalculator(strikepayoff, spot, stddev, discount)
+
+print("%-20s: %4.4f" %("Option Price for Treasury Futures Contract (10-Year Note)", black.value() )) 
+print("%-20s: %4.4f" %("Delta", black.delta(spot)))
+print("%-20s: %4.4f" %("Gamma", black.gamma(spot)))
+print("%-20s: %4.4f" %("Theta", black.theta(spot, T))) 
+print("%-20s: %4.4f" %("Vega", black.vega(T)))
+print("%-20s: %4.4f" %("Rho", black.rho( T)))
+
+# ------------------------------------------------------- #
+


### PR DESCRIPTION
Models include Caps with constant volatility, Callable bonds, and options on T-notes. 
Caps and floors: Using interest rate term structure for discounting and floating leg we can construct a cap with constant volatility using the ql.BlackCapFloorEngine pricing engine.

Option Value on T-notes: Using CME (Chicago Mercantile Exchange) on the Treasury notes for 2-year, 3-year, 5-year, and 10-year notes. We use the Black calculator to pass standard deviation, spot price, strike payoff, and discount factor. In addition, the treasury notes all have greeks built in payoffs to accurately price the derivatives.

Callable bonds: Using the Caps and floors Model within the C++ QuantLib library, we pass the same design patterns and information to yield similar results. For example, HullWhite interest rate model and TreeCallableFixedRateBondEngine to value the bond. 