### PR TITLE
Cleanup comparisons

### DIFF
--- a/Python/test/test_money.py
+++ b/Python/test/test_money.py
@@ -1,0 +1,18 @@
+import QuantLib as ql
+import operator
+import unittest
+
+
+class MoneyTest(unittest.TestCase):
+    def test_order(self):
+        ops = [operator.eq, operator.ne, operator.lt, operator.le, operator.gt, operator.ge]
+        usd = lambda v: ql.Money(v, ql.USDCurrency())
+        for m1 in (usd(1), usd(2)):
+            for m2 in (usd(1), usd(2)):
+                for op in ops:
+                    self.assertEqual(op(m1,  m2), op(m1.value(), m2.value()))
+
+
+if __name__ == "__main__":
+    print("testing QuantLib", ql.__version__)
+    unittest.main(verbosity=2)

--- a/SWIG/common.i
+++ b/SWIG/common.i
@@ -88,9 +88,6 @@ namespace ext {
             return (*self).operator->();
         }
         #if defined(SWIGPYTHON)
-        bool __nonzero__() {
-            return !!(*self);
-        }
         bool __bool__() {
             return !!(*self);
         }
@@ -111,9 +108,6 @@ class Handle {
     ext::shared_ptr<T> currentLink();
     #if defined(SWIGPYTHON)
     %extend {
-        bool __nonzero__() {
-            return !self->empty();
-        }
         bool __bool__() {
             return !self->empty();
         }

--- a/SWIG/currencies.i
+++ b/SWIG/currencies.i
@@ -78,9 +78,6 @@ class Currency {
         Money __rmul__(Decimal x) {
             return *self*x;
         }
-        bool __nonzero__() {
-            return !self->empty();
-        }
         bool __bool__() {
             return !self->empty();
         }

--- a/SWIG/date.i
+++ b/SWIG/date.i
@@ -282,7 +282,9 @@ else
   }
 %}
 #endif
-
+#if defined(SWIGJAVA)
+%typemap(javainterfaces) Period QL_JAVA_INTERFACES "Comparable<Period>"
+#endif
 
 %{
 using QuantLib::Period;
@@ -290,10 +292,6 @@ using QuantLib::PeriodParser;
 %}
 
 class Period {
-    #if defined(SWIGJAVA)
-    %rename("repr")           __repr__;
-    %rename("compare")        __cmp__;
-    #endif
   public:
     Period();
     Period(Integer n, TimeUnit units);
@@ -330,6 +328,7 @@ class Period {
             return *self * n;
         }
         #endif
+        #if defined(SWIGPYTHON) || defined(SWIGR) || defined(SWIGJAVA)
         #if defined(SWIGPYTHON)
         Period __rmul__(Integer n) {
             return *self * n;
@@ -346,8 +345,13 @@ class Period {
         bool __ge__(const Period& other) {
             return !(*self < other);
         }
+        #else
+        int __cmp__(const Period& other) {
+            return *self < other  ? -1 :
+                   *self == other ?  0 :
+                                     1;
+        }
         #endif
-        #if defined(SWIGPYTHON) || defined(SWIGR) || defined(SWIGJAVA)
         bool __eq__(const Period& other) {
             return *self == other;
         }
@@ -360,11 +364,6 @@ class Period {
             boost::hash_combine(seed, p.length());
             boost::hash_combine(seed, p.units());
             return seed;
-        }
-        int __cmp__(const Period& other) {
-            return *self < other  ? -1 :
-                   *self == other ?  0 :
-                                     1;
         }
         #endif
 
@@ -551,6 +550,9 @@ function(from) {Period(from)})
    }
 %}
 #endif
+#if defined(SWIGJAVA)
+%typemap(javainterfaces) Date QL_JAVA_INTERFACES "Comparable<Date>"
+#endif
 
 %{
     // used in Date(string, string) defined below
@@ -563,10 +565,6 @@ function(from) {Period(from)})
 %}
 
 class Date {
-    #if defined(SWIGJAVA)
-    %rename("repr")           __repr__;
-    %rename("compare")        __cmp__;
-    #endif
   public:
     Date();
     Date(Day d, Month m, Year y);
@@ -742,19 +740,7 @@ class Date {
         hash_t __hash__() {
             return std::hash<Date>()(*self);
         }
-        int __cmp__(const Date& other) {
-            if (*self < other)
-                return -1;
-            else if (*self == other)
-                return 0;
-            else
-                return 1;
-        }
-        #endif
         #if defined(SWIGPYTHON)
-        bool __nonzero__() {
-            return (*self != Date());
-        }
         bool __bool__() {
             return (*self != Date());
         }
@@ -779,6 +765,16 @@ class Date {
             return Date(PyDateTime_GET_DAY(date), Month(PyDateTime_GET_MONTH(date)),
                         PyDateTime_GET_YEAR(date));
         }
+        #else
+        int __cmp__(const Date& other) {
+            if (*self < other)
+                return -1;
+            else if (*self == other)
+                return 0;
+            else
+                return 1;
+        }
+        #endif
         #endif
     }
 

--- a/SWIG/linearalgebra.i
+++ b/SWIG/linearalgebra.i
@@ -408,9 +408,6 @@ class Array {
                       "arrays are not resizable");
             std::copy(rhs.begin(),rhs.end(),self->begin()+i);
         }
-        bool __nonzero__() {
-            return (self->size() != 0);
-        }
         bool __bool__() {
             return (self->size() != 0);
         }

--- a/SWIG/money.i
+++ b/SWIG/money.i
@@ -22,14 +22,15 @@
 
 %include currencies.i
 
+#if defined(SWIGJAVA)
+%typemap(javainterfaces) Money QL_JAVA_INTERFACES "Comparable<Money>"
+#endif
+
 %{
 using QuantLib::Money;
 %}
 
 class Money {
-    #if defined(SWIGJAVA)
-    %rename("compare") __cmp__;
-    #endif
   public:
     Money(const Currency& currency, Decimal value);
     Money(Decimal value, const Currency& currency);
@@ -60,7 +61,7 @@ class Money {
         bool __ge__(const Money& other) {
             return !(*self < other);
         }
-        #endif
+        #else
         int __cmp__(const Money& other) {
             if (*self < other)
                 return -1;
@@ -68,6 +69,13 @@ class Money {
                 return 0;
             else
                 return 1;
+        }
+        #endif
+        bool __eq__(const Money& other) {
+            return *self == other;
+        }
+        bool __ne__(const Money& other) {
+            return *self != other;
         }
         std::string __str__() {
             std::ostringstream out;

--- a/SWIG/ql.i
+++ b/SWIG/ql.i
@@ -91,8 +91,11 @@ GNU autoconf configure script.
 %rename(getValue)      operator();
 %rename(equals)        __eq__;
 %rename(unEquals)      __ne__;
+%rename(compareTo)     __cmp__;
+%javamethodmodifiers   __cmp__ "@Override public"
 %rename(hashCode)      __hash__;
 %rename(toString)      __str__;
+%rename(repr)          __repr__;
 #elif defined(SWIGCSHARP)
 %rename(Add)           operator+;
 %rename(Add)           __add__;

--- a/SWIG/quantlib.i
+++ b/SWIG/quantlib.i
@@ -70,12 +70,13 @@ const char* __version__;
 %typemap(javaimports) SWIGTYPE %{
 import java.lang.AutoCloseable;
 %}
-%typemap(javainterfaces) SWIGTYPE "AutoCloseable";
+#define QL_JAVA_INTERFACES "AutoCloseable, "
+%typemap(javainterfaces) SWIGTYPE "AutoCloseable"
 %extend std::vector {
-    %typemap(javainterfaces) std::vector "AutoCloseable, java.util.RandomAccess";
+    %typemap(javainterfaces) std::vector QL_JAVA_INTERFACES "java.util.RandomAccess"
 };
 %extend std::vector<bool> {
-    %typemap(javainterfaces) std::vector "AutoCloseable, java.util.RandomAccess"
+    %typemap(javainterfaces) std::vector QL_JAVA_INTERFACES "java.util.RandomAccess"
 }
 %typemap(javacode) SWIGTYPE %{
   @Override
@@ -83,6 +84,8 @@ import java.lang.AutoCloseable;
    this.delete();
   }
 %}
+#else
+#define QL_JAVA_INTERFACES
 #endif
 
 #if !defined(JAVA_FINALIZER)

--- a/SWIG/timeseries.i
+++ b/SWIG/timeseries.i
@@ -54,9 +54,6 @@ class TimeSeries {
     Size size();
     #if defined(SWIGPYTHON)
     %extend {
-        bool __nonzero__() {
-            return !self->empty();
-        }
         bool __bool__() {
             return !self->empty();
         }


### PR DESCRIPTION
* Fix comparing Money in Python: `__eq__` and `__ne__` were missing.

* Expose `__cmp__` as compareTo() in Java. This is the correct name for this method. "compare" is for Comparators[1][2]. Note that this is only a change for Money. Period and Date did not have `__cmp__` exposed in Java until #610.

* Remove `__cmp__` and `__nonzero__` methods from Python. These were Python 2 magic methods that are not used in Python 3[3].

[1] https://docs.oracle.com/javase/8/docs/api/java/lang/Comparable.html#compareTo-T-
[2] https://docs.oracle.com/javase/8/docs/api/java/util/Comparator.html#compare-T-T-
[3] https://docs.python.org/3/reference/datamodel.html