### PR TITLE
Use typemap in PyObserver.[un]registerWith

### DIFF
--- a/Python/test/test_marketelements.py
+++ b/Python/test/test_marketelements.py
@@ -37,6 +37,11 @@ class MarketElementTest(unittest.TestCase):
         me.setValue(3.14)
         if not flag:
             self.fail("Observer was not notified of market element change")
+        flag = None
+        obs.unregisterWith(me)
+        me.setValue(2.71)
+        if flag:
+            self.fail("Observer was notified after unregistering")
 
     def testObservableHandle(self):
         "Testing observability of market element handles"
@@ -54,6 +59,26 @@ class MarketElementTest(unittest.TestCase):
         h.linkTo(me2)
         if not flag:
             self.fail("Observer was not notified of market element change")
+        flag = None
+        obs.unregisterWith(h)
+        me2.setValue(2.71)
+        if flag:
+            self.fail("Observer was notified after unregistering")
+
+    def testObservableErrors(self):
+        class Handle:
+            def __init__(self, x):
+                self.x = x
+
+            def asObservable(self):
+                return 10 / self.x
+
+        obs = ql.Observer(raiseFlag)
+        self.assertRaises(TypeError, obs.registerWith, 123)
+        self.assertRaises(TypeError, obs.registerWith, obs)
+        self.assertRaises(TypeError, obs.registerWith, Handle)
+        self.assertRaises(ZeroDivisionError, obs.registerWith, Handle(0))
+        self.assertRaises(TypeError, obs.registerWith, Handle(1))
 
 
 if __name__ == "__main__":

--- a/SWIG/calendars.i
+++ b/SWIG/calendars.i
@@ -71,9 +71,9 @@ enum JointCalendarRule { JoinHolidays, JoinBusinessDays };
     else
         SWIG_exception(SWIG_TypeError, "int expected");
 %}
-%typecheck (QL_TYPECHECK_BUSINESSDAYCONVENTION) ext::optional<BusinessDayConvention> {
+%typecheck (QL_TYPECHECK_BUSINESSDAYCONVENTION) ext::optional<BusinessDayConvention> %{
     $1 = (PyLong_Check($input) || $input == Py_None) ? 1 : 0;
-}
+%}
 #endif
 
 class Calendar {

--- a/SWIG/common.i
+++ b/SWIG/common.i
@@ -47,16 +47,18 @@
 %typemap(in) ext::optional<bool> %{
     if ($input == Py_None)
         $1 = ext::nullopt;
-    else
+    else if (PyBool_Check($input))
         $1 = $input == Py_True;
+    else
+        SWIG_exception(SWIG_TypeError, "bool expected");
 %}
-%typecheck (QL_TYPECHECK_BOOL) ext::optional<bool> {
+%typecheck (QL_TYPECHECK_BOOL) ext::optional<bool> %{
     $1 = (PyBool_Check($input) || $input == Py_None) ? 1 : 0;
-}
-%typemap(out) ext::optional<bool> {
+%}
+%typemap(out) ext::optional<bool> %{
     $result = !$1 ? Py_None : *$1 ? Py_True : Py_False;
     Py_INCREF($result);
-}
+%}
 #else
 #if defined(SWIGCSHARP)
 %typemap(cscode) ext::optional<bool> %{

--- a/SWIG/date.i
+++ b/SWIG/date.i
@@ -179,9 +179,9 @@ enum Frequency {
     else
         SWIG_exception(SWIG_TypeError, "int expected");
 %}
-%typecheck (QL_TYPECHECK_FREQUENCY) ext::optional<Frequency> {
+%typecheck (QL_TYPECHECK_FREQUENCY) ext::optional<Frequency> %{
     $1 = (PyLong_Check($input) || $input == Py_None) ? 1 : 0;
-}
+%}
 #else
 #if defined(SWIGCSHARP)
 %typemap(cscode) ext::optional<Frequency> %{
@@ -394,7 +394,7 @@ class Period {
         }
     }
 %}
-%typecheck (QL_TYPECHECK_PERIOD) ext::optional<Period> {
+%typecheck (QL_TYPECHECK_PERIOD) ext::optional<Period> %{
     if($input == Py_None) {
         $1 = 1;
     } else {
@@ -403,7 +403,7 @@ class Period {
         int res = SWIG_ConvertPtr($input, &vptr, $descriptor(Period*), SWIG_POINTER_NO_NULL);
         $1 = SWIG_CheckState(res);
     }
-}
+%}
 #endif
 
 namespace std {

--- a/SWIG/null.i
+++ b/SWIG/null.i
@@ -35,45 +35,45 @@ double nullDouble() { return Null<double>(); }
 
 #if defined(SWIGPYTHON)
 
-%typemap(in) intOrNull {
+%typemap(in) intOrNull %{
     if ($input == Py_None)
         $1 = Null<int>();
     else if (PyLong_Check($input))
         $1 = int(PyLong_AsLong($input));
     else
         SWIG_exception(SWIG_TypeError, "int expected");
-}
-%typecheck(SWIG_TYPECHECK_INTEGER) intOrNull {
+%}
+%typecheck(SWIG_TYPECHECK_INTEGER) intOrNull %{
     $1 = ($input == Py_None || PyLong_Check($input)) ? 1 : 0;
-}
-%typemap(out) intOrNull {
+%}
+%typemap(out) intOrNull %{
     if ($1 == Null<int>()) {
         Py_INCREF(Py_None);
         $result = Py_None;
     } else {
         $result = PyLong_FromLong($1);
     }
-}
+%}
 
-%typemap(in) doubleOrNull {
+%typemap(in) doubleOrNull %{
     if ($input == Py_None)
         $1 = Null<double>();
     else if (PyFloat_Check($input))
         $1 = PyFloat_AsDouble($input);
     else
         SWIG_exception(SWIG_TypeError,"double expected");
-}
-%typecheck(SWIG_TYPECHECK_DOUBLE) doubleOrNull {
+%}
+%typecheck(SWIG_TYPECHECK_DOUBLE) doubleOrNull %{
     $1 = ($input == Py_None || PyFloat_Check($input)) ? 1 : 0;
-}
-%typemap(out) doubleOrNull {
+%}
+%typemap(out) doubleOrNull %{
     if ($1 == Null<double>()) {
         Py_INCREF(Py_None);
         $result = Py_None;
     } else {
         $result = PyFloat_FromDouble($1);
     }
-}
+%}
 
 #elif defined(SWIGJAVA)
 
@@ -92,22 +92,22 @@ typedef double doubleOrNull;
    %{ $input = as($input, "integer"); %}
 %typemap(scoerceout) intOrNull %{ %}
 
-%typemap(in) intOrNull {
+%typemap(in) intOrNull %{
   $1 = ($1_ltype) INTEGER($input)[0];
   if ($1 == R_NaInt) $1 = Null<int>();
-}
+%}
 
 %typemap(rtypecheck) intOrNull %{
   ((length($arg) == 0) || (length($arg) == 1 && is.integer($arg)) || (length($arg) == 1 && is.numeric($arg)) || (length($arg) == 1 && is.na($arg)))
 %}
 
 
-%typemap(out) intOrNull {
+%typemap(out) intOrNull %{
     if ($1 == Null<int>())
     $result = Rf_ScalarLogical(NA_LOGICAL)
     else
     $result = ScalarInteger($1);
-}
+%}
 
 %typemap(rtype) doubleOrNull "numeric";
 
@@ -115,22 +115,22 @@ typedef double doubleOrNull;
     %{ $input = as($input, "numeric"); %}
 %typemap(scoerceout) doubleOrNull %{ %}
 
-%typemap(in) doubleOrNull {
+%typemap(in) doubleOrNull %{
   $1 = ($1_ltype) REAL($input)[0];
   if (R_IsNA($1)) $1 = Null<double>();
-}
+%}
 
 %typemap(rtypecheck) doubleOrNull %{
   ((length($arg) == 0) || (length($arg) == 1 && is.numeric($arg)) || (length($arg) == 1 && is.na($arg)))
 %}
 
 
-%typemap(out) doubleOrNull {
+%typemap(out) doubleOrNull %{
     if ($1 == Null<double>())
         $result = Rf_ScalarLogical(NA_LOGICAL);
     else
         $result = Rf_ScalarReal($1);
-}
+%}
 
 #endif
 

--- a/SWIG/scheduler.i
+++ b/SWIG/scheduler.i
@@ -47,9 +47,9 @@ struct DateGeneration {
     else
         SWIG_exception(SWIG_TypeError, "int expected");
 %}
-%typecheck (QL_TYPECHECK_DATEGENERATION) ext::optional<DateGeneration::Rule> {
+%typecheck (QL_TYPECHECK_DATEGENERATION) ext::optional<DateGeneration::Rule> %{
     $1 = (PyLong_Check($input) || $input == Py_None) ? 1 : 0;
-}
+%}
 #endif
 
 class Schedule {

--- a/SWIG/volatilities.i
+++ b/SWIG/volatilities.i
@@ -57,9 +57,9 @@ enum VolatilityType { ShiftedLognormal, Normal };
     else
         SWIG_exception(SWIG_TypeError, "int expected");
 %}
-%typecheck (QL_TYPECHECK_VOLATILITYTYPE) ext::optional<VolatilityType> {
+%typecheck (QL_TYPECHECK_VOLATILITYTYPE) ext::optional<VolatilityType> %{
     $1 = (PyLong_Check($input) || $input == Py_None) ? 1 : 0;
-}
+%}
 #endif
 
 %{


### PR DESCRIPTION
Use a typemap to handle conversion from Handles to Observable. This is compatible with -builtin and avoids code duplication.

Also, remove unneeded {} in typemaps.