### PR TITLE
Add support for `ext::optional`

### DIFF
--- a/.github/workflows/namespaces.yml
+++ b/.github/workflows/namespaces.yml
@@ -16,6 +16,8 @@ jobs:
         sed -i -e 's/boost::tuple/ext::tuple/g' SWIG/*
         sed -i -e 's/boost::get/ext::get/g' SWIG/*
         sed -i -e 's/boost::function/ext::function/g' SWIG/*
+        sed -i -e 's/boost::optional/ext::optional/g' SWIG/*
+        sed -i -e 's/boost::none/ext::nullopt/g' SWIG/*
     - uses: peter-evans/create-pull-request@v5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/SWIG/calendars.i
+++ b/SWIG/calendars.i
@@ -63,15 +63,15 @@ using QuantLib::JoinBusinessDays;
 enum JointCalendarRule { JoinHolidays, JoinBusinessDays };
 
 #if defined(SWIGPYTHON)
-%typemap(in) boost::optional<BusinessDayConvention> %{
+%typemap(in) ext::optional<BusinessDayConvention> %{
 	if($input == Py_None)
-		$1 = boost::none;
+		$1 = ext::nullopt;
     else if (PyInt_Check($input))
         $1 = (BusinessDayConvention) PyInt_AsLong($input);
 	else
 		$1 = (BusinessDayConvention) PyLong_AsLong($input);
 %}
-%typecheck (QL_TYPECHECK_BUSINESSDAYCONVENTION) boost::optional<BusinessDayConvention> {
+%typecheck (QL_TYPECHECK_BUSINESSDAYCONVENTION) ext::optional<BusinessDayConvention> {
 if (PyInt_Check($input) || PyLong_Check($input) || Py_None == $input)
 	$1 = 1;
 else

--- a/SWIG/cashflows.i
+++ b/SWIG/cashflows.i
@@ -391,7 +391,7 @@ class BlackIborCouponPricer : public IborCouponPricer {
                           const TimingAdjustment timingAdjustment = Black76,
                           const Handle<Quote> correlation =
                                     Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(1.0))),
-                          boost::optional<bool> useIndexedCoupon = boost::none);
+                          ext::optional<bool> useIndexedCoupon = ext::nullopt);
 };
 
 %shared_ptr(SubPeriodsPricer)
@@ -614,7 +614,7 @@ class LognormalCmsSpreadPricer : public CmsSpreadCouponPricer {
             const Handle<YieldTermStructure> &couponDiscountCurve =
                 Handle<YieldTermStructure>(),
             const Size IntegrationPoints = 16,
-            const boost::optional<VolatilityType> volatilityType = boost::none,
+            const ext::optional<VolatilityType> volatilityType = ext::nullopt,
             const Real shift1 = Null<Real>(), const Real shift2 = Null<Real>());
     Real swapletPrice() const;
     Rate swapletRate() const;
@@ -691,7 +691,7 @@ Leg _IborLeg(const std::vector<Real>& nominals,
              bool exCouponEndOfMonth = false,
              const Calendar& paymentCalendar = Calendar(),
              const Natural paymentLag = 0,
-             boost::optional<bool> withIndexedCoupons = boost::none) {
+             ext::optional<bool> withIndexedCoupons = ext::nullopt) {
     return QuantLib::IborLeg(schedule, index)
         .withNotionals(nominals)
         .withPaymentDayCounter(paymentDayCounter)
@@ -732,7 +732,7 @@ Leg _IborLeg(const std::vector<Real>& nominals,
              bool exCouponEndOfMonth = false,
              const Calendar& paymentCalendar = Calendar(),
              Natural paymentLag = 0,
-             boost::optional<bool> withIndexedCoupons = boost::none);
+             ext::optional<bool> withIndexedCoupons = ext::nullopt);
 
 %{
 Leg _OvernightLeg(const std::vector<Real>& nominals,

--- a/SWIG/common.i
+++ b/SWIG/common.i
@@ -44,15 +44,15 @@
 %}
 
 #if defined(SWIGPYTHON)
-%typemap(in) boost::optional<bool> %{
+%typemap(in) ext::optional<bool> %{
 	if($input == Py_None)
-		$1 = boost::none;
+		$1 = ext::nullopt;
 	else if ($input == Py_True)
 		$1 = true;
 	else
 		$1 = false;
 %}
-%typecheck (QL_TYPECHECK_BOOL) boost::optional<bool> {
+%typecheck (QL_TYPECHECK_BOOL) ext::optional<bool> {
 if (PyBool_Check($input) || Py_None == $input) 
 	$1 = 1;
 else
@@ -60,18 +60,18 @@ else
 }
 #else
 #if defined(SWIGCSHARP)
-%typemap(cscode) boost::optional<bool> %{
+%typemap(cscode) ext::optional<bool> %{
     public static implicit operator OptionalBool(bool b) => new OptionalBool(b);
 %}
 #endif
-namespace boost {
+namespace ext {
     template<class T>
     class optional {
       public:
         optional(T t);
     };
 }
-%template(OptionalBool) boost::optional<bool>;
+%template(OptionalBool) ext::optional<bool>;
 #endif
 
 %{

--- a/SWIG/creditdefaultswap.i
+++ b/SWIG/creditdefaultswap.i
@@ -104,8 +104,8 @@ class CreditDefaultSwap : public Instrument {
     Real notional() const;
     Rate runningSpread() const;
     %extend {
-    doubleOrNull upfront() const {
-            boost::optional<Rate> result =
+        doubleOrNull upfront() const {
+            ext::optional<Rate> result =
                 self->upfront();
             if (result)
                 return *result;

--- a/SWIG/date.i
+++ b/SWIG/date.i
@@ -347,18 +347,18 @@ class Period {
 };
 
 #if defined(SWIGPYTHON)
-%typemap(in) boost::optional<Period> %{
+%typemap(in) ext::optional<Period> %{
     if($input == Py_None)
-        $1 = boost::none;
+        $1 = ext::nullopt;
     else
     {
         Period *temp;
         if (!SWIG_IsOK(SWIG_ConvertPtr($input,(void **) &temp, $descriptor(Period*),0)))
             SWIG_exception_fail(SWIG_TypeError, "in method '$symname', expecting type Period");
-        $1 = (boost::optional<Period>) *temp;
+        $1 = (ext::optional<Period>) *temp;
     }
 %}
-%typecheck (QL_TYPECHECK_PERIOD) boost::optional<Period> {
+%typecheck (QL_TYPECHECK_PERIOD) ext::optional<Period> {
     if($input == Py_None)
         $1 = 1;
     else {

--- a/SWIG/options.i
+++ b/SWIG/options.i
@@ -694,7 +694,7 @@ class MCAmericanEngine : public PricingEngine {
                          intOrNull polynomOrder = 2,
                          LsmBasisSystem::PolynomType polynomType = LsmBasisSystem::Monomial,
                          int nCalibrationSamples = 2048,
-                         boost::optional<bool> antitheticVariateCalibration = boost::none,
+                         ext::optional<bool> antitheticVariateCalibration = ext::nullopt,
                          BigNatural seedCalibration = Null<Size>()) {
             return new MCAmericanEngine<RNG>(process,
                                              timeSteps,

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -227,13 +227,12 @@ class SwapRateHelper : public RateHelper {
             const ext::shared_ptr<IborIndex>& index,
             const Handle<Quote>& spread = Handle<Quote>(),
             const Period& fwdStart = 0*Days,
-            const Handle<YieldTermStructure>& discountingCurve
-                                        = Handle<YieldTermStructure>(),
+            const Handle<YieldTermStructure>& discountingCurve = {},
             Natural settlementDays = Null<Natural>(),
             Pillar::Choice pillar = Pillar::LastRelevantDate,
             Date customPillarDate = Date(),
             bool endOfMonth = false,
-            boost::optional<bool> withIndexedCoupons = boost::none);
+            ext::optional<bool> withIndexedCoupons = ext::nullopt);
     SwapRateHelper(
             Rate rate,
             const Period& tenor,
@@ -244,35 +243,32 @@ class SwapRateHelper : public RateHelper {
             const ext::shared_ptr<IborIndex>& index,
             const Handle<Quote>& spread = Handle<Quote>(),
             const Period& fwdStart = 0*Days,
-            const Handle<YieldTermStructure>& discountingCurve
-                                        = Handle<YieldTermStructure>(),
+            const Handle<YieldTermStructure>& discountingCurve = {},
             Natural settlementDays = Null<Natural>(),
             Pillar::Choice pillar = Pillar::LastRelevantDate,
             Date customPillarDate = Date(),
             bool endOfMonth = false,
-            boost::optional<bool> withIndexedCoupons = boost::none);
+            ext::optional<bool> withIndexedCoupons = ext::nullopt);
     SwapRateHelper(
             const Handle<Quote>& rate,
             const ext::shared_ptr<SwapIndex>& index,
             const Handle<Quote>& spread = Handle<Quote>(),
             const Period& fwdStart = 0*Days,
-            const Handle<YieldTermStructure>& discountingCurve
-                                        = Handle<YieldTermStructure>(),
+            const Handle<YieldTermStructure>& discountingCurve = {},
             Pillar::Choice pillar = Pillar::LastRelevantDate,
             Date customPillarDate = Date(),
             bool endOfMonth = false,
-            boost::optional<bool> withIndexedCoupons = boost::none);
+            ext::optional<bool> withIndexedCoupons = ext::nullopt);
     SwapRateHelper(
             Rate rate,
             const ext::shared_ptr<SwapIndex>& index,
             const Handle<Quote>& spread = Handle<Quote>(),
             const Period& fwdStart = 0*Days,
-            const Handle<YieldTermStructure>& discountingCurve
-                                        = Handle<YieldTermStructure>(),
+            const Handle<YieldTermStructure>& discountingCurve = {},
             Pillar::Choice pillar = Pillar::LastRelevantDate,
             Date customPillarDate = Date(),
             bool endOfMonth = false,
-            boost::optional<bool> withIndexedCoupons = boost::none);
+            ext::optional<bool> withIndexedCoupons = ext::nullopt);
     Spread spread();
     ext::shared_ptr<VanillaSwap> swap();
 };
@@ -322,8 +318,7 @@ class OISRateHelper : public RateHelper {
             const Period& tenor,
             const Handle<Quote>& rate,
             const ext::shared_ptr<OvernightIndex>& index,
-            const Handle<YieldTermStructure>& discountingCurve
-                                        = Handle<YieldTermStructure>(),
+            const Handle<YieldTermStructure>& discountingCurve = {},
             bool telescopicValueDates = false,
             Natural paymentLag = 0,
             BusinessDayConvention paymentConvention = Following,
@@ -334,7 +329,7 @@ class OISRateHelper : public RateHelper {
             Pillar::Choice pillar = Pillar::LastRelevantDate,
             Date customPillarDate = Date(), 
             RateAveraging::Type averagingMethod = RateAveraging::Compound,
-            boost::optional<bool> endOfMonth = boost::none);
+            ext::optional<bool> endOfMonth = ext::nullopt);
     ext::shared_ptr<OvernightIndexedSwap> swap();
 };
 

--- a/SWIG/scheduler.i
+++ b/SWIG/scheduler.i
@@ -39,15 +39,15 @@ struct DateGeneration {
                 OldCDS, CDS, CDS2015 };
 };
 #if defined(SWIGPYTHON)
-%typemap(in) boost::optional<DateGeneration::Rule> %{
+%typemap(in) ext::optional<DateGeneration::Rule> %{
     if($input == Py_None)
-        $1 = boost::none;
+        $1 = ext::nullopt;
     else if (PyInt_Check($input))
         $1 = (DateGeneration::Rule) PyInt_AsLong($input);
     else
         $1 = (DateGeneration::Rule) PyLong_AsLong($input);
 %}
-%typecheck (QL_TYPECHECK_DATEGENERATION) boost::optional<DateGeneration::Rule> {
+%typecheck (QL_TYPECHECK_DATEGENERATION) ext::optional<DateGeneration::Rule> {
 if (PyInt_Check($input) || PyLong_Check($input) || Py_None == $input)
     $1 = 1;
 else
@@ -65,11 +65,10 @@ class Schedule {
     Schedule(const std::vector<Date>&,
              const Calendar& calendar = NullCalendar(),
              const BusinessDayConvention convention = Unadjusted,
-             boost::optional<BusinessDayConvention>
-             terminationDateConvention = boost::none,
-             const boost::optional<Period> tenor = boost::none,
-             boost::optional<DateGeneration::Rule> rule = boost::none,
-             boost::optional<bool> endOfMonth = boost::none,
+             ext::optional<BusinessDayConvention> terminationDateConvention = ext::nullopt,
+             ext::optional<Period> tenor = ext::nullopt,
+             ext::optional<DateGeneration::Rule> rule = ext::nullopt,
+             ext::optional<bool> endOfMonth = ext::nullopt,
              const std::vector<bool>& isRegular = std::vector<bool>(0));
     #else
     Schedule(const std::vector<Date>&,

--- a/SWIG/swap.i
+++ b/SWIG/swap.i
@@ -72,9 +72,9 @@ class VanillaSwap : public Swap {
                     const ext::shared_ptr<IborIndex>& index,
                     Spread spread,
                     const DayCounter& floatingDayCount,
-                    boost::optional<bool> withIndexedCoupons = boost::none) {
+                    ext::optional<bool> withIndexedCoupons = ext::nullopt) {
             // work around the lack of typemap for this argument
-            boost::optional<BusinessDayConvention> paymentConvention = boost::none;
+            ext::optional<BusinessDayConvention> paymentConvention = ext::nullopt;
 
             return new VanillaSwap(type, nominal, fixedSchedule, fixedRate, fixedDayCount,
                                    floatSchedule, index, spread, floatingDayCount,
@@ -286,7 +286,7 @@ class DiscountingSwapEngine : public PricingEngine {
                               const Date& settlementDate = Date(),
                               const Date& npvDate = Date()) {
             return new DiscountingSwapEngine(discountCurve,
-                                             boost::none,
+                                             ext::nullopt,
                                              settlementDate,
                                              npvDate);
         }

--- a/SWIG/volatilities.i
+++ b/SWIG/volatilities.i
@@ -49,15 +49,15 @@ using QuantLib::Normal;
 enum VolatilityType { ShiftedLognormal, Normal };
 
 #if defined(SWIGPYTHON)
-%typemap(in) boost::optional<VolatilityType> %{
+%typemap(in) ext::optional<VolatilityType> %{
     if($input == Py_None)
-        $1 = boost::none;
+        $1 = ext::nullopt;
     else if (PyInt_Check($input))
         $1 = (VolatilityType) PyInt_AsLong($input);
     else
         $1 = (VolatilityType) PyLong_AsLong($input);
 %}
-%typecheck (QL_TYPECHECK_VOLATILITYTYPE) boost::optional<VolatilityType> {
+%typecheck (QL_TYPECHECK_VOLATILITYTYPE) ext::optional<VolatilityType> {
 if (PyInt_Check($input) || PyLong_Check($input) || Py_None == $input)
     $1 = 1;
 else


### PR DESCRIPTION
See https://github.com/lballabio/QuantLib/pull/1617.

This allows wrappers to work also when `std::optional` is used.