### PR TITLE
Replace PyInt functions with PyLong

### DIFF
--- a/SWIG/calendars.i
+++ b/SWIG/calendars.i
@@ -64,18 +64,15 @@ enum JointCalendarRule { JoinHolidays, JoinBusinessDays };
 
 #if defined(SWIGPYTHON)
 %typemap(in) ext::optional<BusinessDayConvention> %{
-	if($input == Py_None)
-		$1 = ext::nullopt;
-    else if (PyInt_Check($input))
-        $1 = (BusinessDayConvention) PyInt_AsLong($input);
-	else
-		$1 = (BusinessDayConvention) PyLong_AsLong($input);
+    if ($input == Py_None)
+        $1 = ext::nullopt;
+    else if (PyLong_Check($input))
+        $1 = (BusinessDayConvention)PyLong_AsLong($input);
+    else
+        SWIG_exception(SWIG_TypeError, "int expected");
 %}
 %typecheck (QL_TYPECHECK_BUSINESSDAYCONVENTION) ext::optional<BusinessDayConvention> {
-if (PyInt_Check($input) || PyLong_Check($input) || Py_None == $input)
-	$1 = 1;
-else
-	$1 = 0;
+    $1 = (PyLong_Check($input) || $input == Py_None) ? 1 : 0;
 }
 #endif
 

--- a/SWIG/date.i
+++ b/SWIG/date.i
@@ -172,18 +172,15 @@ enum Frequency {
 #if defined(SWIGPYTHON)
 %define QL_TYPECHECK_FREQUENCY       6210    %enddef
 %typemap(in) ext::optional<Frequency> %{
-	if($input == Py_None)
-		$1 = ext::nullopt;
-    else if (PyInt_Check($input))
-        $1 = (Frequency) PyInt_AsLong($input);
-	else
-		$1 = (Frequency) PyLong_AsLong($input);
+    if ($input == Py_None)
+        $1 = ext::nullopt;
+    else if (PyLong_Check($input))
+        $1 = (Frequency)PyLong_AsLong($input);
+    else
+        SWIG_exception(SWIG_TypeError, "int expected");
 %}
 %typecheck (QL_TYPECHECK_FREQUENCY) ext::optional<Frequency> {
-if (PyInt_Check($input) || PyLong_Check($input) || Py_None == $input)
-	$1 = 1;
-else
-	$1 = 0;
+    $1 = (PyLong_Check($input) || $input == Py_None) ? 1 : 0;
 }
 #else
 #if defined(SWIGCSHARP)

--- a/SWIG/linearalgebra.i
+++ b/SWIG/linearalgebra.i
@@ -47,8 +47,8 @@ bool ArrayFromSequence(PyObject* source, Array* target) {
             if (PyFloat_Check(o)) {
                 (*target)[i] = PyFloat_AsDouble(o);
                 Py_DECREF(o);
-            } else if (PyInt_Check(o)) {
-                (*target)[i] = Real(PyInt_AsLong(o));
+            } else if (PyLong_Check(o)) {
+                (*target)[i] = Real(PyLong_AsLong(o));
                 Py_DECREF(o);
             } else {
                 Py_DECREF(o);
@@ -176,8 +176,8 @@ bool ArrayFromSequence(PyObject* source, Array* target) {
                     if (PyFloat_Check(d)) {
                         $1[i][j] = PyFloat_AsDouble(d);
                         Py_DECREF(d);
-                    } else if (PyInt_Check(d)) {
-                        $1[i][j] = Real(PyInt_AsLong(d));
+                    } else if (PyLong_Check(d)) {
+                        $1[i][j] = Real(PyLong_AsLong(d));
                         Py_DECREF(d);
                     } else {
                         PyErr_SetString(PyExc_TypeError,"doubles expected");
@@ -247,8 +247,8 @@ bool ArrayFromSequence(PyObject* source, Array* target) {
                     if (PyFloat_Check(d)) {
                         temp[i][j] = PyFloat_AsDouble(d);
                         Py_DECREF(d);
-                    } else if (PyInt_Check(d)) {
-                        temp[i][j] = Real(PyInt_AsLong(d));
+                    } else if (PyLong_Check(d)) {
+                        temp[i][j] = Real(PyLong_AsLong(d));
                         Py_DECREF(d);
                     } else {
                         PyErr_SetString(PyExc_TypeError,"doubles expected");

--- a/SWIG/null.i
+++ b/SWIG/null.i
@@ -38,20 +38,20 @@ double nullDouble() { return Null<double>(); }
 %typemap(in) intOrNull {
     if ($input == Py_None)
         $1 = Null<int>();
-    else if (PyInt_Check($input))
-        $1 = int(PyInt_AsLong($input));
+    else if (PyLong_Check($input))
+        $1 = int(PyLong_AsLong($input));
     else
-        SWIG_exception(SWIG_TypeError,"int expected");
+        SWIG_exception(SWIG_TypeError, "int expected");
 }
 %typecheck(SWIG_TYPECHECK_INTEGER) intOrNull {
-    $1 = ($input == Py_None || PyInt_Check($input)) ? 1 : 0;
+    $1 = ($input == Py_None || PyLong_Check($input)) ? 1 : 0;
 }
 %typemap(out) intOrNull {
     if ($1 == Null<int>()) {
         Py_INCREF(Py_None);
         $result = Py_None;
     } else {
-        $result = PyInt_FromLong(long($1));
+        $result = PyLong_FromLong($1);
     }
 }
 

--- a/SWIG/scheduler.i
+++ b/SWIG/scheduler.i
@@ -40,18 +40,15 @@ struct DateGeneration {
 };
 #if defined(SWIGPYTHON)
 %typemap(in) ext::optional<DateGeneration::Rule> %{
-    if($input == Py_None)
+    if ($input == Py_None)
         $1 = ext::nullopt;
-    else if (PyInt_Check($input))
-        $1 = (DateGeneration::Rule) PyInt_AsLong($input);
+    else if (PyLong_Check($input))
+        $1 = (DateGeneration::Rule)PyLong_AsLong($input);
     else
-        $1 = (DateGeneration::Rule) PyLong_AsLong($input);
+        SWIG_exception(SWIG_TypeError, "int expected");
 %}
 %typecheck (QL_TYPECHECK_DATEGENERATION) ext::optional<DateGeneration::Rule> {
-if (PyInt_Check($input) || PyLong_Check($input) || Py_None == $input)
-    $1 = 1;
-else
-    $1 = 0;
+    $1 = (PyLong_Check($input) || $input == Py_None) ? 1 : 0;
 }
 #endif
 

--- a/SWIG/timebasket.i
+++ b/SWIG/timebasket.i
@@ -64,7 +64,6 @@ class TimeBasket {
             return self->hasDate(d);
         }
         PyObject* __iter__() {
-            %#if PY_VERSION_HEX >= 0x02020000
             PyObject* keyList = PyList_New(self->size());
             TimeBasket::iterator i;
             Size j;
@@ -77,11 +76,7 @@ class TimeBasket {
             PyObject* iter = PyObject_GetIter(keyList);
             Py_DECREF(keyList);
             return iter;
-            %#else
-            throw std::runtime_error("Python 2.2 or later is needed"
-                                     " for iterator support");
-            %#endif
-            }
+        }
         #endif
     }
 };

--- a/SWIG/types.i
+++ b/SWIG/types.i
@@ -55,7 +55,7 @@ typedef Real Probability;
 #if defined(SWIGPYTHON)
 // needed for those using SWIG 1.3.21 in order to compile with VC++6
 %typecheck(SWIG_TYPECHECK_INTEGER) std::size_t {
-    $1 = (PyInt_Check($input) || PyLong_Check($input)) ? 1 : 0;
+    $1 = PyLong_Check($input) ? 1 : 0;
 }
 #endif
 

--- a/SWIG/volatilities.i
+++ b/SWIG/volatilities.i
@@ -50,18 +50,15 @@ enum VolatilityType { ShiftedLognormal, Normal };
 
 #if defined(SWIGPYTHON)
 %typemap(in) ext::optional<VolatilityType> %{
-    if($input == Py_None)
+    if ($input == Py_None)
         $1 = ext::nullopt;
-    else if (PyInt_Check($input))
-        $1 = (VolatilityType) PyInt_AsLong($input);
+    else if (PyLong_Check($input))
+        $1 = (VolatilityType)PyLong_AsLong($input);
     else
-        $1 = (VolatilityType) PyLong_AsLong($input);
+        SWIG_exception(SWIG_TypeError, "int expected");
 %}
 %typecheck (QL_TYPECHECK_VOLATILITYTYPE) ext::optional<VolatilityType> {
-if (PyInt_Check($input) || PyLong_Check($input) || Py_None == $input)
-    $1 = 1;
-else
-    $1 = 0;
+    $1 = (PyLong_Check($input) || $input == Py_None) ? 1 : 0;
 }
 #endif
 


### PR DESCRIPTION
PyInt_* functions were removed from Python 3 (the short int type no longer exists in Python). The code only compiles because SWIG adds compatibility macros in generated wrappers.