### PR TITLE
Add constructor and test for `JointCalendar`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ R/R/QuantLib.R
 R/QuantLib.RData
 
 .vscode
+**/venv

--- a/Python/test/QuantLibTestSuite.py
+++ b/Python/test/QuantLibTestSuite.py
@@ -35,6 +35,7 @@ from ratehelpers import (
     FxSwapRateHelperTest,
     OISRateHelperTest,
     CrossCurrencyBasisSwapRateHelperTest)
+from calendars import JointCalendarTest
 from cms import CmsTest
 from assetswap import AssetSwapTest
 from capfloor import CapFloorTest
@@ -109,6 +110,7 @@ def test():
     suite.addTest(unittest.makeSuite(AndreasenHugeVolatilityTest, "test"))
     suite.addTest(unittest.makeSuite(EquityIndexTest, "test"))
     suite.addTest(unittest.makeSuite(EquityTotalReturnSwapTest, "test"))
+    suite.addTest(unittest.makeSuite(JointCalendarTest, "test"))
 
     result = unittest.TextTestRunner(verbosity=2).run(suite)
 

--- a/Python/test/calendars.py
+++ b/Python/test/calendars.py
@@ -32,7 +32,7 @@ class JointCalendarTest(unittest.TestCase):
         base_holidays = [calendar.holidayList(start_date, end_date) for calendar in base_calendars]
         base_holidays = set(itertools.chain.from_iterable(base_holidays))
         for holiday in base_holidays:
-            assert holiday in joint_holidays
+            self.assertIn(holiday, joint_holidays)
 
 
 if __name__ == "__main__":

--- a/Python/test/calendars.py
+++ b/Python/test/calendars.py
@@ -24,7 +24,7 @@ class JointCalendarTest(unittest.TestCase):
 
     def test_joint_calendar_holidays(self):
         base_calendars = [ql.Sweden(), ql.Denmark(), ql.Finland(), ql.Norway(), ql.Iceland()]
-        joint_nordics = ql.JointCalendar(ql.CalendarVector(base_calendars))
+        joint_nordics = ql.JointCalendar(base_calendars)
         start_date = ql.Date(1, ql.January, 2023)
         end_date = ql.Date(31, ql.December, 2023)
 

--- a/Python/test/calendars.py
+++ b/Python/test/calendars.py
@@ -1,0 +1,42 @@
+"""
+ Copyright (C) 2023 Skandinaviska Enskilda Banken AB (publ)
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+"""
+import itertools
+import unittest
+
+import QuantLib as ql
+
+
+class JointCalendarTest(unittest.TestCase):
+
+    def test_joint_calendar_holidays(self):
+        base_calendars = [ql.Sweden(), ql.Denmark(), ql.Finland(), ql.Norway(), ql.Iceland()]
+        joint_nordics = ql.JointCalendar(ql.CalendarVector(base_calendars))
+        start_date = ql.Date(1, ql.January, 2023)
+        end_date = ql.Date(31, ql.December, 2023)
+
+        joint_holidays = set(joint_nordics.holidayList(start_date, end_date))
+        base_holidays = [calendar.holidayList(start_date, end_date) for calendar in base_calendars]
+        base_holidays = set(itertools.chain.from_iterable(base_holidays))
+        for holiday in base_holidays:
+            assert holiday in joint_holidays
+
+
+if __name__ == "__main__":
+    print("testing QuantLib " + ql.__version__)
+    suite = unittest.TestSuite()
+    suite.addTest(JointCalendarTest())
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/SWIG/calendars.i
+++ b/SWIG/calendars.i
@@ -33,11 +33,6 @@
 using QuantLib::Calendar;
 %}
 
-
-namespace std {
-    %template(CalendarVector) vector<Calendar>;
-}
-
 %{
 using QuantLib::BusinessDayConvention;
 using QuantLib::Following;
@@ -133,6 +128,10 @@ class Calendar {
     %}
     #endif
 };
+
+namespace std {
+    %template(CalendarVector) vector<Calendar>;
+}
 
 namespace QuantLib {
 

--- a/SWIG/calendars.i
+++ b/SWIG/calendars.i
@@ -33,6 +33,11 @@
 using QuantLib::Calendar;
 %}
 
+
+namespace std {
+    %template(CalendarVector) vector<Calendar>;
+}
+
 %{
 using QuantLib::BusinessDayConvention;
 using QuantLib::Following;
@@ -331,6 +336,8 @@ namespace QuantLib {
         JointCalendar(const Calendar&, const Calendar&,
                       const Calendar&, const Calendar&,
                       JointCalendarRule rule = QuantLib::JoinHolidays);
+        explicit JointCalendar(const std::vector<Calendar>&,
+                               JointCalendarRule = QuantLib::JoinHolidays);
     };
 
     class BespokeCalendar : public Calendar {


### PR DESCRIPTION
Hi,
This extends the existing interface to add the "new" constructor for `JointCalendar`. A test verifies that the construction is correct against the base calendars. 

As far as I could tell, the Python usage has to go through a template helper `CalendarVector`, but if there's a simpler way then feel free to let me know.

Unrelated note: `OISRateHelperTest.test_ois_default_calendar` fails on my machine when building the latest versions of QL & QL-SWIG. Error code is `Process finished with exit code -1073741571 (0xC00000FD)`, failing on the `self.discounting_yts_handle.linkTo(self.oisSwapCurve)` step of `build_eur_curve()`. Anyone else getting this?

Best,
Fredrik