### PR TITLE
Porting #2063 PR QuantLib C++ - Warsaw Stock Exchange Calendar (Poland)

### DIFF
--- a/SWIG/calendars.i
+++ b/SWIG/calendars.i
@@ -245,7 +245,12 @@ namespace QuantLib {
 
     class NewZealand : public Calendar {};
     class Norway : public Calendar {};
-    class Poland : public Calendar {};
+
+    class Poland : public Calendar {
+      public:
+        enum Market { Settlement, WSE };
+        Poland(Market m = Settlement);
+    };
 
     class Romania : public Calendar {
       public:


### PR DESCRIPTION
Warsaw Stock Exchange calendar for Poland market. 

ql.Poland() would be calling ql.Poland(ql.Poland. Settlement), so invisible change compatible backwards and we would gain access to optional ql.Poland(ql.Poland.WSE) calendar if explicitly stated by user.

More at PR on QuantLib C++: https://github.com/lballabio/QuantLib/pull/2063