### PR TITLE
Use a Python typemap for `std::variant<Real, Handle<Quote>>`

### DIFF
--- a/SWIG/defaultprobability.i
+++ b/SWIG/defaultprobability.i
@@ -196,6 +196,26 @@ namespace std {
 %shared_ptr(SpreadCdsHelper)
 class SpreadCdsHelper : public DefaultProbabilityHelper {
   public:
+    #if defined(SWIGPYTHON)
+    %feature("kwargs") SpreadCdsHelper;
+    SpreadCdsHelper(
+            const std::variant<Real, Handle<Quote>>& spread,
+            const Period& tenor,
+            Integer settlementDays,
+            const Calendar& calendar,
+            Frequency frequency,
+            BusinessDayConvention convention,
+            DateGeneration::Rule rule,
+            const DayCounter& dayCounter,
+            Real recoveryRate,
+            const Handle<YieldTermStructure>& discountCurve,
+            bool settlesAccrual = true,
+            bool paysAtDefaultTime = true,
+            const Date& startDate = Date(),
+            const DayCounter& lastPeriodDayCounter = DayCounter(),
+            bool rebatesAccrual = true,
+            CreditDefaultSwap::PricingModel model = CreditDefaultSwap::Midpoint);
+    #else
     SpreadCdsHelper(
             const Handle<Quote>& spread,
             const Period& tenor,
@@ -230,12 +250,35 @@ class SpreadCdsHelper : public DefaultProbabilityHelper {
             const DayCounter& lastPeriodDayCounter = DayCounter(),
             bool rebatesAccrual = true,
             CreditDefaultSwap::PricingModel model = CreditDefaultSwap::Midpoint);
+    #endif
 };
 
 
 %shared_ptr(UpfrontCdsHelper)
 class UpfrontCdsHelper : public DefaultProbabilityHelper {
   public:
+    #if defined(SWIGPYTHON)
+    %feature("kwargs") UpfrontCdsHelper;
+    UpfrontCdsHelper(
+            const std::variant<Real, Handle<Quote>>& upfront,
+            Rate spread,
+            const Period& tenor,
+            Integer settlementDays,
+            const Calendar& calendar,
+            Frequency frequency,
+            BusinessDayConvention convention,
+            DateGeneration::Rule rule,
+            const DayCounter& dayCounter,
+            Real recoveryRate,
+            const Handle<YieldTermStructure>& discountCurve,
+            Natural upfrontSettlementDays=0,
+            bool settlesAccrual = true,
+            bool paysAtDefaultTime = true,
+            const Date& startDate = Date(),
+            const DayCounter& lastPeriodDayCounter = DayCounter(),
+            bool rebatesAccrual = true,
+            CreditDefaultSwap::PricingModel model = CreditDefaultSwap::Midpoint);
+    #else
     UpfrontCdsHelper(
             const Handle<Quote>& upfront,
             Rate spread,
@@ -274,6 +317,7 @@ class UpfrontCdsHelper : public DefaultProbabilityHelper {
             const DayCounter& lastPeriodDayCounter = DayCounter(),
             bool rebatesAccrual = true,
             CreditDefaultSwap::PricingModel model = CreditDefaultSwap::Midpoint);
+    #endif
 };
 
 

--- a/SWIG/marketelements.i
+++ b/SWIG/marketelements.i
@@ -47,6 +47,62 @@ class Quote : public Observable {
 
 RelinkableHandle<Quote> makeQuoteHandle(Real value);
 
+#if defined(SWIGPYTHON)
+
+%typecheck(SWIG_TYPECHECK_DOUBLE) std::variant<Real, Handle<Quote>>, const std::variant<Real, Handle<Quote>>& %{
+    {
+        int res = SWIG_AsVal_double($input, NULL);
+        $1 = SWIG_CheckState(res);
+    }
+    if (!$1) {
+        int res = SWIG_ConvertPtr($input, 0, $descriptor(Handle<Quote>*), SWIG_POINTER_NO_NULL | 0);
+        $1 = SWIG_CheckState(res);;
+    }
+%}
+
+%typemap(in) std::variant<Real, Handle<Quote>> (int res, Real val, void * argp) %{
+    res = SWIG_AsVal_double($input, &val);
+    if (SWIG_IsOK(res)) {
+        $1 = val;
+    } else {
+        res = SWIG_ConvertPtr($input, &argp, $descriptor(Handle<Quote>*), SWIG_POINTER_NO_NULL);
+        if (!SWIG_IsOK(res)) {
+            SWIG_exception_fail(SWIG_ArgError(res), "in method '$symname', argument $argnum of type '$type'");
+        } else if (!argp) {
+            SWIG_exception_fail(SWIG_ValueError, "invalid null reference in method '$symname', argument $argnum of type '$type'");
+        } else {
+            Handle< Quote > * h = reinterpret_cast< Handle< Quote > * >(argp);
+            $1 = *h;
+            if (SWIG_IsNewObj(res)) delete h;
+        }
+    }
+%}
+
+%typemap(in) const std::variant<Real, Handle<Quote>>& (std::variant<Real, Handle<Quote>> temp, int res, Real val, void * argp) %{
+    res = SWIG_AsVal_double($input, &val);
+    if (SWIG_IsOK(res)) {
+        temp = val;
+        $1 = &temp;
+    } else {
+        res = SWIG_ConvertPtr($input, &argp, $descriptor(Handle<Quote>*), SWIG_POINTER_NO_NULL);
+        if (!SWIG_IsOK(res)) {
+            SWIG_exception_fail(SWIG_ArgError(res), "in method '$symname', argument $argnum of type '$type'");
+        } else if (!argp) {
+            SWIG_exception_fail(SWIG_ValueError, "invalid null reference in method '$symname', argument $argnum of type '$type'");
+        } else {
+            Handle< Quote > * h = reinterpret_cast< Handle< Quote > * >(argp);
+            temp = *h;
+            $1 = &temp;
+            if (SWIG_IsNewObj(res)) delete h;
+        }
+    }
+%}
+
+#endif
+
+
+
+
 // actual quotes
 %{
 using QuantLib::SimpleQuote;

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -359,6 +359,66 @@ class OISRateHelper : public RateHelper {
     %feature("kwargs") forDates;
     #endif
   public:
+    #if defined(SWIGPYTHON)
+    OISRateHelper(
+            Natural settlementDays,
+            const Period& tenor,
+            const std::variant<Real, Handle<Quote>>& rate,
+            const ext::shared_ptr<OvernightIndex>& index,
+            const Handle<YieldTermStructure>& discountingCurve = {},
+            bool telescopicValueDates = false,
+            Integer paymentLag = 0,
+            BusinessDayConvention paymentConvention = Following,
+            Frequency paymentFrequency = Annual,
+            const Calendar& paymentCalendar = Calendar(),
+            const Period& forwardStart = 0 * Days,
+            const Spread overnightSpread = 0.0,
+            Pillar::Choice pillar = Pillar::LastRelevantDate,
+            Date customPillarDate = Date(),
+            RateAveraging::Type averagingMethod = RateAveraging::Compound,
+            ext::optional<bool> endOfMonth = ext::nullopt,
+            ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
+            const Calendar& fixedCalendar = Calendar(),
+            Natural lookbackDays = Null<Natural>(),
+            Natural lockoutDays = 0,
+            bool applyObservationShift = false,
+            const ext::shared_ptr<FloatingRateCouponPricer>& pricer = {},
+            DateGeneration::Rule rule = DateGeneration::Backward,
+            const Calendar& overnightCalendar = Calendar());
+    %extend {
+        static ext::shared_ptr<OISRateHelper> forDates(
+                const Date& startDate,
+                const Date& endDate,
+                const std::variant<Real, Handle<Quote>>& rate,
+                const ext::shared_ptr<OvernightIndex>& index,
+                const Handle<YieldTermStructure>& discountingCurve = {},
+                bool telescopicValueDates = false,
+                Integer paymentLag = 0,
+                BusinessDayConvention paymentConvention = Following,
+                Frequency paymentFrequency = Annual,
+                const Calendar& paymentCalendar = Calendar(),
+                Spread overnightSpread = 0.0,
+                Pillar::Choice pillar = Pillar::LastRelevantDate,
+                Date customPillarDate = Date(),
+                RateAveraging::Type averagingMethod = RateAveraging::Compound,
+                ext::optional<bool> endOfMonth = ext::nullopt,
+                ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
+                const Calendar& fixedCalendar = Calendar(),
+                Natural lookbackDays = Null<Natural>(),
+                Natural lockoutDays = 0,
+                bool applyObservationShift = false,
+                const ext::shared_ptr<FloatingRateCouponPricer>& pricer = {},
+                DateGeneration::Rule rule = DateGeneration::Backward,
+                const Calendar& overnightCalendar = Calendar()) {
+            return ext::make_shared<OISRateHelper>(
+                startDate, endDate, rate, index, discountingCurve,
+                telescopicValueDates, paymentLag, paymentConvention, paymentFrequency,
+                paymentCalendar, overnightSpread, pillar, customPillarDate, averagingMethod,
+                endOfMonth, fixedPaymentFrequency, fixedCalendar, lookbackDays, lockoutDays,
+                applyObservationShift, pricer, rule, overnightCalendar);
+        }
+    }
+    #else
     OISRateHelper(
             Natural settlementDays,
             const Period& tenor,
@@ -417,6 +477,7 @@ class OISRateHelper : public RateHelper {
                 applyObservationShift, pricer, rule, overnightCalendar);
         }
     }
+    #endif
     ext::shared_ptr<OvernightIndexedSwap> swap();
 };
 


### PR DESCRIPTION
In a couple of cases, this makes it possible to avoid overloading on `Real` and `Handle<Quote>` and thus to enable kwargs.

However, it requires to maintain two different declarations for Python and for the other languages (C# might be made to work too, but the duplication would remain) so it's a trade-off.