### PR TITLE
Fix declaration order for `AssetSwap`

### DIFF
--- a/SWIG/bonds.i
+++ b/SWIG/bonds.i
@@ -31,6 +31,7 @@
 %include cashflows.i
 %include interestrate.i
 %include indexes.i
+%shared_ptr(Bond)
 %include inflation.i
 %include shortratemodels.i
 
@@ -55,7 +56,6 @@ class BondPrice {
     bool isValid() const;
 };
 
-%shared_ptr(Bond)
 class Bond : public Instrument {
     #if defined(SWIGPYTHON)
     %rename(bondYield) yield;


### PR DESCRIPTION
AssetSwap is exposed to C# but the C# generated code looks like this:

AssetSwap(bool payFixedRate, SWIGTYPE_p_ext__shared_ptrT_Bond_t bond, ...)

instead of:

AssetSwap(bool payFixedRate, Bond bond, ...)

This is because of the SWIG include order. bonds.i included inflation.i before declaring %shared_ptr(Bond).

The fix is to have the declaration %shared_ptr(Bond) earlier.