### PR TITLE
Use C++ operators instead of Python magics for comparison

### DIFF
--- a/Python/test/test_date.py
+++ b/Python/test/test_date.py
@@ -16,6 +16,7 @@
 """
 
 import datetime
+import operator
 import QuantLib as ql
 import unittest
 
@@ -65,6 +66,14 @@ wrong day, month, year increment
                 self.assertEqual(date1 != date2, not expected)
                 self.assertEqual(hash(date1) == hash(date2), expected)
 
+    def test_order(self):
+        ops = [operator.eq, operator.ne, operator.lt, operator.le, operator.gt, operator.ge]
+        for date1 in (ql.Date(1, 2, 2020), ql.Date(3, 4, 2022), ql.Date()):
+            for date2 in (ql.Date(1, 2, 2020), ql.Date(3, 4, 2022), ql.Date()):
+                for op in ops:
+                    self.assertEqual(op(date1,  date2),
+                                     op(date1.serialNumber(), date2.serialNumber()))
+
     def testHolidayList(self):
         """ Testing Calendar testHolidayList() method. """
         holidayLstFunction = ql.Calendar.holidayList(ql.Poland(), ql.Date(31, 12, 2014), ql.Date(3, 4, 2015), False)
@@ -94,6 +103,13 @@ class PeriodTest(unittest.TestCase):
                 self.assertEqual(per1 == per2, expected)
                 self.assertEqual(per1 != per2, not expected)
                 self.assertEqual(hash(per1) == hash(per2), expected)
+
+    def test_order(self):
+        ops = [operator.eq, operator.ne, operator.lt, operator.le, operator.gt, operator.ge]
+        for per1 in (ql.Period("1D"), ql.Period("1W"), ql.Period("12M")):
+            for per2 in (ql.Period("1D"), ql.Period("1Y")):
+                for op in ops:
+                    self.assertEqual(op(per1,  per2), op(per2.frequency(), per1.frequency()))
 
 
 if __name__ == "__main__":

--- a/SWIG/calendars.i
+++ b/SWIG/calendars.i
@@ -113,10 +113,10 @@ class Calendar {
             return self->name()+" calendar";
         }
         #if defined(SWIGPYTHON) || defined(SWIGJAVA)
-        bool __eq__(const Calendar& other) {
+        bool operator==(const Calendar& other) {
             return (*self) == other;
         }
-        bool __ne__(const Calendar& other) {
+        bool operator!=(const Calendar& other) {
             return (*self) != other;
         }
         hash_t __hash__() {

--- a/SWIG/currencies.i
+++ b/SWIG/currencies.i
@@ -61,10 +61,10 @@ class Currency {
             return self->name();
         }
         #if defined(SWIGPYTHON) || defined(SWIGJAVA)
-        bool __eq__(const Currency& other) {
+        bool operator==(const Currency& other) {
             return (*self) == other;
         }
-        bool __ne__(const Currency& other) {
+        bool operator!=(const Currency& other) {
             return (*self) != other;
         }
         hash_t __hash__() {

--- a/SWIG/date.i
+++ b/SWIG/date.i
@@ -330,16 +330,16 @@ class Period {
         Period __rmul__(Integer n) {
             return *self * n;
         }
-        bool __lt__(const Period& other) {
+        bool operator<(const Period& other) {
             return *self < other;
         }
-        bool __gt__(const Period& other) {
+        bool operator>(const Period& other) {
             return other < *self;
         }
-        bool __le__(const Period& other) {
+        bool operator<=(const Period& other) {
             return !(other < *self);
         }
-        bool __ge__(const Period& other) {
+        bool operator>=(const Period& other) {
             return !(*self < other);
         }
         #else
@@ -349,10 +349,10 @@ class Period {
                                      1;
         }
         #endif
-        bool __eq__(const Period& other) {
+        bool operator==(const Period& other) {
             return *self == other;
         }
-        bool __ne__(const Period& other) {
+        bool operator!=(const Period& other) {
             return *self != other;
         }
         hash_t __hash__() {
@@ -721,10 +721,10 @@ class Date {
             return *self - other;
         }
         #if defined(SWIGPYTHON) || defined(SWIGR) || defined(SWIGJAVA)
-        bool __eq__(const Date& other) {
+        bool operator==(const Date& other) {
             return *self == other;
         }
-        bool __ne__(const Date& other) {
+        bool operator!=(const Date& other) {
             return *self != other;
         }
         hash_t __hash__() {
@@ -734,16 +734,16 @@ class Date {
         bool __bool__() {
             return (*self != Date());
         }
-        bool __lt__(const Date& other) {
+        bool operator<(const Date& other) {
             return *self < other;
         }
-        bool __gt__(const Date& other) {
+        bool operator>(const Date& other) {
             return other < *self;
         }
-        bool __le__(const Date& other) {
+        bool operator<=(const Date& other) {
             return !(other < *self);
         }
-        bool __ge__(const Date& other) {
+        bool operator>=(const Date& other) {
             return !(*self < other);
         }
         PyObject* to_date() {

--- a/SWIG/daycounters.i
+++ b/SWIG/daycounters.i
@@ -48,10 +48,10 @@ class DayCounter {
             return self->name()+" day counter";
         }
         #if defined(SWIGPYTHON) || defined(SWIGJAVA)
-        bool __eq__(const DayCounter& other) {
+        bool operator==(const DayCounter& other) {
             return (*self) == other;
         }
-        bool __ne__(const DayCounter& other) {
+        bool operator!=(const DayCounter& other) {
             return (*self) != other;
         }
         hash_t __hash__() {

--- a/SWIG/money.i
+++ b/SWIG/money.i
@@ -49,16 +49,16 @@ class Money {
         Decimal operator/(const Money& m) { return *self/m; }
         #if defined(SWIGPYTHON)
         Money __rmul__(Decimal x) { return *self*x; }
-        bool __lt__(const Money& other) {
+        bool operator<(const Money& other) {
             return *self < other;
         }
-        bool __gt__(const Money& other) {
+        bool operator>(const Money& other) {
             return other < *self;
         }
-        bool __le__(const Money& other) {
+        bool operator<=(const Money& other) {
             return !(other < *self);
         }
-        bool __ge__(const Money& other) {
+        bool operator>=(const Money& other) {
             return !(*self < other);
         }
         #else
@@ -71,10 +71,10 @@ class Money {
                 return 1;
         }
         #endif
-        bool __eq__(const Money& other) {
+        bool operator==(const Money& other) {
             return *self == other;
         }
-        bool __ne__(const Money& other) {
+        bool operator!=(const Money& other) {
             return *self != other;
         }
         std::string __str__() {

--- a/SWIG/ql.i
+++ b/SWIG/ql.i
@@ -89,8 +89,8 @@ GNU autoconf configure script.
 %rename(divide)        operator/;
 %rename(divide)        __div__;
 %rename(getValue)      operator();
-%rename(equals)        __eq__;
-%rename(unEquals)      __ne__;
+%rename(equals)        operator==;
+%rename(unEquals)      operator!=;
 %rename(compareTo)     __cmp__;
 %javamethodmodifiers   __cmp__ "@Override public"
 %rename(hashCode)      __hash__;


### PR DESCRIPTION
This works in -builtin mode for Python and can work in other languages (e.g. R) if we extend ifdefs.