### PR TITLE
Enable different definition of macro QL_JAVA_INTERFACES by testing if it is already defined

### DIFF
--- a/SWIG/quantlib.i
+++ b/SWIG/quantlib.i
@@ -67,9 +67,6 @@ const char* __version__;
 %include stl.i
 
 #if defined(JAVA_AUTOCLOSEABLE)
-%typemap(javaimports) SWIGTYPE %{
-import java.lang.AutoCloseable;
-%}
 #define QL_JAVA_INTERFACES "AutoCloseable, "
 %typemap(javainterfaces) SWIGTYPE "AutoCloseable"
 %extend std::vector {
@@ -85,7 +82,9 @@ import java.lang.AutoCloseable;
   }
 %}
 #else
+#if !defined(QL_JAVA_INTERFACES)
 #define QL_JAVA_INTERFACES
+#endif
 #endif
 
 #if !defined(JAVA_FINALIZER)


### PR DESCRIPTION
I'm using a slightly different approach for `JAVA_AUTOCLOSEABLE` [here](https://github.com/ralfkonrad/quantlib_for_maven/blob/master/swig/QuantLibEntrypoint.i). Therefore, I need to define my own `QL_JAVA_INTERFACES` in upfront to reflect the changes made in #613 and we need to avoid the duplication of the definition of the `QL_JAVA_INTERFACES` macro.

---

Also, I have removed the `import java.lang.AutoCloseable;` for simplicity as classes in the `java.lang` packages are imported by default in `java` like `Double` or `Boolean`.