### PR TITLE
Release Python GIL when bootstrapping curves

### DIFF
--- a/SWIG/common.i
+++ b/SWIG/common.i
@@ -263,9 +263,64 @@ class PyPtr {
     PyObject* ptr_;
 };
 
+static thread_local PyThreadState* s_saved_thread_state = nullptr;
+
+// Similar to Py_BEGIN_ALLOW_THREADS/Py_END_ALLOW_THREADS but exception-safe and can be nested.
+class PyAllowThreads {
+  public:
+    PyAllowThreads(): allowed_(false) {
+        if (s_saved_thread_state == nullptr) {
+            s_saved_thread_state = PyEval_SaveThread();
+            allowed_ = true;
+        }
+    }
+    ~PyAllowThreads() {
+        if (allowed_) {
+            PyEval_RestoreThread(s_saved_thread_state);
+            s_saved_thread_state = nullptr;
+        }
+    }
+  private:
+    bool allowed_;
+};
+
+// Similar to Py_BLOCK_THREADS/Py_UNBLOCK_THREADS but exception-safe and is a no-op when threads
+// are not allowed.
+class PyBlockThreads {
+  public:
+    PyBlockThreads(): blocked_(false) {
+        if (s_saved_thread_state != nullptr) {
+            PyEval_RestoreThread(s_saved_thread_state);
+            s_saved_thread_state = nullptr;
+            blocked_ = true;
+        }
+    }
+    ~PyBlockThreads() {
+        if (blocked_) {
+            s_saved_thread_state = PyEval_SaveThread();
+        }
+    }
+  private:
+    bool blocked_;
+};
+
+template <class Wrapped>
+class ExpensiveLazyObject : public Wrapped {
+  public:
+    using Wrapped::Wrapped;
+  private:
+    void performCalculations() const override {
+        PyAllowThreads allow_threads;
+        Wrapped::performCalculations();
+    }
+};
+
 #define cpp_deprecate_feature(OldName, NewName) \
     PyErr_WarnEx(PyExc_FutureWarning, (#OldName " is deprecated; use " #NewName), 1)
 #else
+template <class Wrapped>
+using ExpensiveLazyObject = Wrapped;
+
 #define cpp_deprecate_feature(OldName, NewName)
 #endif
 %}

--- a/SWIG/functions.i
+++ b/SWIG/functions.i
@@ -36,12 +36,14 @@ class UnaryFunction {
     : function_(PyPtr::fromBorrowed(function)) {}
 
     Real operator()(Real x) const {
+        PyBlockThreads block_threads;
         auto pyResult = PyPtr::fromResult(
             PyObject_CallFunction(function_.get(), "d", x),
             "failed to call Python function");
         return PyFloat_AsDouble(pyResult.get());
     }
     Real derivative(Real x) const {
+        PyBlockThreads block_threads;
         auto pyResult = PyPtr::fromResult(
             PyObject_CallMethod(function_.get(), "derivative", "d", x),
             "failed to call derivative() on Python object");
@@ -57,6 +59,7 @@ class BinaryFunction {
     : function_(PyPtr::fromBorrowed(function)) {}
 
     Real operator()(Real x, Real y) const {
+        PyBlockThreads block_threads;
         auto pyResult = PyPtr::fromResult(
             PyObject_CallFunction(function_.get(), "dd", x, y),
             "failed to call Python function");
@@ -72,6 +75,7 @@ class ArrayFunction {
     : function_(PyPtr::fromBorrowed(function)) {}
 
     Real operator()(const Array& x) const {
+        PyBlockThreads block_threads;
         auto tuple = PyPtr::fromResult(PyTuple_New(x.size()), "failed to convert arguments");
         for (Size i=0; i<x.size(); i++)
             PyTuple_SetItem(tuple.get(), i, PyFloat_FromDouble(x[i]));

--- a/SWIG/inflation.i
+++ b/SWIG/inflation.i
@@ -641,8 +641,12 @@ class YearOnYearInflationSwapHelper : public BootstrapHelper<YoYInflationTermStr
 
 
 %{
-using QuantLib::PiecewiseZeroInflationCurve;
-using QuantLib::PiecewiseYoYInflationCurve;
+template <class Interpolator>
+using PiecewiseZeroInflationCurve = ExpensiveLazyObject<
+                                        QuantLib::PiecewiseZeroInflationCurve<Interpolator>>;
+template <class Interpolator>
+using PiecewiseYoYInflationCurve = ExpensiveLazyObject<
+                                        QuantLib::PiecewiseYoYInflationCurve<Interpolator>>;
 %}
 
 %shared_ptr(PiecewiseZeroInflationCurve<Linear>);
@@ -675,6 +679,7 @@ class PiecewiseZeroInflationCurve : public ZeroInflationTermStructure {
                 Real accuracy = 1.0e-12,
                 const Interpolator& i = Interpolator()) {
             auto func = [pyFunc = PyPtr::fromBorrowed(baseDateFunc)]() {
+                PyBlockThreads block_threads;
                 auto pyResult = PyPtr::fromResult(
                     PyObject_CallObject(pyFunc.get(), NULL),
                     "failed to call Python baseDateFunc");

--- a/SWIG/observer.i
+++ b/SWIG/observer.i
@@ -62,6 +62,7 @@ class PyObserver : public Observer {
     : callback_(PyPtr::fromBorrowed(callback)) {}
 
     void update() {
+        PyBlockThreads block_threads;
         PyPtr::fromResult(PyObject_CallObject(callback_.get(), NULL),
                           "failed to notify Python observer");
     }

--- a/SWIG/piecewiseyieldcurve.i
+++ b/SWIG/piecewiseyieldcurve.i
@@ -30,7 +30,6 @@
 using QuantLib::Discount;
 using QuantLib::ZeroYield;
 using QuantLib::ForwardRate;
-using QuantLib::PiecewiseYieldCurve;
 %}
 
 %{
@@ -88,7 +87,7 @@ struct _IterativeBootstrap {
 %define export_piecewise_curve(Name,Traits,Interpolator)
 
 %{
-typedef PiecewiseYieldCurve<Traits, Interpolator> Name;
+typedef ExpensiveLazyObject<QuantLib::PiecewiseYieldCurve<Traits, Interpolator>> Name;
 %}
 
 %shared_ptr(Name);
@@ -244,8 +243,7 @@ struct _GlobalBootstrap {
 
 
 %{
-using QuantLib::SimpleZeroYield;
-typedef PiecewiseYieldCurve<SimpleZeroYield, Linear, QuantLib::GlobalBootstrap>
+typedef QuantLib::PiecewiseYieldCurve<QuantLib::SimpleZeroYield, Linear, QuantLib::GlobalBootstrap>
     GlobalLinearSimpleZeroCurve;
 %}
 
@@ -280,14 +278,10 @@ class GlobalLinearSimpleZeroCurve : public YieldTermStructure {
 };
 
 
-%{
-using QuantLib::PiecewiseSpreadYieldCurve;
-%}
-
 %define export_piecewise_spread_curve(Name,Traits,Interpolator)
 
 %{
-typedef PiecewiseSpreadYieldCurve<Traits, Interpolator> Name;
+typedef ExpensiveLazyObject<QuantLib::PiecewiseSpreadYieldCurve<Traits, Interpolator>> Name;
 %}
 
 %shared_ptr(Name);


### PR DESCRIPTION
This allows building multiple curves concurrently. This is also quite useful in any multi-threaded setting (for example, a service), because building a curve no longer blocks all other Python threads.

While there's an ongoing work on free-threaded Python, it still has compatibility issues, and the current implementation still requires using these APIs: https://docs.python.org/3/c-api/threads.html#apis