### PR TITLE
Some cleanup for -builtin mode

### DIFF
--- a/Python/QuantLib/__init__.py
+++ b/Python/QuantLib/__init__.py
@@ -16,14 +16,8 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
-import sys
-if sys.version_info.major >= 3:
-    from .QuantLib import *
-    from .QuantLib import _QuantLib
-else:
-    from QuantLib import *
-    from QuantLib import _QuantLib
-del sys
+from .QuantLib import *
+from . import _QuantLib
 
 __author__ = 'The QuantLib Group'
 __email__ = 'quantlib-users@lists.sourceforge.net'

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -81,7 +81,7 @@ class my_wrap(Command):
         os.system('swig -python -c++ -modern ' +
                   '-I%s ' % swig_dir +
                   '-outdir QuantLib -o QuantLib/quantlib_wrap.cpp ' +
-                  'quantlib.i')
+                  '%s/quantlib.i' % swig_dir)
 
 class my_build(build):
     user_options = build.user_options + [

--- a/Python/setup.py.in
+++ b/Python/setup.py.in
@@ -81,7 +81,7 @@ class my_wrap(Command):
         os.system('swig -python -c++ -modern ' +
                   '-I%s ' % swig_dir +
                   '-outdir QuantLib -o QuantLib/quantlib_wrap.cpp ' +
-                  'quantlib.i')
+                  '%s/quantlib.i' % swig_dir)
 
 class my_build(build):
     user_options = build.user_options + [

--- a/SWIG/linearalgebra.i
+++ b/SWIG/linearalgebra.i
@@ -70,7 +70,7 @@ bool extractArray(PyObject* source, Array* target) {
             $1 = *v;
         else {
             PyErr_SetString(PyExc_TypeError, "Array expected");
-            return NULL;
+            SWIG_fail;
         }
     }
 };
@@ -80,7 +80,7 @@ bool extractArray(PyObject* source, Array* target) {
     } else {
         if (SWIG_ConvertPtr($input,(void **) &$1,$1_descriptor,1) == -1) {
             PyErr_SetString(PyExc_TypeError, "Array expected");
-            return NULL;
+            SWIG_fail;
         }
     }
 };
@@ -152,7 +152,7 @@ bool extractArray(PyObject* source, Array* target) {
             } else {
                 PyErr_SetString(PyExc_TypeError, "Matrix expected");
                 Py_DECREF(o);
-                return NULL;
+                SWIG_fail;
             }
         } else {
             cols = 0;
@@ -168,7 +168,7 @@ bool extractArray(PyObject* source, Array* target) {
                     PyErr_SetString(PyExc_TypeError,
                         "Matrix must have equal-length rows");
                     Py_DECREF(o);
-                    return NULL;
+                    SWIG_fail;
                 }
                 for (Size j=0; j<cols; j++) {
                     PyObject* d = PySequence_GetItem(o,j);
@@ -182,14 +182,14 @@ bool extractArray(PyObject* source, Array* target) {
                         PyErr_SetString(PyExc_TypeError,"doubles expected");
                         Py_DECREF(d);
                         Py_DECREF(o);
-                        return NULL;
+                        SWIG_fail;
                     }
                 }
                 Py_DECREF(o);
             } else {
                 PyErr_SetString(PyExc_TypeError, "Matrix expected");
                 Py_DECREF(o);
-                return NULL;
+                SWIG_fail;
             }
         }
     } else {
@@ -214,7 +214,7 @@ bool extractArray(PyObject* source, Array* target) {
             } else {
                 PyErr_SetString(PyExc_TypeError, "Matrix expected");
                 Py_DECREF(o);
-                return NULL;
+                SWIG_fail;
             }
         } else {
             cols = 0;
@@ -231,7 +231,7 @@ bool extractArray(PyObject* source, Array* target) {
                     PyErr_SetString(PyExc_TypeError,
                         "Matrix must have equal-length rows");
                     Py_DECREF(o);
-                    return NULL;
+                    SWIG_fail;
                 }
                 for (Size j=0; j<cols; j++) {
                     PyObject* d = PySequence_GetItem(o,j);
@@ -245,14 +245,14 @@ bool extractArray(PyObject* source, Array* target) {
                         PyErr_SetString(PyExc_TypeError,"doubles expected");
                         Py_DECREF(d);
                         Py_DECREF(o);
-                        return NULL;
+                        SWIG_fail;
                     }
                 }
                 Py_DECREF(o);
             } else {
                 PyErr_SetString(PyExc_TypeError, "Matrix expected");
                 Py_DECREF(o);
-                return NULL;
+                SWIG_fail;
             }
         }
         $1 = &temp;


### PR DESCRIPTION
1. Fix import of _QuantLib in `__init__.py`
2. Replace `return NULL` with `SWIG_fail`, which handles cases where the error value is -1.
3. Also, fix swig command-line to avoid this warning:

    SWIG:1: Warning 125: Use of the include path to find the input file
    is deprecated and will not work with ccache. Please include the path
    when specifying the input file.