### PR TITLE
Expose `reset` function in calendar base class

### DIFF
--- a/Python/test/test_calendars.py
+++ b/Python/test/test_calendars.py
@@ -35,6 +35,21 @@ class JointCalendarTest(unittest.TestCase):
             self.assertIn(holiday, joint_holidays)
 
 
+class ResetBespokeCalendarTest(unittest.TestCase):
+
+    def test_reset_added_holidays(self):
+        calendar = ql.BespokeCalendar("bespoke thing")
+
+        test_date: ql.Date = ql.Date(1, ql.January, 2024)
+        self.assertFalse(calendar.isHoliday(test_date))
+        calendar.addHoliday(test_date)
+        self.assertTrue(calendar.isHoliday(test_date))
+        # TODO: Can extend test with this, if exposed:
+        # self.assertEqual(len(calendar.addedHolidays()), 1)
+        calendar.resetAddedAndRemovedHolidays()
+        self.assertFalse(calendar.isHoliday(test_date))
+
+
 if __name__ == "__main__":
     print("testing QuantLib", ql.__version__)
     unittest.main(verbosity=2)

--- a/SWIG/calendars.i
+++ b/SWIG/calendars.i
@@ -90,6 +90,8 @@ class Calendar {
     bool isEndOfMonth(const Date&);
     void addHoliday(const Date&);
     void removeHoliday(const Date&);
+    void resetAddedAndRemovedHolidays();
+
     Date adjust(const Date& d,
                 BusinessDayConvention convention = QuantLib::Following);
     Date advance(const Date& d, Integer n, TimeUnit unit,


### PR DESCRIPTION
New test to ensure it's usable.

I'd also like to expose `addedHolidays()` and `removedHolidays()`, but it seems rather tricky to expose `std::set` with SWIG (as opposed to an `std::unordered_set`). If anyone else can have a go, feel free! This might be a relevant reference: [Stack Overflow](https://stackoverflow.com/questions/73900661/using-swig-python-wrapper-argument-2-of-type-stdunordered-set-stdstring)