### PR TITLE
Add forDates() to SwapRateHelper and OISRateHelper

### DIFF
--- a/SWIG/forward.i
+++ b/SWIG/forward.i
@@ -56,10 +56,9 @@ class Forward : public Instrument{
 };
 
 
-// FixedRateBondForward
+// BondForward
 %{
 using QuantLib::BondForward;
-using QuantLib::FixedRateBondForward;
 using QuantLib::FixedRateBond;
 using QuantLib::BusinessDayConvention;
 using QuantLib::Position;
@@ -84,25 +83,6 @@ class BondForward : public Forward {
 
     Real forwardPrice();
     Real cleanForwardPrice();
-};
-
-%shared_ptr(FixedRateBondForward)
-class FixedRateBondForward : public BondForward {
-  public:
-    FixedRateBondForward(
-                const Date& valueDate,
-                const Date& maturityDate,
-                Position::Type type,
-                Real strike,
-                Natural settlementDays,
-                const DayCounter& dayCounter,
-                const Calendar& calendar,
-                BusinessDayConvention businessDayConvention,
-                const ext::shared_ptr<FixedRateBond>& fixedBond,
-                const Handle<YieldTermStructure>& discountCurve =
-                                            Handle<YieldTermStructure>(),
-                const Handle<YieldTermStructure>& incomeDiscountCurve =
-                                            Handle<YieldTermStructure>());
 };
 
 #endif

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -217,6 +217,9 @@ class FuturesRateHelper : public RateHelper {
 
 %shared_ptr(SwapRateHelper)
 class SwapRateHelper : public RateHelper {
+    #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
+    %feature("kwargs") forDates;
+    #endif
   public:
     SwapRateHelper(
             const Handle<Quote>& rate,
@@ -270,6 +273,28 @@ class SwapRateHelper : public RateHelper {
             Date customPillarDate = Date(),
             bool endOfMonth = false,
             ext::optional<bool> withIndexedCoupons = ext::nullopt);
+    %extend {
+        static SwapRateHelper forDates(
+                const Handle<Quote>& rate,
+                const Date& startDate,
+                const Date& endDate,
+                Calendar calendar,
+                Frequency fixedFrequency,
+                BusinessDayConvention fixedConvention,
+                DayCounter fixedDayCount,
+                const ext::shared_ptr<IborIndex>& index,
+                const Handle<Quote>& spread = Handle<Quote>(),
+                Handle<YieldTermStructure> discountingCurve = {},
+                Pillar::Choice pillar = Pillar::LastRelevantDate,
+                Date customPillarDate = Date(),
+                bool endOfMonth = false,
+                const ext::optional<bool>& withIndexedCoupons = ext::nullopt) {
+            return SwapRateHelper(
+                rate, startDate, endDate, std::move(calendar), fixedFrequency,
+                fixedConvention, fixedDayCount, index, spread, std::move(discountingCurve),
+                pillar, customPillarDate, endOfMonth, withIndexedCoupons);
+        }
+    }
     Spread spread();
     ext::shared_ptr<VanillaSwap> swap();
 };
@@ -312,6 +337,7 @@ class FixedRateBondHelper : public BondHelper {
 class OISRateHelper : public RateHelper {
     #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
     %feature("kwargs") OISRateHelper;
+    %feature("kwargs") forDates;
     #endif
   public:
     OISRateHelper(
@@ -337,6 +363,37 @@ class OISRateHelper : public RateHelper {
             Natural lockoutDays = 0,
             bool applyObservationShift = false,
             const ext::shared_ptr<FloatingRateCouponPricer>& pricer = {});
+    %extend {
+        static OISRateHelper forDates(
+                const Date& startDate,
+                const Date& endDate,
+                const Handle<Quote>& rate,
+                const ext::shared_ptr<OvernightIndex>& index,
+                Handle<YieldTermStructure> discountingCurve = {},
+                bool telescopicValueDates = false,
+                Integer paymentLag = 0,
+                BusinessDayConvention paymentConvention = Following,
+                Frequency paymentFrequency = Annual,
+                Calendar paymentCalendar = Calendar(),
+                Spread overnightSpread = 0.0,
+                Pillar::Choice pillar = Pillar::LastRelevantDate,
+                Date customPillarDate = Date(),
+                RateAveraging::Type averagingMethod = RateAveraging::Compound,
+                ext::optional<bool> endOfMonth = ext::nullopt,
+                ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
+                Calendar fixedCalendar = Calendar(),
+                Natural lookbackDays = Null<Natural>(),
+                Natural lockoutDays = 0,
+                bool applyObservationShift = false,
+                ext::shared_ptr<FloatingRateCouponPricer> pricer = {}) {
+            return OISRateHelper(
+                startDate, endDate, rate, index, std::move(discountingCurve),
+                telescopicValueDates, paymentLag, paymentConvention, paymentFrequency,
+                paymentCalendar, overnightSpread, pillar, customPillarDate, averagingMethod,
+                endOfMonth, fixedPaymentFrequency, fixedCalendar, lookbackDays, lockoutDays,
+                applyObservationShift, pricer);
+        }
+    }
     ext::shared_ptr<OvernightIndexedSwap> swap();
 };
 

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -274,7 +274,7 @@ class SwapRateHelper : public RateHelper {
             bool endOfMonth = false,
             ext::optional<bool> withIndexedCoupons = ext::nullopt);
     %extend {
-        static SwapRateHelper forDates(
+        static ext::shared_ptr<SwapRateHelper> forDates(
                 const Handle<Quote>& rate,
                 const Date& startDate,
                 const Date& endDate,
@@ -289,7 +289,7 @@ class SwapRateHelper : public RateHelper {
                 Date customPillarDate = Date(),
                 bool endOfMonth = false,
                 const ext::optional<bool>& withIndexedCoupons = ext::nullopt) {
-            return SwapRateHelper(
+            return ext::make_shared<SwapRateHelper>(
                 rate, startDate, endDate, std::move(calendar), fixedFrequency,
                 fixedConvention, fixedDayCount, index, spread, discountingCurve,
                 pillar, customPillarDate, endOfMonth, withIndexedCoupons);
@@ -364,7 +364,7 @@ class OISRateHelper : public RateHelper {
             bool applyObservationShift = false,
             const ext::shared_ptr<FloatingRateCouponPricer>& pricer = {});
     %extend {
-        static OISRateHelper forDates(
+        static ext::shared_ptr<OISRateHelper> forDates(
                 const Date& startDate,
                 const Date& endDate,
                 const Handle<Quote>& rate,
@@ -386,7 +386,7 @@ class OISRateHelper : public RateHelper {
                 Natural lockoutDays = 0,
                 bool applyObservationShift = false,
                 ext::shared_ptr<FloatingRateCouponPricer> pricer = {}) {
-            return OISRateHelper(
+            return ext::make_shared<OISRateHelper>(
                 startDate, endDate, rate, index, discountingCurve,
                 telescopicValueDates, paymentLag, paymentConvention, paymentFrequency,
                 paymentCalendar, overnightSpread, pillar, customPillarDate, averagingMethod,

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -284,14 +284,14 @@ class SwapRateHelper : public RateHelper {
                 DayCounter fixedDayCount,
                 const ext::shared_ptr<IborIndex>& index,
                 const Handle<Quote>& spread = Handle<Quote>(),
-                Handle<YieldTermStructure> discountingCurve = {},
+                const Handle<YieldTermStructure>& discountingCurve = {},
                 Pillar::Choice pillar = Pillar::LastRelevantDate,
                 Date customPillarDate = Date(),
                 bool endOfMonth = false,
                 const ext::optional<bool>& withIndexedCoupons = ext::nullopt) {
             return SwapRateHelper(
                 rate, startDate, endDate, std::move(calendar), fixedFrequency,
-                fixedConvention, fixedDayCount, index, spread, std::move(discountingCurve),
+                fixedConvention, fixedDayCount, index, spread, discountingCurve,
                 pillar, customPillarDate, endOfMonth, withIndexedCoupons);
         }
     }
@@ -369,7 +369,7 @@ class OISRateHelper : public RateHelper {
                 const Date& endDate,
                 const Handle<Quote>& rate,
                 const ext::shared_ptr<OvernightIndex>& index,
-                Handle<YieldTermStructure> discountingCurve = {},
+                const Handle<YieldTermStructure>& discountingCurve = {},
                 bool telescopicValueDates = false,
                 Integer paymentLag = 0,
                 BusinessDayConvention paymentConvention = Following,
@@ -387,7 +387,7 @@ class OISRateHelper : public RateHelper {
                 bool applyObservationShift = false,
                 ext::shared_ptr<FloatingRateCouponPricer> pricer = {}) {
             return OISRateHelper(
-                startDate, endDate, rate, index, std::move(discountingCurve),
+                startDate, endDate, rate, index, discountingCurve,
                 telescopicValueDates, paymentLag, paymentConvention, paymentFrequency,
                 paymentCalendar, overnightSpread, pillar, customPillarDate, averagingMethod,
                 endOfMonth, fixedPaymentFrequency, fixedCalendar, lookbackDays, lockoutDays,


### PR DESCRIPTION
These produce "dated" helpers.

Do not overload constructors so that we can support kwargs.