### PR TITLE
Expose `forDates` on inflation swap helpers

### DIFF
--- a/SWIG/inflation.i
+++ b/SWIG/inflation.i
@@ -547,21 +547,24 @@ namespace std {
 %shared_ptr(ZeroCouponInflationSwapHelper)
 class ZeroCouponInflationSwapHelper : public BootstrapHelper<ZeroInflationTermStructure> {
     #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
+    %feature("kwargs") forDates;
+    #endif
+    #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
     //%feature("kwargs") ZeroCouponInflationSwapHelper;
     #endif
     // remove the kludge below when we go back to just one constructor
     // and we re-enable kwargs above
 #if defined(SWIGPYTHON)
 %feature("shadow") ZeroCouponInflationSwapHelper %{
-def __init__(self, quote, lag, maturity, calendar, bcd, dayCounter, index, observationInterpolation, nominalTS=None):
+def __init__(self, quote, lag, maturity, calendar, bdc, dayCounter, index, observationInterpolation, nominalTS=None):
     r"""
-    __init__(ZeroCouponInflationSwapHelper self, QuoteHandle quote, Period lag, Date maturity, Calendar calendar, BusinessDayConvention bcd, DayCounter dayCounter, ext::shared_ptr< ZeroInflationIndex > const & index, CPI::InterpolationType observationInterpolation) -> ZeroCouponInflationSwapHelper
-    __init__(ZeroCouponInflationSwapHelper self, QuoteHandle quote, Period lag, Date maturity, Calendar calendar, BusinessDayConvention bcd, DayCounter dayCounter, ext::shared_ptr< ZeroInflationIndex > const & index, CPI::InterpolationType observationInterpolation, YieldTermStructureHandle nominalTS) -> ZeroCouponInflationSwapHelper
+    __init__(ZeroCouponInflationSwapHelper self, QuoteHandle quote, Period lag, Date maturity, Calendar calendar, BusinessDayConvention bdc, DayCounter dayCounter, ext::shared_ptr< ZeroInflationIndex > const & index, CPI::InterpolationType observationInterpolation) -> ZeroCouponInflationSwapHelper
+    __init__(ZeroCouponInflationSwapHelper self, QuoteHandle quote, Period lag, Date maturity, Calendar calendar, BusinessDayConvention bdc, DayCounter dayCounter, ext::shared_ptr< ZeroInflationIndex > const & index, CPI::InterpolationType observationInterpolation, YieldTermStructureHandle nominalTS) -> ZeroCouponInflationSwapHelper
     """
     if nominalTS is None:
-        _QuantLib.ZeroCouponInflationSwapHelper_swiginit(self, _QuantLib.new_ZeroCouponInflationSwapHelper(quote, lag, maturity, calendar, bcd, dayCounter, index, observationInterpolation))
+        _QuantLib.ZeroCouponInflationSwapHelper_swiginit(self, _QuantLib.new_ZeroCouponInflationSwapHelper(quote, lag, maturity, calendar, bdc, dayCounter, index, observationInterpolation))
     else:
-        _QuantLib.ZeroCouponInflationSwapHelper_swiginit(self, _QuantLib.new_ZeroCouponInflationSwapHelper(quote, lag, maturity, calendar, bcd, dayCounter, index, observationInterpolation, nominalTS))
+        _QuantLib.ZeroCouponInflationSwapHelper_swiginit(self, _QuantLib.new_ZeroCouponInflationSwapHelper(quote, lag, maturity, calendar, bdc, dayCounter, index, observationInterpolation, nominalTS))
 %}
 #endif
   public:
@@ -570,7 +573,7 @@ def __init__(self, quote, lag, maturity, calendar, bcd, dayCounter, index, obser
             const Period& lag,   // lag on swap observation of index
             const Date& maturity,
             const Calendar& calendar,
-            BusinessDayConvention bcd,
+            BusinessDayConvention bdc,
             const DayCounter& dayCounter,
             const ext::shared_ptr<ZeroInflationIndex>& index,
             CPI::InterpolationType observationInterpolation);
@@ -580,17 +583,35 @@ def __init__(self, quote, lag, maturity, calendar, bcd, dayCounter, index, obser
             const Period& lag,   // lag on swap observation of index
             const Date& maturity,
             const Calendar& calendar,
-            BusinessDayConvention bcd,
+            BusinessDayConvention bdc,
             const DayCounter& dayCounter,
             const ext::shared_ptr<ZeroInflationIndex>& index,
             CPI::InterpolationType observationInterpolation,
             const Handle<YieldTermStructure>& nominalTS);
-
+    %extend {
+        static ext::shared_ptr<ZeroCouponInflationSwapHelper> forDates(
+                const Handle<Quote>& quote,
+                const Period& lag,
+                const Date& startDate,
+                const Date& endDate,
+                const Calendar& calendar,
+                BusinessDayConvention bdc,
+                const DayCounter& dayCounter,
+                const ext::shared_ptr<ZeroInflationIndex>& index,
+                CPI::InterpolationType observationInterpolation) {
+            return ext::make_shared<ZeroCouponInflationSwapHelper>(
+                quote, lag, startDate, endDate, calendar, bdc, dayCounter, index,
+                observationInterpolation);
+        }
+    }
     ext::shared_ptr<ZeroCouponInflationSwap> swap() const;
 };
 
 %shared_ptr(YearOnYearInflationSwapHelper)
 class YearOnYearInflationSwapHelper : public BootstrapHelper<YoYInflationTermStructure> {
+    #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
+    %feature("kwargs") forDates;
+    #endif
   public:
     YearOnYearInflationSwapHelper(const Handle<Quote>& quote,
                                   const Period& lag,
@@ -601,7 +622,23 @@ class YearOnYearInflationSwapHelper : public BootstrapHelper<YoYInflationTermStr
                                   const ext::shared_ptr<YoYInflationIndex>& index,
                                   CPI::InterpolationType interpolation,
                                   const Handle<YieldTermStructure>& nominalTS);
-
+    %extend {
+        static ext::shared_ptr<YearOnYearInflationSwapHelper> forDates(
+                const Handle<Quote>& quote,
+                const Period& lag,
+                const Date& startDate,
+                const Date& endDate,
+                const Calendar& calendar,
+                BusinessDayConvention bdc,
+                const DayCounter& dayCounter,
+                const ext::shared_ptr<YoYInflationIndex>& index,
+                CPI::InterpolationType interpolation,
+                const Handle<YieldTermStructure>& nominalTS) {
+            return ext::make_shared<YearOnYearInflationSwapHelper>(
+                quote, lag, startDate, endDate, calendar, bdc, dayCounter, index,
+                interpolation, nominalTS);
+        }
+    }
     ext::shared_ptr<YearOnYearInflationSwap> swap() const;
 };
 


### PR DESCRIPTION
This exports the new constructor from https://github.com/lballabio/QuantLib/pull/2351