### PR TITLE
Fix build errors due to inheritance of YoYCapFloorTermPriceSurface 

### DIFF
--- a/Python/test/test_date.py
+++ b/Python/test/test_date.py
@@ -69,7 +69,7 @@ wrong day, month, year increment
         """ Testing Calendar testHolidayList() method. """
         holidayLstFunction = ql.Calendar.holidayList(ql.Poland(), ql.Date(31, 12, 2014), ql.Date(3, 4, 2015), False)
         holidayLstManual = (ql.Date(1, 1, 2015), ql.Date(6, 1, 2015))
-        # check if dates both from function and from manual imput are the same
+        # check if dates both from function and from manual input are the same
         self.assertTrue(all([(a == b) for a, b in zip(holidayLstFunction, holidayLstManual)]))
 
     def testConversion(self):

--- a/Python/test/test_ratehelpers.py
+++ b/Python/test/test_ratehelpers.py
@@ -122,7 +122,7 @@ class OISRateHelperTest(unittest.TestCase):
 
         # build rate helpers
         dayCounter = ql.Actual360()
-        # looping left if somone wants two add more deposits to tests, e.g. T/N
+        # looping left if someone wants two add more deposits to tests, e.g. T/N
 
         self.depositHelpers = [
             ql.DepositRateHelper(
@@ -191,7 +191,7 @@ class OISRateHelperTest(unittest.TestCase):
         already set and additional calendar will have no impact. The test checks
         if the constructor exposed to Python maintains this desired property and
         verifies that the start date of a EUR plain vanilla OIS traded on March
-        29th, 2018 is equal to April 4th, 2018 (du to holiday on March 30th,
+        29th, 2018 is equal to April 4th, 2018 (due to holiday on March 30th,
         2018 in TARGET calendar.
         """
         test_date = ql.Date(29, 3, 2018)

--- a/SWIG/inflation.i
+++ b/SWIG/inflation.i
@@ -1079,7 +1079,7 @@ class YoYCapFloorTermPriceSurface : public TermStructure {
     virtual Rate atmYoYRate(const Date &d,
                             const Period &obsLag = Period(-1,Days),
                             bool extrapolate = true);
-    virtual Date baseDate() const = 0;
+    virtual Date baseDate() const;
     virtual Real price(const Period& d, Rate k) const;
     virtual Real capPrice(const Period& d, Rate k) const;
     virtual Real floorPrice(const Period& d, Rate k) const;

--- a/SWIG/inflation.i
+++ b/SWIG/inflation.i
@@ -2,6 +2,7 @@
  Copyright (C) 2010 Joseph Wang
  Copyright (C) 2010, 2011, 2014 StatPro Italia srl
  Copyright (C) 2018, 2019, 2020 Matthias Lungwitz
+ Copyright (C) 2024 Skandinaviska Enskilda Banken AB (publ)
  
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -1058,7 +1059,7 @@ using QuantLib::InterpolatedYoYCapFloorTermPriceSurface;
 %}
 
 %shared_ptr(YoYCapFloorTermPriceSurface)
-class YoYCapFloorTermPriceSurface : public InflationTermStructure {
+class YoYCapFloorTermPriceSurface : public TermStructure {
   private:
     YoYCapFloorTermPriceSurface();
   public:
@@ -1067,6 +1068,8 @@ class YoYCapFloorTermPriceSurface : public InflationTermStructure {
     virtual ext::shared_ptr<YoYInflationTermStructure> YoYTS() const;
     ext::shared_ptr<YoYInflationIndex> yoyIndex();
     virtual BusinessDayConvention businessDayConvention() const;
+    virtual Period observationLag() const;
+    virtual Frequency frequency() const;
     virtual Natural fixingDays() const;
     virtual Real price(const Date& d, Rate k);
     virtual Real capPrice(const Date& d, Rate k);
@@ -1076,7 +1079,7 @@ class YoYCapFloorTermPriceSurface : public InflationTermStructure {
     virtual Rate atmYoYRate(const Date &d,
                             const Period &obsLag = Period(-1,Days),
                             bool extrapolate = true);
-
+    virtual Date baseDate() const = 0;
     virtual Real price(const Period& d, Rate k) const;
     virtual Real capPrice(const Period& d, Rate k) const;
     virtual Real floorPrice(const Period& d, Rate k) const;

--- a/Scala/README.txt
+++ b/Scala/README.txt
@@ -4,7 +4,7 @@ Instructions for building the QuantLib-Java module under Eclipse are
 available at
 <http://users.telenet.be/johan.witters/website/skwash.com/get/get3.html>.
 
-On Linux systems, the module can be build by supplying the location of
+On Linux systems, the module can be built by supplying the location of
 the JDK to configure, as in (for example)
 
 ./configure --with-jdk-include=/usr/lib/jvm/java-1.5.0-sun-1.5.0.08/include \


### PR DESCRIPTION
Hi,
We noticed this failing our build pipelines recently. The change in the inheritance is required after this change in QL: https://github.com/lballabio/QuantLib/commit/1ebd2428aff7b8900f311518ab28d72b39136805.

I threw in some minor textual fixes as well.