### PR TITLE
Allow passing dividends to pricing engines

### DIFF
--- a/Python/test/options.py
+++ b/Python/test/options.py
@@ -54,8 +54,7 @@ class OptionsTest(unittest.TestCase):
         option.setPricingEngine(
             ql.FdHestonHullWhiteVanillaEngine(
                 ql.HestonModel(heston_process), hull_white_process, -0.5,
-                10, 200, 25, 10,
-                controlVariate=True
+                10, 200, 25, 10, 0, True
             )
         )
 

--- a/SWIG/barrieroptions.i
+++ b/SWIG/barrieroptions.i
@@ -22,6 +22,7 @@
 #define quantlib_barrier_options_i
 
 %include options.i
+%include dividends.i
 
 %{
 using QuantLib::Barrier;
@@ -49,6 +50,14 @@ class BarrierOption : public OneAssetOption {
     Volatility impliedVolatility(
                          Real targetValue,
                          const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+                         Real accuracy = 1.0e-4,
+                         Size maxEvaluations = 100,
+                         Volatility minVol = 1.0e-4,
+                         Volatility maxVol = 4.0);
+    Volatility impliedVolatility(
+                         Real targetValue,
+                         const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+                         const DividendSchedule& dividends,
                          Real accuracy = 1.0e-4,
                          Size maxEvaluations = 100,
                          Volatility minVol = 1.0e-4,
@@ -230,12 +239,24 @@ class FdBlackScholesBarrierEngine : public PricingEngine {
                                 const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas(),
                                 bool localVol = false,
                                 Real illegalLocalVolOverwrite = -Null<Real>());
+    FdBlackScholesBarrierEngine(const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+                                DividendSchedule dividends,
+                                Size tGrid = 100, Size xGrid = 100, Size dampingSteps = 0,
+                                const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas(),
+                                bool localVol = false,
+                                Real illegalLocalVolOverwrite = -Null<Real>());
 };
 
 %shared_ptr(FdBlackScholesRebateEngine)
 class FdBlackScholesRebateEngine : public PricingEngine {
   public:
     FdBlackScholesRebateEngine(const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+                               Size tGrid = 100, Size xGrid = 100, Size dampingSteps = 0,
+                               const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas(),
+                               bool localVol = false,
+                               Real illegalLocalVolOverwrite = -Null<Real>());
+    FdBlackScholesRebateEngine(const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+                               DividendSchedule dividends,
                                Size tGrid = 100, Size xGrid = 100, Size dampingSteps = 0,
                                const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas(),
                                bool localVol = false,
@@ -248,8 +269,13 @@ class FdHestonBarrierEngine : public PricingEngine {
     FdHestonBarrierEngine(const ext::shared_ptr<HestonModel>& model,
                           Size tGrid = 100, Size xGrid = 100, Size vGrid = 50, Size dampingSteps = 0,
                           const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
-                          const ext::shared_ptr<LocalVolTermStructure>& leverageFct
-                              = ext::shared_ptr<LocalVolTermStructure>(),
+                          const ext::shared_ptr<LocalVolTermStructure>& leverageFct = {},
+                          const Real mixingFactor = 1.0);
+    FdHestonBarrierEngine(const ext::shared_ptr<HestonModel>& model,
+                          DividendSchedule dividends,
+                          Size tGrid = 100, Size xGrid = 100, Size vGrid = 50, Size dampingSteps = 0,
+                          const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
+                          const ext::shared_ptr<LocalVolTermStructure>& leverageFct = {},
                           const Real mixingFactor = 1.0);
 };
 
@@ -259,8 +285,13 @@ class FdHestonRebateEngine : public PricingEngine {
     FdHestonRebateEngine(const ext::shared_ptr<HestonModel>& model,
                          Size tGrid = 100, Size xGrid = 100, Size vGrid = 50, Size dampingSteps = 0,
                          const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
-                         const ext::shared_ptr<LocalVolTermStructure>& leverageFct
-                             = ext::shared_ptr<LocalVolTermStructure>(),
+                         const ext::shared_ptr<LocalVolTermStructure>& leverageFct = {},
+                         const Real mixingFactor = 1.0);
+    FdHestonRebateEngine(const ext::shared_ptr<HestonModel>& model,
+                         DividendSchedule dividends,
+                         Size tGrid = 100, Size xGrid = 100, Size vGrid = 50, Size dampingSteps = 0,
+                         const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
+                         const ext::shared_ptr<LocalVolTermStructure>& leverageFct = {},
                          const Real mixingFactor = 1.0);
 };
 

--- a/SWIG/calibratedmodel.i
+++ b/SWIG/calibratedmodel.i
@@ -1,0 +1,99 @@
+/*
+ Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
+ Copyright (C) 2003, 2007, 2009 StatPro Italia srl
+ Copyright (C) 2005 Dominic Thuillier
+ Copyright (C) 2007 Luis Cota
+ Copyright (C) 2016 Gouthaman Balaraman
+ Copyright (C) 2016 Peter Caspers
+ Copyright (C) 2018 Matthias Lungwitz
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#ifndef quantlib_calibrated_model_i
+#define quantlib_calibrated_model_i
+
+%include termstructures.i
+%include optimizers.i
+%include linearalgebra.i
+%include types.i
+%include vectors.i
+
+%{
+using QuantLib::CalibrationHelper;
+%}
+
+// calibration helpers
+%shared_ptr(CalibrationHelper)
+class CalibrationHelper {
+  public:
+    Real calibrationError();
+  private:
+    CalibrationHelper();
+};
+
+
+// allow use of vectors of helpers
+#if defined(SWIGCSHARP)
+SWIG_STD_VECTOR_ENHANCED( ext::shared_ptr<CalibrationHelper> )
+#endif
+namespace std {
+    %template(CalibrationHelperVector) vector<ext::shared_ptr<CalibrationHelper> >;
+}
+
+// the base class for calibrated models
+%{
+using QuantLib::CalibratedModel;
+using QuantLib::TermStructureConsistentModel;
+%}
+
+%shared_ptr(CalibratedModel)
+class CalibratedModel : public virtual Observable {
+    #if defined(SWIGCSHARP)
+    %rename("parameters") params;
+    #endif
+  public:
+    Array params() const;
+    virtual void calibrate(
+        const std::vector<ext::shared_ptr<CalibrationHelper> >&,
+        OptimizationMethod&, const EndCriteria &,
+        const Constraint& constraint = Constraint(),
+        const std::vector<Real>& weights = std::vector<Real>(),
+        const std::vector<bool>& fixParameters = std::vector<bool>());
+
+    void setParams(const Array& params);
+    Real value(const Array& params,
+               const std::vector<ext::shared_ptr<CalibrationHelper> >&);
+    const ext::shared_ptr<Constraint>& constraint() const;
+    EndCriteria::Type endCriteria() const;
+    const Array& problemValues() const;
+    Integer functionEvaluation() const;
+  private:
+    CalibratedModel();
+};
+
+%shared_ptr(TermStructureConsistentModel)
+class TermStructureConsistentModel : public virtual Observable{
+  public:
+    const Handle<YieldTermStructure>& termStructure() const;
+  private:
+    TermStructureConsistentModel();
+};
+
+%template(CalibratedModelHandle) Handle<CalibratedModel>;
+%template(RelinkableCalibratedModelHandle) RelinkableHandle<CalibratedModel>;
+
+
+
+#endif

--- a/SWIG/calibrationhelpers.i
+++ b/SWIG/calibrationhelpers.i
@@ -24,14 +24,13 @@
 #ifndef quantlib_calibration_helpers_i
 #define quantlib_calibration_helpers_i
 
+%include calibratedmodel.i
 %include date.i
 %include calendars.i
 %include daycounters.i
 %include cashflows.i
 %include marketelements.i
 %include termstructures.i
-%include optimizers.i
-%include options.i
 %include linearalgebra.i
 %include types.i
 %include vectors.i
@@ -39,21 +38,11 @@
 %{
 using QuantLib::VanillaSwap;
 using QuantLib::Swaption;
-using QuantLib::CalibrationHelper;
 using QuantLib::BlackCalibrationHelper;
 using QuantLib::SwaptionHelper;
 using QuantLib::CapHelper;
 using QuantLib::HestonModelHelper;
 %}
-
-// calibration helpers
-%shared_ptr(CalibrationHelper)
-class CalibrationHelper {
-  public:
-    Real calibrationError();
-  private:
-    CalibrationHelper();
-};
 
 %shared_ptr(BlackCalibrationHelper)
 class BlackCalibrationHelper : public CalibrationHelper {
@@ -196,57 +185,11 @@ class HestonModelHelper : public BlackCalibrationHelper {
 
 // allow use of vectors of helpers
 #if defined(SWIGCSHARP)
-SWIG_STD_VECTOR_ENHANCED( ext::shared_ptr<CalibrationHelper> )
 SWIG_STD_VECTOR_ENHANCED( ext::shared_ptr<BlackCalibrationHelper> )
 #endif
 namespace std {
-    %template(CalibrationHelperVector)
-        vector<ext::shared_ptr<CalibrationHelper> >;
     %template(BlackCalibrationHelperVector)
         vector<ext::shared_ptr<BlackCalibrationHelper> >;
 }
-
-// the base class for calibrated models
-%{
-using QuantLib::CalibratedModel;
-using QuantLib::TermStructureConsistentModel;
-%}
-
-%shared_ptr(CalibratedModel)
-class CalibratedModel : public virtual Observable {
-    #if defined(SWIGCSHARP)
-    %rename("parameters") params;
-    #endif
-  public:
-    Array params() const;
-    virtual void calibrate(
-        const std::vector<ext::shared_ptr<CalibrationHelper> >&,
-        OptimizationMethod&, const EndCriteria &,
-        const Constraint& constraint = Constraint(),
-        const std::vector<Real>& weights = std::vector<Real>(),
-        const std::vector<bool>& fixParameters = std::vector<bool>());
-
-    void setParams(const Array& params);
-    Real value(const Array& params,
-               const std::vector<ext::shared_ptr<CalibrationHelper> >&);
-    const ext::shared_ptr<Constraint>& constraint() const;
-    EndCriteria::Type endCriteria() const;
-    const Array& problemValues() const;
-    Integer functionEvaluation() const;
-  private:
-    CalibratedModel();
-};
-
-%shared_ptr(TermStructureConsistentModel)
-class TermStructureConsistentModel : public virtual Observable{
-  public:
-    const Handle<YieldTermStructure>& termStructure() const;
-  private:
-    TermStructureConsistentModel();
-};
-
-%template(CalibratedModelHandle) Handle<CalibratedModel>;
-%template(RelinkableCalibratedModelHandle)
-RelinkableHandle<CalibratedModel>;
 
 #endif

--- a/SWIG/dividends.i
+++ b/SWIG/dividends.i
@@ -49,11 +49,14 @@ class FractionalDividend : public Dividend {
 };
 
 
+%{
+using QuantLib::DividendSchedule;
+%}
+
 #if defined(SWIGCSHARP)
 SWIG_STD_VECTOR_ENHANCED( ext::shared_ptr<Dividend> )
 #endif
-namespace std {
-    %template(DividendSchedule) vector<ext::shared_ptr<Dividend> >;
-}
+%template(DividendSchedule) std::vector<ext::shared_ptr<Dividend>>;
+typedef std::vector<ext::shared_ptr<Dividend>> DividendSchedule;
 
 #endif

--- a/SWIG/options.i
+++ b/SWIG/options.i
@@ -27,12 +27,13 @@
 #define quantlib_options_i
 
 %include common.i
+%include dividends.i
 %include exercise.i
 %include stochasticprocess.i
 %include instruments.i
 %include stl.i
 %include linearalgebra.i
-%include calibrationhelpers.i
+%include calibratedmodel.i
 %include grid.i
 %include parameter.i
 %include vectors.i
@@ -188,6 +189,15 @@ class VanillaOption : public OneAssetOption {
                          Size maxEvaluations = 100,
                          Volatility minVol = 1.0e-4,
                          Volatility maxVol = 4.0);
+    Volatility impliedVolatility(
+                         Real targetValue,
+                         const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+                         const DividendSchedule& dividends,
+                         Real accuracy = 1.0e-4,
+                         Size maxEvaluations = 100,
+                         Volatility minVol = 1.0e-4,
+                         Volatility maxVol = 4.0);
+
     %extend{
         SampledCurve priceCurve() {
             return self->result<SampledCurve>("priceCurve");
@@ -993,6 +1003,9 @@ class AnalyticDividendEuropeanEngine : public PricingEngine {
   public:
     AnalyticDividendEuropeanEngine(
             const ext::shared_ptr<GeneralizedBlackScholesProcess>& process);
+    AnalyticDividendEuropeanEngine(
+            const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+            DividendSchedule dividends);
 };
 
 %{
@@ -1141,23 +1154,50 @@ class FdBlackScholesVanillaEngine : public PricingEngine {
         Real illegalLocalVolOverwrite = -Null<Real>(),
         CashDividendModel cashDividendModel = Spot);
 
+    FdBlackScholesVanillaEngine(
+        const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+        DividendSchedule dividends,
+        Size tGrid = 100, Size xGrid = 100, Size dampingSteps = 0,
+        const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas(),
+        bool localVol = false,
+        Real illegalLocalVolOverwrite = -Null<Real>(),
+        CashDividendModel cashDividendModel = Spot);
+
+    FdBlackScholesVanillaEngine(
+        const ext::shared_ptr<GeneralizedBlackScholesProcess>&,
+        DividendSchedule dividends,
+        const ext::shared_ptr<FdmQuantoHelper>& quantoHelper,
+        Size tGrid = 100, Size xGrid = 100, Size dampingSteps = 0,
+        const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas(),
+        bool localVol = false,
+        Real illegalLocalVolOverwrite = -Null<Real>(),
+        CashDividendModel cashDividendModel = Spot);
+
     #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
     %feature("kwargs") make;
     %extend {
         static ext::shared_ptr<FdBlackScholesVanillaEngine> make(
                     const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
-                    const ext::shared_ptr<FdmQuantoHelper>& quantoHelper
-                        = ext::shared_ptr<FdmQuantoHelper>(),
+                    const DividendSchedule& dividends = {},
+                    const ext::shared_ptr<FdmQuantoHelper>& quantoHelper = {},
                     Size tGrid = 100, Size xGrid = 100, Size dampingSteps = 0,
                     const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas(),
                     bool localVol = false,
                     Real illegalLocalVolOverwrite = -Null<Real>(),
                     CashDividendModel cashDividendModel = Spot) {
-            return ext::shared_ptr<FdBlackScholesVanillaEngine>(
-                new FdBlackScholesVanillaEngine(process, quantoHelper, tGrid, xGrid,
+            if (dividends.empty()) {
+                return ext::make_shared<FdBlackScholesVanillaEngine>(
+                                                process, quantoHelper, tGrid, xGrid,
                                                 dampingSteps, schemeDesc,
                                                 localVol, illegalLocalVolOverwrite,
-                                                cashDividendModel));
+                                                cashDividendModel);
+            } else {
+                return ext::make_shared<FdBlackScholesVanillaEngine>(
+                                                process, dividends, quantoHelper, tGrid, xGrid,
+                                                dampingSteps, schemeDesc,
+                                                localVol, illegalLocalVolOverwrite,
+                                                cashDividendModel);
+            }
         }
     }
     #endif
@@ -1170,17 +1210,26 @@ class FdBlackScholesShoutEngine : public PricingEngine {
         const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
         Size tGrid = 100, Size xGrid = 100, Size dampingSteps = 0,
         const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas());
+    FdBlackScholesShoutEngine(
+        const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+        DividendSchedule dividends,
+        Size tGrid = 100, Size xGrid = 100, Size dampingSteps = 0,
+        const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas());
 };
 
 %shared_ptr(FdOrnsteinUhlenbeckVanillaEngine)
 class FdOrnsteinUhlenbeckVanillaEngine : public PricingEngine {
   public:
-    #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
-    %feature("kwargs") FdOrnsteinUhlenbeckVanillaEngine;
-    #endif
     FdOrnsteinUhlenbeckVanillaEngine(
         const ext::shared_ptr<OrnsteinUhlenbeckProcess>&,
         const ext::shared_ptr<YieldTermStructure>& rTS,
+        Size tGrid = 100, Size xGrid = 100, Size dampingSteps = 0,
+        Real epsilon = 0.0001,
+        const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas());
+    FdOrnsteinUhlenbeckVanillaEngine(
+        const ext::shared_ptr<OrnsteinUhlenbeckProcess>&,
+        const ext::shared_ptr<YieldTermStructure>& rTS,
+        DividendSchedule dividends,
         Size tGrid = 100, Size xGrid = 100, Size dampingSteps = 0,
         Real epsilon = 0.0001,
         const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas());
@@ -1194,6 +1243,12 @@ class FdBatesVanillaEngine : public PricingEngine {
             Size tGrid = 100, Size xGrid = 100,
             Size vGrid=50, Size dampingSteps = 0,
             const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer());
+    FdBatesVanillaEngine(
+            const ext::shared_ptr<BatesModel>& model,
+            DividendSchedule dividends,
+            Size tGrid = 100, Size xGrid = 100,
+            Size vGrid=50, Size dampingSteps = 0,
+            const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer());
 };
 
 %shared_ptr(FdHestonVanillaEngine)
@@ -1204,8 +1259,7 @@ class FdHestonVanillaEngine : public PricingEngine {
         Size tGrid = 100, Size xGrid = 100,
         Size vGrid = 50, Size dampingSteps = 0,
         const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
-        const ext::shared_ptr<LocalVolTermStructure>& leverageFct
-            = ext::shared_ptr<LocalVolTermStructure>(),
+        const ext::shared_ptr<LocalVolTermStructure>& leverageFct = {},
         const Real mixingFactor = 1.0);
 
     FdHestonVanillaEngine(
@@ -1216,8 +1270,28 @@ class FdHestonVanillaEngine : public PricingEngine {
         Size vGrid = 50, 
         Size dampingSteps = 0,
         const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
-        const ext::shared_ptr<LocalVolTermStructure>& leverageFct
-            = ext::shared_ptr<LocalVolTermStructure>(),
+        const ext::shared_ptr<LocalVolTermStructure>& leverageFct = {},
+        const Real mixingFactor = 1.0);
+
+    FdHestonVanillaEngine(
+        const ext::shared_ptr<HestonModel>& model,
+        DividendSchedule dividends,
+        Size tGrid = 100, Size xGrid = 100,
+        Size vGrid = 50, Size dampingSteps = 0,
+        const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
+        const ext::shared_ptr<LocalVolTermStructure>& leverageFct = {},
+        const Real mixingFactor = 1.0);
+
+    FdHestonVanillaEngine(
+        const ext::shared_ptr<HestonModel>& model,
+        DividendSchedule dividends,
+        const ext::shared_ptr<FdmQuantoHelper>& quantoHelper,
+        Size tGrid = 100, 
+        Size xGrid = 100,
+        Size vGrid = 50, 
+        Size dampingSteps = 0,
+        const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
+        const ext::shared_ptr<LocalVolTermStructure>& leverageFct = {},
         const Real mixingFactor = 1.0);
 
     #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
@@ -1225,17 +1299,22 @@ class FdHestonVanillaEngine : public PricingEngine {
     %extend {
         static ext::shared_ptr<FdHestonVanillaEngine> make(
                     const ext::shared_ptr<HestonModel>& model,
-                    const ext::shared_ptr<FdmQuantoHelper>& quantoHelper
-                        = ext::shared_ptr<FdmQuantoHelper>(),
+                    const DividendSchedule& dividends = {},
+                    const ext::shared_ptr<FdmQuantoHelper>& quantoHelper = {},
                     Size tGrid = 100, Size xGrid = 100, Size vGrid = 50,
                     Size dampingSteps = 0,
                     const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
-                    const ext::shared_ptr<LocalVolTermStructure>& leverageFct
-                        = ext::shared_ptr<LocalVolTermStructure>(),
+                    const ext::shared_ptr<LocalVolTermStructure>& leverageFct = {},
                     const Real mixingFactor = 1.0) {
-            return ext::shared_ptr<FdHestonVanillaEngine>(
-                new FdHestonVanillaEngine(model, quantoHelper, tGrid, xGrid, vGrid,
-                                          dampingSteps, schemeDesc, leverageFct, mixingFactor));
+            if (dividends.empty()) {
+                return ext::make_shared<FdHestonVanillaEngine>(
+                    model, quantoHelper, tGrid, xGrid, vGrid,
+                    dampingSteps, schemeDesc, leverageFct, mixingFactor);
+            } else {
+                return ext::make_shared<FdHestonVanillaEngine>(
+                    model, dividends, quantoHelper, tGrid, xGrid, vGrid,
+                    dampingSteps, schemeDesc, leverageFct, mixingFactor);
+            }
         }
     }
     #endif
@@ -1292,12 +1371,21 @@ using QuantLib::FdHestonHullWhiteVanillaEngine;
 %shared_ptr(FdHestonHullWhiteVanillaEngine);
 class FdHestonHullWhiteVanillaEngine : public PricingEngine {
   public:
-    #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
-    %feature("kwargs") FdHestonHullWhiteVanillaEngine;
-    #endif
     FdHestonHullWhiteVanillaEngine(
         const ext::shared_ptr<HestonModel>& model,
         ext::shared_ptr<HullWhiteProcess> hwProcess,
+        Real corrEquityShortRate,
+        Size tGrid = 50,
+        Size xGrid = 100,
+        Size vGrid = 40,
+        Size rGrid = 20,
+        Size dampingSteps = 0,
+        bool controlVariate = true,
+        const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer());    
+    FdHestonHullWhiteVanillaEngine(
+        const ext::shared_ptr<HestonModel>& model,
+        ext::shared_ptr<HullWhiteProcess> hwProcess,
+        DividendSchedule dividends,
         Real corrEquityShortRate,
         Size tGrid = 50,
         Size xGrid = 100,

--- a/SWIG/ql.i
+++ b/SWIG/ql.i
@@ -118,6 +118,7 @@ QL_DEPRECATED_DISABLE_WARNING
 %include bonds.i
 %include bondfunctions.i
 %include calendars.i
+%include calibratedmodel.i
 %include calibrationhelpers.i
 %include capfloor.i
 %include cashflows.i

--- a/SWIG/shortratemodels.i
+++ b/SWIG/shortratemodels.i
@@ -24,7 +24,7 @@
 #ifndef quantlib_short_rate_models_i
 #define quantlib_short_rate_models_i
 
-%include calibrationhelpers.i
+%include calibratedmodel.i
 %include grid.i
 %include options.i
 

--- a/SWIG/volatilities.i
+++ b/SWIG/volatilities.i
@@ -34,7 +34,6 @@
 %include interpolation.i
 %include indexes.i
 %include optimizers.i
-%include options.i
 %include termstructures.i
 %include vectors.i
 %include tuple.i
@@ -516,7 +515,7 @@ class SwaptionVolatilityMatrix : public SwaptionVolatilityDiscrete {
                                  const bool flatExtrapolation = false,
                                  const VolatilityType type = ShiftedLognormal,
                                  const Matrix& shifts = Matrix()) {
-            return new SwaptionVolatilityMatrix(referenceDate, NullCalendar(), Following,
+            return new SwaptionVolatilityMatrix(referenceDate, QuantLib::NullCalendar(), Following,
                                                 dates, lengths, vols, dayCounter,
                                                 flatExtrapolation, type, shifts);
         }


### PR DESCRIPTION
See https://github.com/lballabio/QuantLib/pull/1586 and https://github.com/lballabio/QuantLib/pull/1568.

Unfortunately, this introduces constructor overloads and thus disables keyword arguments for the classes that previously provided them.

These changes also showed a couple of inclusion cycles in the SWIG interface files.  Hopefully, the cycles are now broken.