### PR TITLE
Expose `Calendar.addedHolidays()`/`removedHolidays()`

### DIFF
--- a/Python/test/test_calendars.py
+++ b/Python/test/test_calendars.py
@@ -55,10 +55,30 @@ class BespokeCalendarTest(unittest.TestCase):
         self.assertFalse(calendar.isHoliday(test_date))
         calendar.addHoliday(test_date)
         self.assertTrue(calendar.isHoliday(test_date))
-        # TODO: Can extend test with this, if exposed:
-        # self.assertEqual(len(calendar.addedHolidays()), 1)
+        self.assertEqual(len(calendar.addedHolidays()), 1)
         calendar.resetAddedAndRemovedHolidays()
         self.assertFalse(calendar.isHoliday(test_date))
+
+
+class AddedRemovedHolidaysTest(unittest.TestCase):
+
+    def test_added_and_removed_holidays(self):
+        calendar = ql.TARGET()
+        added = ql.Date(15, ql.March, 2023)   # a Wednesday, normally a business day
+        removed = ql.Date(7, ql.April, 2023)  # Good Friday 2023, a real TARGET holiday
+
+        self.assertFalse(calendar.isHoliday(added))
+        self.assertTrue(calendar.isHoliday(removed))
+
+        calendar.addHoliday(added)
+        calendar.removeHoliday(removed)
+
+        self.assertEqual(list(calendar.addedHolidays()), [added])
+        self.assertEqual(list(calendar.removedHolidays()), [removed])
+
+        calendar.resetAddedAndRemovedHolidays()
+        self.assertEqual(len(calendar.addedHolidays()), 0)
+        self.assertEqual(len(calendar.removedHolidays()), 0)
 
 
 if __name__ == "__main__":

--- a/SWIG/calendars.i
+++ b/SWIG/calendars.i
@@ -111,6 +111,14 @@ class Calendar {
     std::string name();
     bool empty();
     %extend {
+        std::vector<Date> addedHolidays() {
+            return std::vector<Date>(self->addedHolidays().begin(),
+                                     self->addedHolidays().end());
+        }
+        std::vector<Date> removedHolidays() {
+            return std::vector<Date>(self->removedHolidays().begin(),
+                                     self->removedHolidays().end());
+        }
         std::string __str__() {
             return self->name()+" calendar";
         }


### PR DESCRIPTION
`Calendar` already exposes `addHoliday`, `removeHoliday`, and `resetAddedAndRemovedHolidays`, but not the corresponding read-back accessors `addedHolidays()` / `removedHolidays()`. As a result, Python users can modify a calendar's holiday set but cannot inspect which dates they added or removed.

**What's now exposed:** `Calendar::addedHolidays()` and `Calendar::removedHolidays()` (from `ql/time/calendar.hpp`).

**How:** The C++ methods return `const std::set<Date>&`, for which there is no SWIG typemap. They're wrapped via `%extend` returning the already-supported `std::vector<Date>` (sorted, since `std::set` iterates in order), mirroring how `holidayList`/`businessDayList` already surface date collections. No new typemaps required.

**Testing:** Added `AddedRemovedHolidaysTest` in `Python/test/test_calendars.py`, asserting against independently known values — `Date(15, March, 2023)` (an ordinary Wednesday business day) added, and `Date(7, April, 2023)` (Good Friday 2023, a genuine TARGET holiday) removed — then verifying the accessors return exactly those dates and that both clear after `resetAddedAndRemovedHolidays()`. Also fills in the existing `# TODO` in `test_reset_added_holidays` that requested this. Full Python suite passes locally.

**Why useful:** Lets Python callers introspect calendar customizations (e.g. audit or serialize bespoke holiday overrides) instead of only being able to apply them blindly.