### PR TITLE
Use %extend for properties of Settings

### DIFF
--- a/Python/examples/gaussian1d-models.py
+++ b/Python/examples/gaussian1d-models.py
@@ -94,7 +94,7 @@ def calibration_data(basket, volatilities):
 
 # %%
 refDate = ql.Date(30, 4, 2014)
-ql.Settings.instance().setEvaluationDate(refDate)
+ql.Settings.instance().evaluationDate = refDate
 
 # %% [markdown]
 # We assume a multicurve setup, for simplicity with flat yield term structures.

--- a/Python/examples/isda-engine.py
+++ b/Python/examples/isda-engine.py
@@ -34,7 +34,7 @@ import pandas as pd
 interactive = 'get_ipython' in globals()
 
 trade_date = ql.Date(21,5,2009)
-ql.Settings.instance().setEvaluationDate(trade_date)
+ql.Settings.instance().evaluationDate = trade_date
 
 ql.IborCoupon.createAtParCoupons()
 

--- a/Python/test/test_settings.py
+++ b/Python/test/test_settings.py
@@ -3,6 +3,22 @@ import unittest
 
 
 class SettingsTest(unittest.TestCase):
+    def test_properties(self):
+        settings = ql.Settings.instance()
+        with ql.SavedSettings():
+            for v in (ql.Date(1, 1, 2023), ql.Date(2, 2, 2023)):
+                settings.evaluationDate = v
+                self.assertEqual(settings.evaluationDate, v)
+            for v in (True, False):
+                settings.enforcesTodaysHistoricFixings = v
+                self.assertEqual(settings.enforcesTodaysHistoricFixings, v)
+            for v in (True, False):
+                settings.includeReferenceDateEvents = v
+                self.assertEqual(settings.includeReferenceDateEvents, v)
+            for v in (True, False, None):
+                settings.includeTodaysCashFlows = v
+                self.assertEqual(settings.includeTodaysCashFlows, v)
+
     def test_saved_settings(self):
         settings = ql.Settings.instance()
         settings.evaluationDate = ql.Date(1, 1, 2023)

--- a/SWIG/common.i
+++ b/SWIG/common.i
@@ -45,18 +45,17 @@
 
 #if defined(SWIGPYTHON)
 %typemap(in) ext::optional<bool> %{
-	if($input == Py_None)
-		$1 = ext::nullopt;
-	else if ($input == Py_True)
-		$1 = true;
-	else
-		$1 = false;
+    if ($input == Py_None)
+        $1 = ext::nullopt;
+    else
+        $1 = $input == Py_True;
 %}
 %typecheck (QL_TYPECHECK_BOOL) ext::optional<bool> {
-if (PyBool_Check($input) || Py_None == $input) 
-	$1 = 1;
-else
-	$1 = 0;
+    $1 = (PyBool_Check($input) || $input == Py_None) ? 1 : 0;
+}
+%typemap(out) ext::optional<bool> {
+    $result = !$1 ? Py_None : *$1 ? Py_True : Py_False;
+    Py_INCREF($result);
 }
 #else
 #if defined(SWIGCSHARP)
@@ -170,5 +169,13 @@ def OldName(*args, **kwargs):
 #endif
 %enddef
 
+%{
+#if defined(SWIGPYTHON)
+#define cpp_deprecate_feature(OldName, NewName) \
+    PyErr_WarnEx(PyExc_FutureWarning, (#OldName " is deprecated; use " #NewName), 1)
+#else
+#define cpp_deprecate_feature(OldName, NewName)
+#endif
+%}
 
 #endif

--- a/SWIG/settings.i
+++ b/SWIG/settings.i
@@ -19,10 +19,38 @@
 #ifndef quantlib_settings_i
 #define quantlib_settings_i
 
+%include common.i
 %include date.i
 
 %{
 using QuantLib::Settings;
+
+#if defined(SWIGPYTHON)
+Date* Settings_evaluationDate_get(Settings* self) {
+    return new Date(self->evaluationDate());
+}
+void Settings_evaluationDate_set(Settings* self, const Date* d) {
+    self->evaluationDate() = *d;
+}
+bool Settings_enforcesTodaysHistoricFixings_get(Settings* self) {
+    return self->enforcesTodaysHistoricFixings();
+}
+void Settings_enforcesTodaysHistoricFixings_set(Settings* self, bool b) {
+    self->enforcesTodaysHistoricFixings() = b;
+}
+bool Settings_includeReferenceDateEvents_get(Settings* self) {
+    return self->includeReferenceDateEvents();
+}
+void Settings_includeReferenceDateEvents_set(Settings* self, bool b) {
+    self->includeReferenceDateEvents() = b;
+}
+ext::optional<bool> Settings_includeTodaysCashFlows_get(Settings* self) {
+    return self->includeTodaysCashFlows();
+}
+void Settings_includeTodaysCashFlows_set(Settings* self, ext::optional<bool> b) {
+    self->includeTodaysCashFlows() = b;
+}
+#endif
 %}
 
 class Settings {
@@ -30,40 +58,53 @@ class Settings {
     Settings();
   public:
     static Settings& instance();
+    void anchorEvaluationDate();
+    void resetEvaluationDate();
     %extend {
         Date getEvaluationDate() {
+            #if defined(SWIGPYTHON)
+            cpp_deprecate_feature(getEvaluationDate, evaluationDate);
+            #endif
             return self->evaluationDate();
         }
         void setEvaluationDate(const Date& d) {
+            #if defined(SWIGPYTHON)
+            cpp_deprecate_feature(setEvaluationDate, evaluationDate);
+            #endif
             self->evaluationDate() = d;
         }
-
+        bool getEnforcesTodaysHistoricFixings() {
+            #if defined(SWIGPYTHON)
+            cpp_deprecate_feature(getEnforcesTodaysHistoricFixings, enforcesTodaysHistoricFixings);
+            #endif
+            return self->enforcesTodaysHistoricFixings();
+        }
+        void setEnforcesTodaysHistoricFixings(bool b) {
+            #if defined(SWIGPYTHON)
+            cpp_deprecate_feature(setEnforcesTodaysHistoricFixings, enforcesTodaysHistoricFixings);
+            #endif
+            self->enforcesTodaysHistoricFixings() = b;
+        }
+        #if defined(SWIGPYTHON)
+        %newobject evaluationDate;
+        Date evaluationDate;
+        bool enforcesTodaysHistoricFixings;
+        bool includeReferenceDateEvents;
+        ext::optional<bool> includeTodaysCashFlows;
+        #else
         void includeReferenceDateEvents(bool b) {
             self->includeReferenceDateEvents() = b;
         }
         void includeTodaysCashFlows(bool b) {
             self->includeTodaysCashFlows() = b;
         }
-        void setEnforcesTodaysHistoricFixings(bool b) {
-            self->enforcesTodaysHistoricFixings() = b;
-        }
-        bool getEnforcesTodaysHistoricFixings() {
-            return self->enforcesTodaysHistoricFixings();
-        }
+        #endif
     }
-    #if defined(SWIGPYTHON)
-    %pythoncode %{
-    evaluationDate = property(getEvaluationDate,setEvaluationDate,None)
-    includeReferenceDateCashFlows = property(None,includeReferenceDateEvents,None)
-    includeReferenceDateEvents = property(None,includeReferenceDateEvents,None)
-    includeTodaysCashFlows = property(None,includeTodaysCashFlows,None)
-    enforcesTodaysHistoricFixings = property(getEnforcesTodaysHistoricFixings, setEnforcesTodaysHistoricFixings, None)
-    %}
-    #endif
 };
 
 #if defined(SWIGPYTHON)
-%{
+%rename(SavedSettings) _SavedSettings;
+%inline %{
 class _SavedSettings {
     ext::optional<QuantLib::SavedSettings> saved_;
   public:
@@ -75,13 +116,6 @@ class _SavedSettings {
     }
 };
 %}
-
-%rename(SavedSettings) _SavedSettings;
-class _SavedSettings {
-  public:
-    void __enter__();
-    void __exit__(PyObject*, PyObject*, PyObject*);
-};
 #endif
 
 #endif


### PR DESCRIPTION
Use SWIG native way to add properties to Settings[1]. This works with all target languages using the most natural feature available (e.g. properties in Python and C# and get/set methods in Java).

For now only enable this for Python. Other languages are easy as well, except for backward compatibility concerns.

Also, deprecate get/set methods in Python.

[1] https://www.swig.org/Doc4.2/SWIG.html#SWIG_adding_member_functions near the end of the section.