### PR TITLE
added redemption and paymentLag args to amortizingbond signatures

### DIFF
--- a/SWIG/bonds.i
+++ b/SWIG/bonds.i
@@ -316,7 +316,9 @@ class AmortizingFixedRateBond : public Bond {
             const Period& exCouponPeriod = Period(),
             const Calendar& exCouponCalendar = Calendar(),
             const BusinessDayConvention exCouponConvention = Unadjusted,
-            bool exCouponEndOfMonth = false);
+            bool exCouponEndOfMonth = false,
+            const std::vector<Real>& redemptions = { 100.0 },
+            Natural paymentLag = 0);
     AmortizingFixedRateBond(
             Integer settlementDays,
             const Calendar& paymentCalendar,
@@ -368,7 +370,9 @@ class AmortizingFloatingRateBond : public Bond {
         const Period& exCouponPeriod = Period(),
         const Calendar& exCouponCalendar = Calendar(),
         const BusinessDayConvention exCouponConvention = Unadjusted,
-        bool exCouponEndOfMonth = false);
+        bool exCouponEndOfMonth = false,
+        const std::vector<Real>& redemptions = { 100.0 },
+        Natural paymentLag = 0);;
 };
 
 


### PR DESCRIPTION
This PR syncs up the SWIG code to the C++ function signatures in  [#1790](https://github.com/lballabio/QuantLib/pull/1790).
