### PR TITLE
Target netstandard2.0

### DIFF
--- a/CSharp/csharp/NQuantLib.csproj
+++ b/CSharp/csharp/NQuantLib.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <PackageDescription>QuantLib</PackageDescription>
   </PropertyGroup>
   <ItemGroup>

--- a/CSharp/examples/BermudanSwaption/BermudanSwaption.csproj
+++ b/CSharp/examples/BermudanSwaption/BermudanSwaption.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/CSharp/examples/EquityOption/EquityOption.csproj
+++ b/CSharp/examples/EquityOption/EquityOption.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/CSharp/examples/FiniteDifferenceMethods/FiniteDifferenceMethods.csproj
+++ b/CSharp/examples/FiniteDifferenceMethods/FiniteDifferenceMethods.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/CSharp/examples/Times/Times.csproj
+++ b/CSharp/examples/Times/Times.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
   </PropertyGroup>


### PR DESCRIPTION
Many .NET applications still run on .NET Framework and cannot consume the `net60` build. I propose we also target `netstandard2.0` which would require a minimum .NET Framework version of `net472`. I don't think it's worth targeting lower than that.

I added the `net472` target for the example projects, but strictly that's not required. Let me know if I should revert that.

Do you have a manual process to prepare the NuGet package?