### PR TITLE
Better reporting of deprecation warning

### DIFF
--- a/SWIG/common.i
+++ b/SWIG/common.i
@@ -162,7 +162,7 @@ a
 %pythoncode %{
 def OldName(*args, **kwargs):
     from warnings import warn
-    warn('%s is deprecated; use %s' % (OldName.__name__, NewName.__name__))
+    warn(f'{OldName.__name__} is deprecated; use {NewName.__name__}', FutureWarning, stacklevel=2)
     return NewName(*args, **kwargs)
 %}
 #endif


### PR DESCRIPTION
The message should now point to the location of the deprecated call.
Added category; `FutureWarning` was used because `DeprecatedWarning` is ignored by default.