### PR TITLE
Avoid using the deprecated `distutils` module; `setuptools` is now required for building

### DIFF
--- a/Python/README.txt
+++ b/Python/README.txt
@@ -2,7 +2,8 @@
 The C++ wrappers for the QuantLib-Python extension module are created
 by means of SWIG (Simplified Wrapper and Interface Generator)
 available from <http://www.swig.org/>; the latest version is suggested.
-At this time, we only support Python 3.x.
+
+Building the wrappers requires the Setuptools package.
 
 Generating the wrappers is not required if you are using a distributed
 tarball. If you're building from a Git checkout, instead, use the
@@ -10,12 +11,11 @@ command:
 
     python setup.py wrap
 
-The commands to be issued for building, testing and installing the
+The commands to be issued for building and testing the
 wrappers are:
 
     python setup.py build
     python setup.py test
-    python setup.py install
 
 respectively.
 
@@ -25,10 +25,13 @@ found by the compiler. On Unix-like platforms, this requires that
 it requires you to define a `QL_DIR` environment variable pointing to
 your QuantLib directory (e.g., `C:\Lib\QuantLib`.)
 
-The install step might require superuser privileges.
-An alternate install location can be specified with the command:
+The suggested way to install the module is to run first
 
-    python setup.py install --prefix=/home/johndoe
+    python setup.py bdist_wheel
+
+which requires the wheel module to be available and which will create
+a QuantLib wheel in the dist folder.  The resulting wheel can then
+be installed with pip in the desired environment.
 
 The test suite is implemented on top of the PyUnit framework, which is
 included in the Python standard library.

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -18,15 +18,11 @@
 """
 
 import os, sys, math
-try:
-    from setuptools import setup, Extension
-    from setuptools import Command
-except:
-    from distutils.core import setup, Extension
-    from distutils.cmd import Command
-from distutils.command.build_ext import build_ext
-from distutils.command.build import build
-from distutils.ccompiler import get_default_compiler
+from setuptools import setup, Extension
+from setuptools import Command
+from setuptools.command.build_ext import build_ext
+from setuptools.command.build import build
+from setuptools._distutils.ccompiler import get_default_compiler
 
 class test(Command):
     # Original version of this class posted
@@ -215,10 +211,11 @@ setup(name             = "QuantLib",
       version          = "1.32-dev",
       description      = "Python bindings for the QuantLib library",
       long_description = """
-QuantLib (https://www.quantlib.org/) is a C++ library for financial quantitative
-analysts and developers, aimed at providing a comprehensive software
-framework for quantitative finance.
+QuantLib (https://www.quantlib.org/) is a free/open-source C++ library
+for financial quantitative analysts and developers, aimed at providing
+a comprehensive software framework for quantitative finance.
       """,
+      long_description_content_type = "text/x-rst",
       author           = "QuantLib Team",
       author_email     = "quantlib-users@lists.sourceforge.net",
       url              = "https://www.quantlib.org",

--- a/Python/setup.py.in
+++ b/Python/setup.py.in
@@ -18,15 +18,11 @@
 """
 
 import os, sys, math
-try:
-    from setuptools import setup, Extension
-    from setuptools import Command
-except:
-    from distutils.core import setup, Extension
-    from distutils.cmd import Command
-from distutils.command.build_ext import build_ext
-from distutils.command.build import build
-from distutils.ccompiler import get_default_compiler
+from setuptools import setup, Extension
+from setuptools import Command
+from setuptools.command.build_ext import build_ext
+from setuptools.command.build import build
+from setuptools._distutils.ccompiler import get_default_compiler
 
 class test(Command):
     # Original version of this class posted
@@ -215,10 +211,11 @@ setup(name             = "QuantLib",
       version          = "@PACKAGE_VERSION@",
       description      = "Python bindings for the QuantLib library",
       long_description = """
-QuantLib (https://www.quantlib.org/) is a C++ library for financial quantitative
-analysts and developers, aimed at providing a comprehensive software
-framework for quantitative finance.
+QuantLib (https://www.quantlib.org/) is a free/open-source C++ library
+for financial quantitative analysts and developers, aimed at providing
+a comprehensive software framework for quantitative finance.
       """,
+      long_description_content_type = "text/x-rst",
       author           = "QuantLib Team",
       author_email     = "quantlib-users@lists.sourceforge.net",
       url              = "https://www.quantlib.org",


### PR DESCRIPTION
`distutils` will be removed in Python 3.12, out in October.