### PR TITLE
Export BMA index and swap-rate helper

### DIFF
--- a/Python/test/test_iborindex.py
+++ b/Python/test/test_iborindex.py
@@ -69,6 +69,40 @@ class IborIndexTest(unittest.TestCase):
             self.assertTrue(expected == actual)
 
 
+class BMAIndexTest(unittest.TestCase):
+    def setUp(self):
+        self.index = ql.BMAIndex()
+
+    def testInspectors(self):
+        """Testing BMA index inspectors"""
+
+        self.assertEqual(self.index.familyName(), "BMA")
+        self.assertEqual(self.index.tenor(), ql.Period(1, ql.Weeks))
+        self.assertEqual(self.index.fixingDays(), 1)
+        self.assertEqual(self.index.currency(), ql.USDCurrency())
+
+    def testFixingDates(self):
+        """Testing BMA fixing-date logic"""
+
+        self.assertTrue(self.index.isValidFixingDate(ql.Date(4, 1, 2023)))
+        self.assertFalse(self.index.isValidFixingDate(ql.Date(5, 1, 2023)))
+
+    def testMaturityDate(self):
+        """Testing BMA maturity-date calculation"""
+
+        self.assertEqual(
+            self.index.maturityDate(ql.Date(5, 1, 2023)),
+            ql.Date(12, 1, 2023))
+
+    def testFixingSchedule(self):
+        """Testing BMA fixing schedule"""
+
+        schedule = self.index.fixingSchedule(
+            ql.Date(5, 1, 2023), ql.Date(20, 1, 2023))
+        self.assertEqual(schedule[0], ql.Date(4, 1, 2023))
+        self.assertEqual(schedule[-1], ql.Date(25, 1, 2023))
+
+
 if __name__ == "__main__":
     print("testing QuantLib", ql.__version__)
     unittest.main(verbosity=2)

--- a/Python/test/test_ratehelpers.py
+++ b/Python/test/test_ratehelpers.py
@@ -69,6 +69,37 @@ class FixedRateBondHelperTest(unittest.TestCase):
         ql.Settings.instance().evaluationDate = ql.Date()
 
 
+class BMASwapRateHelperTest(unittest.TestCase):
+    def setUp(self):
+        self.reference_date = ql.Date(4, 1, 2023)
+        ql.Settings.instance().evaluationDate = self.reference_date
+
+    def testConstruction(self):
+        """Testing BMA swap rate-helper construction"""
+
+        forecast_curve = ql.YieldTermStructureHandle(
+            ql.FlatForward(
+                self.reference_date,
+                ql.makeQuoteHandle(0.03),
+                ql.Actual360()))
+        helper = ql.BMASwapRateHelper(
+            ql.makeQuoteHandle(0.75),
+            ql.Period(5, ql.Years),
+            2,
+            ql.UnitedStates(ql.UnitedStates.GovernmentBond),
+            ql.Period(1, ql.Weeks),
+            ql.Following,
+            ql.ActualActual(ql.ActualActual.ISDA),
+            ql.BMAIndex(),
+            ql.USDLibor(ql.Period(1, ql.Months), forecast_curve))
+
+        self.assertTrue(helper.earliestDate() < helper.latestDate())
+        self.assertEqual(helper.quote().value(), 0.75)
+
+    def tearDown(self):
+        ql.Settings.instance().evaluationDate = ql.Date()
+
+
 class OISRateHelperTest(unittest.TestCase):
     def setUp(self):
 

--- a/SWIG/indexes.i
+++ b/SWIG/indexes.i
@@ -30,6 +30,7 @@
 %include currencies.i
 %include types.i
 %include termstructures.i
+%include scheduler.i
 %include timeseries.i
 %include vectors.i
 %include boost_shared_ptr.i
@@ -157,6 +158,21 @@ class OvernightIndex : public IborIndex {
             return ext::dynamic_pointer_cast<OvernightIndex>(self->clone(h));
         }
     }
+};
+
+%{
+using QuantLib::BMAIndex;
+%}
+
+%shared_ptr(BMAIndex)
+
+class BMAIndex : public InterestRateIndex {
+  public:
+    BMAIndex(const Handle<YieldTermStructure>& h =
+                                    Handle<YieldTermStructure>());
+    Handle<YieldTermStructure> forwardingTermStructure() const;
+    Date maturityDate(const Date& valueDate) const;
+    Schedule fixingSchedule(const Date& start, const Date& end);
 };
 
 %{

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -40,6 +40,7 @@ using QuantLib::FuturesRateHelper;
 using QuantLib::SwapRateHelper;
 using QuantLib::BondHelper;
 using QuantLib::FixedRateBondHelper;
+using QuantLib::BMASwapRateHelper;
 using QuantLib::OISRateHelper;
 using QuantLib::FxSwapRateHelper;
 using QuantLib::OvernightIndexFutureRateHelper;
@@ -329,6 +330,21 @@ class SwapRateHelper : public RateHelper {
     }
     Spread spread();
     ext::shared_ptr<VanillaSwap> swap();
+};
+
+%shared_ptr(BMASwapRateHelper)
+class BMASwapRateHelper : public RateHelper {
+  public:
+    BMASwapRateHelper(
+            const Handle<Quote>& liborFraction,
+            const Period& tenor,
+            Natural settlementDays,
+            const Calendar& calendar,
+            const Period& bmaPeriod,
+            BusinessDayConvention bmaConvention,
+            const DayCounter& bmaDayCount,
+            const ext::shared_ptr<BMAIndex>& bmaIndex,
+            const ext::shared_ptr<IborIndex>& index);
 };
 
 %shared_ptr(BondHelper)


### PR DESCRIPTION
Found that BMA index and its rate helper bindings are omitted so added in python