### PR TITLE
export Cubic Forward Curve constructor

### DIFF
--- a/SWIG/forwardcurve.i
+++ b/SWIG/forwardcurve.i
@@ -27,7 +27,9 @@ using QuantLib::InterpolatedForwardCurve;
 %}
 
 %shared_ptr(InterpolatedForwardCurve<BackwardFlat>);
-            
+%shared_ptr(InterpolatedForwardCurve<Cubic>);
+
+
 template <class Interpolator>
 class InterpolatedForwardCurve : public YieldTermStructure {
   public:
@@ -44,6 +46,6 @@ class InterpolatedForwardCurve : public YieldTermStructure {
 };
 
 %template(ForwardCurve) InterpolatedForwardCurve<BackwardFlat>;
-
+%template(CubicForwardCurve) InterpolatedForwardCurve<Cubic>;
 
 #endif


### PR DESCRIPTION
Export a python binding to a forward curve with cubic interpolation. This is a way to bypass the forward glitch mentioned in --> 
https://www.implementingquantlib.com/2018/10/notebook-glitch-in-forwards.html

Note that at the moment something like 
ql.ForwardCurve(dates, forwards, day_count, calendar, ql.Cubic()) throws an error