### PR TITLE
Add missing constructor to a couple of pricers

### DIFF
--- a/SWIG/cashflows.i
+++ b/SWIG/cashflows.i
@@ -525,10 +525,16 @@ class BlackAveragingOvernightIndexedCouponPricer: public ArithmeticAveragedOvern
 };
 
 %shared_ptr(CompoundingMultipleResetsPricer)
-class CompoundingMultipleResetsPricer : public FloatingRateCouponPricer {};
+class CompoundingMultipleResetsPricer : public FloatingRateCouponPricer {
+  public:
+    CompoundingMultipleResetsPricer();
+};
 
 %shared_ptr(AveragingMultipleResetsPricer)
-class AveragingMultipleResetsPricer : public FloatingRateCouponPricer {};
+class AveragingMultipleResetsPricer : public FloatingRateCouponPricer {
+  public:
+    AveragingMultipleResetsPricer();
+};
 
 %shared_ptr(CompoundingRatePricer)
 class CompoundingRatePricer: public SubPeriodsPricer {


### PR DESCRIPTION
SWIG won't generate a default constructor if the base class doesn't have one.