### PR TITLE
Follow standard Python conventions in tests

### DIFF
--- a/Python/test/QuantLibTestSuite.py
+++ b/Python/test/QuantLibTestSuite.py
@@ -16,106 +16,17 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
+import os
 import sys
 import unittest
 
-from date import DateTest
-from daycounters import DayCountersTest
-from instruments import InstrumentTest
-from marketelements import MarketElementTest
-from integrals import IntegralTest
-from solvers1d import Solver1DTest
-from termstructures import TermStructureTest
-from bonds import (
-    FixedRateBondTest,
-    FixedRateBondKwargsTest,
-    AmortizingFixedRateBondTest)
-from ratehelpers import (
-    FixedRateBondHelperTest,
-    FxSwapRateHelperTest,
-    OISRateHelperTest,
-    CrossCurrencyBasisSwapRateHelperTest)
-from calendars import JointCalendarTest
-from cms import CmsTest
-from assetswap import AssetSwapTest
-from capfloor import CapFloorTest
-from blackformula import BlackFormulaTest
-from blackformula import BlackDeltaCalculatorTest
-from iborindex import IborIndexTest
-from sabr import SabrTest
-from slv import SlvTest
-from ode import OdeTest
-from americanquantooption import AmericanQuantoOptionTest
-from extrapolation import ExtrapolationTest
-from fdm import FdmTest
-from swaption import SwaptionTest
-from volatilities import SviSmileSectionTest, SwaptionVolatilityCubeTest, AndreasenHugeVolatilityTest
-from inflation import InflationTest
-from coupons import (
-    CashFlowsTest,
-    SubPeriodsCouponTest,
-    IborCouponTest,
-    OvernightCouponTest,
-    FixedRateCouponTest)
-from options import OptionsTest
-from swap import ZeroCouponSwapTest, EquityTotalReturnSwapTest
-from currencies import CurrencyTest
-from equityindex import EquityIndexTest
+import QuantLib as ql
 
 
 def test():
-    import QuantLib
-    print('testing QuantLib ' + QuantLib.__version__)
-
-    suite = unittest.TestSuite()
-
-    suite.addTest(unittest.makeSuite(DateTest, 'test'))
-    suite.addTest(DayCountersTest())
-    suite.addTest(unittest.makeSuite(InstrumentTest, 'test'))
-    suite.addTest(unittest.makeSuite(MarketElementTest, 'test'))
-    suite.addTest(unittest.makeSuite(IntegralTest, 'test'))
-    suite.addTest(Solver1DTest())
-    suite.addTest(unittest.makeSuite(TermStructureTest, 'test'))
-    suite.addTest(unittest.makeSuite(FixedRateBondTest, 'test'))
-    suite.addTest(unittest.makeSuite(FixedRateBondKwargsTest, 'test'))
-    suite.addTest(unittest.makeSuite(AmortizingFixedRateBondTest, 'test'))
-    suite.addTest(unittest.makeSuite(FixedRateBondHelperTest, 'test'))
-    suite.addTest(unittest.makeSuite(CmsTest, 'test'))
-    suite.addTest(unittest.makeSuite(AssetSwapTest, 'test'))
-    suite.addTest(unittest.makeSuite(OISRateHelperTest, "test"))
-    suite.addTest(unittest.makeSuite(FxSwapRateHelperTest, 'test'))
-    suite.addTest(unittest.makeSuite(CapFloorTest, 'test'))
-    suite.addTest(unittest.makeSuite(BlackFormulaTest, 'test'))
-    suite.addTest(unittest.makeSuite(BlackDeltaCalculatorTest, 'test'))
-    suite.addTest(unittest.makeSuite(IborIndexTest, 'test'))
-    suite.addTest(unittest.makeSuite(SabrTest, 'test'))
-    suite.addTest(unittest.makeSuite(SlvTest, 'test'))
-    suite.addTest(unittest.makeSuite(OdeTest, 'test'))
-    suite.addTest(unittest.makeSuite(AmericanQuantoOptionTest, 'test'))
-    suite.addTest(unittest.makeSuite(ExtrapolationTest, 'test'))
-    suite.addTest(unittest.makeSuite(FdmTest, 'test'))
-    suite.addTest(unittest.makeSuite(SwaptionTest, "test"))
-    suite.addTest(unittest.makeSuite(SwaptionVolatilityCubeTest, 'test'))
-    suite.addTest(unittest.makeSuite(InflationTest, "test"))
-    suite.addTest(unittest.makeSuite(CrossCurrencyBasisSwapRateHelperTest, "test"))
-    suite.addTest(unittest.makeSuite(CashFlowsTest, "test"))
-    suite.addTest(unittest.makeSuite(SubPeriodsCouponTest, "test"))
-    suite.addTest(unittest.makeSuite(IborCouponTest, "test"))
-    suite.addTest(unittest.makeSuite(OvernightCouponTest, "test"))
-    suite.addTest(unittest.makeSuite(FixedRateCouponTest, "test"))
-    suite.addTest(unittest.makeSuite(OptionsTest, "test"))
-    suite.addTest(unittest.makeSuite(ZeroCouponSwapTest, "test"))
-    suite.addTest(unittest.makeSuite(CurrencyTest, "test"))
-    suite.addTest(unittest.makeSuite(SviSmileSectionTest, "test"))
-    suite.addTest(unittest.makeSuite(AndreasenHugeVolatilityTest, "test"))
-    suite.addTest(unittest.makeSuite(EquityIndexTest, "test"))
-    suite.addTest(unittest.makeSuite(EquityTotalReturnSwapTest, "test"))
-    suite.addTest(unittest.makeSuite(JointCalendarTest, "test"))
-
-    result = unittest.TextTestRunner(verbosity=2).run(suite)
-
-    if not result.wasSuccessful():
-        sys.exit(1)
+    print('testing QuantLib', ql.__version__)
+    sys.argv[1:1] = ['discover', '-s', os.path.dirname(__file__)]
+    unittest.main(module=None, verbosity=2)
 
 
 if __name__ == '__main__':

--- a/Python/test/test_americanquantooption.py
+++ b/Python/test/test_americanquantooption.py
@@ -97,7 +97,5 @@ class AmericanQuantoOptionTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    print('testing QuantLib ' + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(AmericanQuantoOptionTest,'test'))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_assetswap.py
+++ b/Python/test/test_assetswap.py
@@ -5351,7 +5351,5 @@ class AssetSwapTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(AssetSwapTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_blackformula.py
+++ b/Python/test/test_blackformula.py
@@ -43,10 +43,10 @@ class BlackFormulaTest(unittest.TestCase):
                                  self.vol,
                                  self.df,
                                  self.displacement)
-        self.assertAlmostEquals(expected, res, delta=1e-4,
-                                msg="Failed to calculate simple  "
-                                    "Black-Scholes-Merton price rounded to "
-                                    "four decimal places.")
+        self.assertAlmostEqual(expected, res, delta=1e-4,
+                               msg="Failed to calculate simple  "
+                                   "Black-Scholes-Merton price rounded to "
+                                   "four decimal places.")
 
     def test_black_formula_implied_stdev(self):
         """Testing implied volatility calculator"""
@@ -57,9 +57,9 @@ class BlackFormulaTest(unittest.TestCase):
                                               self.forward,
                                               black_price,
                                               self.df)
-        self.assertAlmostEquals(expected, res, delta=1e-4,
-                                msg="Failed to determine Implied Vol rounded "
-                                    "to a single vol bps.")
+        self.assertAlmostEqual(expected, res, delta=1e-4,
+                               msg="Failed to determine Implied Vol rounded "
+                                   "to a single vol bps.")
 
 
 class BlackDeltaCalculatorTest(unittest.TestCase):
@@ -109,7 +109,7 @@ class BlackDeltaCalculatorTest(unittest.TestCase):
 
         strike = black_calculator.strikeFromDelta(spot_delta_level)
 
-        self.assertAlmostEquals(expected_strike, strike, delta=1e-4)
+        self.assertAlmostEqual(expected_strike, strike, delta=1e-4)
 
     def test_spot_atm_delta_calculator(self):
         """Test for 0-delta straddle strike"""
@@ -134,8 +134,9 @@ class BlackDeltaCalculatorTest(unittest.TestCase):
 
         strike = black_calculator.atmStrike(ql.DeltaVolQuote.AtmDeltaNeutral)
 
-        self.assertAlmostEquals(expected_strike, strike, delta=1e-4)
+        self.assertAlmostEqual(expected_strike, strike, delta=1e-4)
 
 
 if __name__ == '__main__':
-    unittest.main()
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_bonds.py
+++ b/Python/test/test_bonds.py
@@ -356,9 +356,5 @@ class AmortizingFixedRateBondTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(FixedRateBondTest, "test"))
-    suite.addTest(unittest.makeSuite(FixedRateBondKwargsTest, "test"))
-    suite.addTest(unittest.makeSuite(AmortizingFixedRateBondTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_calendars.py
+++ b/Python/test/test_calendars.py
@@ -36,7 +36,5 @@ class JointCalendarTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(JointCalendarTest())
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_capfloor.py
+++ b/Python/test/test_capfloor.py
@@ -113,7 +113,5 @@ class CapFloorTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    print('testing QuantLib ' + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(CapFloorTest,'test'))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_cms.py
+++ b/Python/test/test_cms.py
@@ -302,7 +302,5 @@ class CmsTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(CmsTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_coupons.py
+++ b/Python/test/test_coupons.py
@@ -467,11 +467,5 @@ class SubPeriodsCouponTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    print('testing QuantLib ' + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(CashFlowsTest, 'test'))
-    suite.addTest(unittest.makeSuite(SubPeriodsCouponTest, 'test'))
-    suite.addTest(unittest.makeSuite(IborCouponTest, 'test'))
-    suite.addTest(unittest.makeSuite(OvernightCouponTest, 'test'))
-    suite.addTest(unittest.makeSuite(FixedRateCouponTest, 'test'))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_currencies.py
+++ b/Python/test/test_currencies.py
@@ -42,7 +42,5 @@ class CurrencyTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    print('testing QuantLib ' + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(CurrencyTest, 'test'))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_date.py
+++ b/Python/test/test_date.py
@@ -71,7 +71,5 @@ wrong day, month, year increment
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(DateTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_daycounters.py
+++ b/Python/test/test_daycounters.py
@@ -3,8 +3,8 @@ import unittest
 
 
 class DayCountersTest(unittest.TestCase):
-    def runTest(self):
-        "Testing daycounters"
+    def test_bus252(self):
+        """Test Business252 daycounter"""
 
         calendar = ql.UnitedStates(ql.UnitedStates.GovernmentBond)
 
@@ -21,7 +21,5 @@ class DayCountersTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(DayCountersTest())
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_equityindex.py
+++ b/Python/test/test_equityindex.py
@@ -63,7 +63,5 @@ class EquityIndexTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    print('testing QuantLib ' + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(EquityIndexTest, 'test'))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_extrapolation.py
+++ b/Python/test/test_extrapolation.py
@@ -40,7 +40,5 @@ class ExtrapolationTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(ExtrapolationTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_fdm.py
+++ b/Python/test/test_fdm.py
@@ -645,7 +645,5 @@ class FdmTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(FdmTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_iborindex.py
+++ b/Python/test/test_iborindex.py
@@ -70,7 +70,5 @@ class IborIndexTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(IborIndexTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_inflation.py
+++ b/Python/test/test_inflation.py
@@ -283,7 +283,7 @@ class InflationTest(unittest.TestCase):
                               actual_payment=actual_inflation_leg_payment,
                               expected_payment=expected_inflation_leg_payment,
                               tolerance=EPSILON)
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             first=actual_inflation_leg_payment,
             second=expected_inflation_leg_payment,
             delta=EPSILON,
@@ -332,7 +332,7 @@ class InflationTest(unittest.TestCase):
                               base_index=swap_base_fixing,
                               expected_base_index=expected_swap_base_index,
                               tolerance=EPSILON)
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             first=swap_base_fixing,
             second=expected_swap_base_index,
             delta=EPSILON,
@@ -368,7 +368,7 @@ class InflationTest(unittest.TestCase):
                               base_fixing=curve_base_fixing,
                               expected_base_fixing=expected_curve_base_fixing,
                               tolerance=EPSILON)
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             first=curve_base_fixing,
             second=expected_curve_base_fixing,
             msg=fail_msg,
@@ -403,7 +403,7 @@ class InflationTest(unittest.TestCase):
                               actual_fixing=actual_fixing,
                               expected_fixing=expected_fixing,
                               tolerance=EPSILON)
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             first=actual_fixing,
             second=expected_fixing,
             msg=fail_msg,
@@ -411,7 +411,5 @@ class InflationTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    print('testing QuantLib ' + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(InflationTest, 'test'))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_instruments.py
+++ b/Python/test/test_instruments.py
@@ -26,38 +26,41 @@ def raiseFlag():
     flag = 1
 
 
-class MarketElementTest(unittest.TestCase):
+class InstrumentTest(unittest.TestCase):
     def testObservable(self):
-        "Testing observability of market elements"
-        global flag
-        flag = None
-        me = ql.SimpleQuote(0.0)
-        obs = ql.Observer(raiseFlag)
-        obs.registerWith(me)
-        me.setValue(3.14)
-        if not flag:
-            self.fail("Observer was not notified of market element change")
-
-    def testObservableHandle(self):
-        "Testing observability of market element handles"
+        "Testing observability of stocks"
         global flag
         flag = None
         me1 = ql.SimpleQuote(0.0)
         h = ql.RelinkableQuoteHandle(me1)
+        s = ql.Stock(h)
+        s.NPV()
+
         obs = ql.Observer(raiseFlag)
-        obs.registerWith(h)
+        obs.registerWith(s)
+
         me1.setValue(3.14)
         if not flag:
-            self.fail("Observer was not notified of market element change")
+            self.fail("Observer was not notified of instrument change")
+
+        s.NPV()
         flag = None
         me2 = ql.SimpleQuote(0.0)
         h.linkTo(me2)
         if not flag:
-            self.fail("Observer was not notified of market element change")
+            self.fail("Observer was not notified of instrument change")
+
+        s.NPV()
+        flag = None
+        s.freeze()
+        me2.setValue(2.71)
+        if flag:
+            self.fail("Observer was notified of frozen instrument change")
+        s.unfreeze()
+        if not flag:
+            self.fail("Observer was not notified of instrument change")
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(MarketElementTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_integrals.py
+++ b/Python/test/test_integrals.py
@@ -65,7 +65,5 @@ integrating %(tag)s
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(IntegralTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_marketelements.py
+++ b/Python/test/test_marketelements.py
@@ -26,43 +26,36 @@ def raiseFlag():
     flag = 1
 
 
-class InstrumentTest(unittest.TestCase):
+class MarketElementTest(unittest.TestCase):
     def testObservable(self):
-        "Testing observability of stocks"
+        "Testing observability of market elements"
+        global flag
+        flag = None
+        me = ql.SimpleQuote(0.0)
+        obs = ql.Observer(raiseFlag)
+        obs.registerWith(me)
+        me.setValue(3.14)
+        if not flag:
+            self.fail("Observer was not notified of market element change")
+
+    def testObservableHandle(self):
+        "Testing observability of market element handles"
         global flag
         flag = None
         me1 = ql.SimpleQuote(0.0)
         h = ql.RelinkableQuoteHandle(me1)
-        s = ql.Stock(h)
-        s.NPV()
-
         obs = ql.Observer(raiseFlag)
-        obs.registerWith(s)
-
+        obs.registerWith(h)
         me1.setValue(3.14)
         if not flag:
-            self.fail("Observer was not notified of instrument change")
-
-        s.NPV()
+            self.fail("Observer was not notified of market element change")
         flag = None
         me2 = ql.SimpleQuote(0.0)
         h.linkTo(me2)
         if not flag:
-            self.fail("Observer was not notified of instrument change")
-
-        s.NPV()
-        flag = None
-        s.freeze()
-        me2.setValue(2.71)
-        if flag:
-            self.fail("Observer was notified of frozen instrument change")
-        s.unfreeze()
-        if not flag:
-            self.fail("Observer was not notified of instrument change")
+            self.fail("Observer was not notified of market element change")
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(InstrumentTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_ode.py
+++ b/Python/test/test_ode.py
@@ -42,7 +42,5 @@ class OdeTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    print('testing QuantLib ' + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(OdeTest,'test'))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_options.py
+++ b/Python/test/test_options.py
@@ -105,7 +105,5 @@ class OptionsTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    print('testing QuantLib ' + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(OptionsTest,'test'))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_ratehelpers.py
+++ b/Python/test/test_ratehelpers.py
@@ -678,7 +678,7 @@ class CrossCurrencyBasisSwapRateHelperTest(unittest.TestCase):
 
         # Trigger bootstrap
         discount_at_origin = term_structure.discount(settlement_date)
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             first=discount_at_origin, second=1.0, delta=eps)
 
         for q, h in zip(self.cross_currency_basis_quotes, helpers):
@@ -694,7 +694,7 @@ class CrossCurrencyBasisSwapRateHelperTest(unittest.TestCase):
                                   actual_rate=actual_rate,
                                   expected_rate=expected_rate,
                                   tolerance=eps)
-            self.assertAlmostEquals(
+            self.assertAlmostEqual(
                 first=actual_rate,
                 second=expected_rate,
                 delta=eps,
@@ -733,11 +733,5 @@ class CrossCurrencyBasisSwapRateHelperTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(FixedRateBondHelperTest, "test"))
-    suite.addTest(unittest.makeSuite(OISRateHelperTest, "test"))
-    suite.addTest(unittest.makeSuite(FxSwapRateHelperTest, "test"))
-    suite.addTest(unittest.makeSuite(
-        CrossCurrencyBasisSwapRateHelperTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_sabr.py
+++ b/Python/test/test_sabr.py
@@ -116,7 +116,5 @@ class SabrTest(unittest.TestCase):
                                msg="Unable to match PDE CEV value with analytic CEV value")
 
 if __name__ == '__main__':
-    print('testing QuantLib ' + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(SabrTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_slv.py
+++ b/Python/test/test_slv.py
@@ -174,7 +174,5 @@ class SlvTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(SlvTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_solvers1d.py
+++ b/Python/test/test_solvers1d.py
@@ -28,7 +28,7 @@ class Foo:
 
 
 class Solver1DTest(unittest.TestCase):
-    def runTest(self):
+    def test_solve(self):
         "Testing 1-D solvers"
         for factory in [ql.Brent, ql.Bisection, ql.FalsePosition, ql.Ridder, ql.Secant]:
             solver = factory()
@@ -87,7 +87,5 @@ class Solver1DTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(Solver1DTest())
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_swap.py
+++ b/Python/test/test_swap.py
@@ -244,8 +244,5 @@ class EquityTotalReturnSwapTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    print('testing QuantLib ' + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(ZeroCouponSwapTest, 'test'))
-    suite.addTest(unittest.makeSuite(EquityTotalReturnSwapTest, 'test'))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_swaption.py
+++ b/Python/test/test_swaption.py
@@ -171,7 +171,7 @@ class SwaptionTest(unittest.TestCase):
                                               method=SETTLEMENT_METHOD_MAP[m],
                                               annuity=annuity,
                                               expected_annuity=expected_annuity)
-                        self.assertAlmostEquals(
+                        self.assertAlmostEqual(
                             first=annuity,
                             second=expected_annuity,
                             delta=EPSILON,
@@ -191,7 +191,5 @@ class SwaptionTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(SwaptionTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_termstructures.py
+++ b/Python/test/test_termstructures.py
@@ -169,7 +169,7 @@ class TermStructureTest(unittest.TestCase):
                         actual zero rate: {actual}
                   """.format(expected=expectedZeroRate,
                              actual=actualZeroRate)
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             first=expectedZeroRate,
             second=actualZeroRate,
             delta=1.0e-12,
@@ -201,7 +201,7 @@ class TermStructureTest(unittest.TestCase):
                       """.format(timeToMaturity=t,
                                  expected=expectedForward,
                                  actual=actualForward)
-            self.assertAlmostEquals(
+            self.assertAlmostEqual(
                 first=expectedForward,
                 second=actualForward,
                 delta=1.0e-12,
@@ -289,7 +289,7 @@ class TermStructureTest(unittest.TestCase):
             vanilla_pv=vanilla_option_pv
         )
 
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             quanto_option_pv,
             vanilla_option_pv,
             delta=1e-12,
@@ -319,7 +319,5 @@ class TermStructureTest(unittest.TestCase):
         self.termStructure.unfreeze()
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(TermStructureTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/Python/test/test_volatilities.py
+++ b/Python/test/test_volatilities.py
@@ -296,7 +296,7 @@ class SwaptionVolatilityCubeTest(unittest.TestCase):
                               swap_tenor=swap_tenor,
                               strike=actual_atm_strike,
                               replicated_strike=expected_atm_strike)
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             first=actual_atm_strike,
             second=expected_atm_strike,
             delta=TOLERANCE,
@@ -331,7 +331,7 @@ class SwaptionVolatilityCubeTest(unittest.TestCase):
                               vol=actual_vol,
                               expected_vol=expected_vol,
                               eps=epsilon)
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             first=actual_vol,
             second=expected_vol,
             delta=epsilon,
@@ -367,7 +367,7 @@ class SwaptionVolatilityCubeTest(unittest.TestCase):
                               vol=actual_vol,
                               expected_vol=expected_vol,
                               eps=epsilon)
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             first=actual_vol,
             second=expected_vol,
             delta=epsilon,
@@ -630,9 +630,5 @@ class AndreasenHugeVolatilityTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print("testing QuantLib " + ql.__version__)
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(SwaptionVolatilityCubeTest, "test"))
-    suite.addTest(unittest.makeSuite(SviSmileSectionTest, "test"))
-    suite.addTest(unittest.makeSuite(AndreasenHugeVolatilityTest, "test"))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
* Rename test scripts to test_*.py. This makes them discoverable by standard tools like IDEs, pytest, TestLoader.discover, etc.

* Automatically discover test classes instead of listing them manually. This is simpler and less error prone. In addition, standard command line options now work, for example, -k for filtering tests.

* Don't use deprecated methods and implement test_ methods instead of runTest.