### PR TITLE
Don't export internal `EndCriteria` method

### DIFF
--- a/SWIG/optimizers.i
+++ b/SWIG/optimizers.i
@@ -203,14 +203,6 @@ class EndCriteria {
                 Real rootEpsilon,
                 Real functionEpsilon,
                 Real gradientNormEpsilon);
-    bool operator()(Size iteration,
-                    Size &statState,
-                    const bool positiveOptimization,
-                    const Real fold,
-                    const Real normgold,
-                    const Real fnew,
-                    const Real normgnewx,
-                    EndCriteria::Type & ecType) const;
 };
 
 


### PR DESCRIPTION
It can't be called anyway, as it requires to pass a reference to Size