### PR TITLE
Don't export bootstrap traits

### DIFF
--- a/SWIG/piecewiseyieldcurve.i
+++ b/SWIG/piecewiseyieldcurve.i
@@ -26,21 +26,10 @@
 %include optimizers.i
 %include null.i
 
-// bootstrap traits
-
 %{
 using QuantLib::Discount;
 using QuantLib::ZeroYield;
 using QuantLib::ForwardRate;
-%}
-
-struct Discount {};
-struct ZeroYield {};
-struct ForwardRate {};
-
-// curve
-
-%{
 using QuantLib::PiecewiseYieldCurve;
 %}
 


### PR DESCRIPTION
Bootstrap traits are only used as template type parameters and never as values, so it does not make sense to export them.