### PR TITLE
Allow different calendars and frequencies in OISRateHelper

### DIFF
--- a/SWIG/date.i
+++ b/SWIG/date.i
@@ -169,6 +169,32 @@ enum Frequency {
     OtherFrequency = 999
 };
 
+#if defined(SWIGPYTHON)
+%define QL_TYPECHECK_FREQUENCY       6210    %enddef
+%typemap(in) ext::optional<Frequency> %{
+	if($input == Py_None)
+		$1 = ext::nullopt;
+    else if (PyInt_Check($input))
+        $1 = (Frequency) PyInt_AsLong($input);
+	else
+		$1 = (Frequency) PyLong_AsLong($input);
+%}
+%typecheck (QL_TYPECHECK_FREQUENCY) ext::optional<Frequency> {
+if (PyInt_Check($input) || PyLong_Check($input) || Py_None == $input)
+	$1 = 1;
+else
+	$1 = 0;
+}
+#else
+#if defined(SWIGCSHARP)
+%typemap(cscode) ext::optional<Frequency> %{
+    public static implicit operator OptionalFrequency(Frequency f) => new OptionalFrequency(f);
+%}
+#endif
+%template(OptionalFrequency) ext::optional<Frequency>;
+#endif
+
+
 #if defined(SWIGJAVA)
 %javaconst(0);
 #endif

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -330,7 +330,9 @@ class OISRateHelper : public RateHelper {
             Pillar::Choice pillar = Pillar::LastRelevantDate,
             Date customPillarDate = Date(), 
             RateAveraging::Type averagingMethod = RateAveraging::Compound,
-            ext::optional<bool> endOfMonth = ext::nullopt);
+            ext::optional<bool> endOfMonth = ext::nullopt,
+            ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
+            const Calendar& fixedCalendar = Calendar());
     ext::shared_ptr<OvernightIndexedSwap> swap();
 };
 
@@ -354,7 +356,9 @@ class DatedOISRateHelper : public RateHelper {
             const Calendar& paymentCalendar = Calendar(),
             const Period& forwardStart = 0 * Days,
             Spread overnightSpread = 0.0,
-            ext::optional<bool> endOfMonth = ext::nullopt);
+            ext::optional<bool> endOfMonth = ext::nullopt,
+            ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
+            const Calendar& fixedCalendar = Calendar());
 };
 
 %shared_ptr(FxSwapRateHelper)


### PR DESCRIPTION
Allow setting different calendars and payment frequencies for fixed and overnight legs.