### PR TITLE
Export a few new methods and typedefs

### DIFF
--- a/SWIG/cashflows.i
+++ b/SWIG/cashflows.i
@@ -297,6 +297,7 @@ class IborCoupon : public FloatingRateCoupon {
                const DayCounter& dayCounter = DayCounter(),
                bool isInArrears = false,
                const Date& exCouponDate = Date());
+    bool hasFixed() const;
     %extend {
         static void createAtParCoupons() {
             IborCoupon::Settings::instance().createAtParCoupons();

--- a/SWIG/fittedbondcurve.i
+++ b/SWIG/fittedbondcurve.i
@@ -71,6 +71,7 @@ class FittedBondDiscountCurve : public YieldTermStructure {
                    const Array &guess = Array(),
                    Real simplexLambda = 1.0);
     const FittingMethod& fitResults() const;
+    void resetGuess(const Array& guess);
 };
 
 

--- a/SWIG/indexes.i
+++ b/SWIG/indexes.i
@@ -404,6 +404,7 @@ export_quoted_xibor_instance(Bkbm6M,Bkbm);
 
 export_xibor_instance(Euribor);
 export_quoted_xibor_instance(EuriborSW,Euribor);
+export_quoted_xibor_instance(Euribor1W,Euribor);
 export_quoted_xibor_instance(Euribor2W,Euribor);
 export_quoted_xibor_instance(Euribor3W,Euribor);
 export_quoted_xibor_instance(Euribor1M,Euribor);


### PR DESCRIPTION
- `IborCoupon::hasFixed`
- `FittedBondDiscountCurve::resetGuess`
- `EuriborSW` renamed to `Euribor1W`, old name still available for a while