### PR TITLE
Use `Schedule` instead of`shared_ptr<Schedule>`

### DIFF
--- a/SWIG/cashflows.i
+++ b/SWIG/cashflows.i
@@ -753,7 +753,7 @@ class RangeAccrualFloatersCoupon: public FloatingRateCoupon {
                                Rate spread,
                                const Date& refPeriodStart,
                                const Date& refPeriodEnd,
-                               ext::shared_ptr<Schedule> observationsSchedule,
+                               const Schedule& observationsSchedule,
                                Real lowerTrigger,
                                Real upperTrigger);
 };


### PR DESCRIPTION
The previous declaration made it impossible to call the constructor.