### PR TITLE
Add flag for building a QuantLib wheel against a debug QuantLib on Windows

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -17,7 +17,13 @@ The build step requires that the QuantLib headers and library can be
 found by the compiler. On Unix-like platforms, this requires that
 `quantlib-config` is in your path. On the Windows platform, instead,
 it requires you to define a `QL_DIR` environment variable pointing to
-your QuantLib directory (e.g., `C:\Lib\QuantLib`.)
+your QuantLib directory (e.g., `C:\Lib\QuantLib`.) Another environment
+variable `QL_DEBUG` on Windows should be set to `TRUE` if you are building
+against a debug version of QuantLib with the objective to
+debug the library called from Python. On Unit-like platforms, appropriate flags
+can be setup in `CXXFLAGS` and `LDFLAGS`. If boost is required for compilation,
+it can be set via the environment variable `INCLUDE`.
+
 
 Once built, the resulting wheel can be installed with `pip`.
 

--- a/SWIG/quantlib.i
+++ b/SWIG/quantlib.i
@@ -95,4 +95,8 @@ const char* __version__;
 %feature("autodoc");
 #endif
 
+%begin %{
+#define SWIG_PYTHON_INTERPRETER_NO_DEBUG
+%}
+
 %include ql.i


### PR DESCRIPTION
As discussed, creating a separate PR for building a QuantLib package against a debug QuantLib version