### PR TITLE
Removed a few features deprecated long ago.

### DIFF
--- a/SWIG/date.i
+++ b/SWIG/date.i
@@ -847,29 +847,6 @@ class PeriodParser {
 };
 
 
-#if defined(SWIGPYTHON)
-%pythoncode %{
-Date._old___add__ = Date.__add__
-Date._old___sub__ = Date.__sub__
-def Date_new___add__(self,x):
-    if type(x) is tuple and len(x) == 2:
-        from warnings import warn
-        warn(f'adding a tuple to a Date is deprecated; use a Period instance', FutureWarning, stacklevel=2)
-        return self._old___add__(Period(x[0],x[1]))
-    else:
-        return self._old___add__(x)
-def Date_new___sub__(self,x):
-    if type(x) is tuple and len(x) == 2:
-        from warnings import warn
-        warn(f'subtracting a tuple from a Date is deprecated; use a Period instance', FutureWarning, stacklevel=2)
-        return self._old___sub__(Period(x[0],x[1]))
-    else:
-        return self._old___sub__(x)
-Date.__add__ = Date_new___add__
-Date.__sub__ = Date_new___sub__
-%}
-#endif
-
 namespace std {
     %template(DateVector) vector<Date>;
 }

--- a/SWIG/old_volatility.i
+++ b/SWIG/old_volatility.i
@@ -32,8 +32,6 @@
 %include volatilities.i
 
 
-// eventually the classes exported here will be redesigned or deprecated
-
 // cap/floor volatilities
 
 %{

--- a/SWIG/settings.i
+++ b/SWIG/settings.i
@@ -61,30 +61,6 @@ class Settings {
     void anchorEvaluationDate();
     void resetEvaluationDate();
     %extend {
-        Date getEvaluationDate() {
-            #if defined(SWIGPYTHON)
-            cpp_deprecate_feature(getEvaluationDate, evaluationDate);
-            #endif
-            return self->evaluationDate();
-        }
-        void setEvaluationDate(const Date& d) {
-            #if defined(SWIGPYTHON)
-            cpp_deprecate_feature(setEvaluationDate, evaluationDate);
-            #endif
-            self->evaluationDate() = d;
-        }
-        bool getEnforcesTodaysHistoricFixings() {
-            #if defined(SWIGPYTHON)
-            cpp_deprecate_feature(getEnforcesTodaysHistoricFixings, enforcesTodaysHistoricFixings);
-            #endif
-            return self->enforcesTodaysHistoricFixings();
-        }
-        void setEnforcesTodaysHistoricFixings(bool b) {
-            #if defined(SWIGPYTHON)
-            cpp_deprecate_feature(setEnforcesTodaysHistoricFixings, enforcesTodaysHistoricFixings);
-            #endif
-            self->enforcesTodaysHistoricFixings() = b;
-        }
         #if defined(SWIGPYTHON)
         %newobject evaluationDate;
         Date evaluationDate;
@@ -92,6 +68,18 @@ class Settings {
         bool includeReferenceDateEvents;
         ext::optional<bool> includeTodaysCashFlows;
         #else
+        Date getEvaluationDate() {
+            return self->evaluationDate();
+        }
+        void setEvaluationDate(const Date& d) {
+            self->evaluationDate() = d;
+        }
+        bool getEnforcesTodaysHistoricFixings() {
+            return self->enforcesTodaysHistoricFixings();
+        }
+        void setEnforcesTodaysHistoricFixings(bool b) {
+            self->enforcesTodaysHistoricFixings() = b;
+        }
         void includeReferenceDateEvents(bool b) {
             self->includeReferenceDateEvents() = b;
         }

--- a/SWIG/volatilities.i
+++ b/SWIG/volatilities.i
@@ -172,7 +172,6 @@ class YoYOptionletVolatilitySurface : public VolatilityTermStructure {
 
 %template(YoYOptionletVolatilitySurfaceHandle) Handle<YoYOptionletVolatilitySurface>;
 %template(RelinkableYoYOptionletVolatilitySurfaceHandle) RelinkableHandle<YoYOptionletVolatilitySurface>;
-deprecate_feature(RelinkableYoYOptionletVolatilitySurface, RelinkableYoYOptionletVolatilitySurfaceHandle);
 
 
 %{
@@ -826,7 +825,6 @@ class SabrSwaptionVolatilityCube : public SwaptionVolatilityCube {
     }
 };
 
-deprecate_feature(SwaptionVolCube1, SabrSwaptionVolatilityCube)
 
 %shared_ptr(InterpolatedSwaptionVolatilityCube);
 class InterpolatedSwaptionVolatilityCube : public SwaptionVolatilityCube {
@@ -840,8 +838,6 @@ class InterpolatedSwaptionVolatilityCube : public SwaptionVolatilityCube {
                                        const ext::shared_ptr<SwapIndex>& shortSwapIndex,
                                        bool vegaWeightedSmileFit);
 };
-
-deprecate_feature(SwaptionVolCube2, InterpolatedSwaptionVolatilityCube)
 
 
 %{


### PR DESCRIPTION
- adding and subtracting from a `Date` a tuple representing a period;
- methods like `getEvaluationDate` and `setEvaluationDate` in `Settings`, instead of using the `evaluationDate` property; the same goes for `enforcesTodaysHistoricFixings`, `includeReferenceDateEvents` and `includeTodaysCashFlows`;
- obsolete aliases like `RelinkableYoYOptionletVolatilitySurface` for `RelinkableYoYOptionletVolatilitySurfaceHandle`, `SwaptionVolCube1` for `SabrSwaptionVolatilityCube` and `SwaptionVolCube2` for `InterpolatedSwaptionVolatilityCube`.

Being defined in the wrappers, they escaped the usual deprecation and removal process.  The latest were in version 1.30.

Also closes #609.