### PR TITLE
Add new features to indices

### DIFF
--- a/SWIG/indexes.i
+++ b/SWIG/indexes.i
@@ -71,6 +71,7 @@ class Index : public Observable {
     bool hasHistoricalFixing(const Date& fixingDate) const;
     Real fixing(const Date& fixingDate,
                 bool forecastTodaysFixing = false) const;
+    Real pastFixing(const Date& fixingDate) const;
     void addFixing(const Date& fixingDate, Rate fixing,
                    bool forceOverwrite = false);
     const TimeSeries<Real>& timeSeries() const;
@@ -347,7 +348,6 @@ class SwapSpreadIndex : public InterestRateIndex {
                     const Real gearing1 = 1.0,
                     const Real gearing2 = -1.0);
     Rate forecastFixing(const Date& fixingDate) const;
-    Rate pastFixing(const Date& fixingDate) const;
     ext::shared_ptr<SwapIndex> swapIndex1();
     ext::shared_ptr<SwapIndex> swapIndex2();
     Real gearing1();
@@ -367,7 +367,14 @@ class EquityIndex : public Index {
                 Handle<YieldTermStructure> interest = {},
                 Handle<YieldTermStructure> dividend = {},
                 Handle<Quote> spot = {});
+    EquityIndex(std::string name,
+                Calendar fixingCalendar,
+                Currency currency,
+                Handle<YieldTermStructure> interest = {},
+                Handle<YieldTermStructure> dividend = {},
+                Handle<Quote> spot = {});
 
+    Currency currency() const;
     Handle<YieldTermStructure> equityInterestRateCurve() const;
     Handle<YieldTermStructure> equityDividendCurve() const;
     Handle<Quote> spot() const;


### PR DESCRIPTION
Reflects PRs https://github.com/lballabio/QuantLib/pull/2020 and https://github.com/lballabio/QuantLib/pull/2022.

@lballabio: There is no need in swig to override `Real pastFixing(const Date& fixingDate) const` e.g. for https://github.com/lballabio/QuantLib/blob/0e83ab7d6b83fd3d6f286f0b4bb72a6411267276/ql/indexes/inflationindex.hpp#L166?