### PR TITLE
Call the correct overload when not passing nominalTS

### DIFF
--- a/SWIG/inflation.i
+++ b/SWIG/inflation.i
@@ -536,7 +536,7 @@ namespace std {
 %shared_ptr(ZeroCouponInflationSwapHelper)
 class ZeroCouponInflationSwapHelper : public BootstrapHelper<ZeroInflationTermStructure> {
     #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
-    %feature("kwargs") ZeroCouponInflationSwapHelper;
+    //%feature("kwargs") ZeroCouponInflationSwapHelper;
     #endif
   public:
     ZeroCouponInflationSwapHelper(
@@ -547,8 +547,18 @@ class ZeroCouponInflationSwapHelper : public BootstrapHelper<ZeroInflationTermSt
             BusinessDayConvention bcd,
             const DayCounter& dayCounter,
             const ext::shared_ptr<ZeroInflationIndex>& index,
+            CPI::InterpolationType observationInterpolation);
+
+    ZeroCouponInflationSwapHelper(
+            const Handle<Quote>& quote,
+            const Period& lag,   // lag on swap observation of index
+            const Date& maturity,
+            const Calendar& calendar,
+            BusinessDayConvention bcd,
+            const DayCounter& dayCounter,
+            const ext::shared_ptr<ZeroInflationIndex>& index,
             CPI::InterpolationType observationInterpolation,
-            const Handle<YieldTermStructure>& nominalTS = {});
+            const Handle<YieldTermStructure>& nominalTS);
 
     ext::shared_ptr<ZeroCouponInflationSwap> swap() const;
 };


### PR DESCRIPTION
With the current code when nominalTS is not passed explicitly, instead of calling the new C++ constructor, the wrapper calls the old C++ constructor and passes a null YieldTermStructureHandle, which makes bootstrapping fail. This is how default arguments in SWIG work when %kwargs feature is enabled. When it's not enabled, default arguments are translated into overloads, so the correct code would have been generated, but this seems quite subtle, so adding an explicit overload seems better.