### PR TITLE
Export `MultiCurve` class and more instantiations of global-bootstrapped curves

### DIFF
--- a/Python/test/test_multicurve.py
+++ b/Python/test/test_multicurve.py
@@ -1,0 +1,81 @@
+"""
+ Copyright (C) 2026 QuantLib contributors
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+"""
+
+import unittest
+
+import QuantLib as ql
+
+
+class MultiCurveTest(unittest.TestCase):
+
+    def test_piecewise_and_spreaded_curve(self):
+        """Globally bootstrap a dependency cycle of two yield curves."""
+        today = ql.Date(23, ql.October, 2025)
+        ql.Settings.instance().evaluationDate = today
+
+        internal_ois = ql.RelinkableYieldTermStructureHandle()
+        internal_3m = ql.RelinkableYieldTermStructureHandle()
+        euribor_3m = ql.Euribor3M(internal_3m)
+
+        quote = ql.SimpleQuote(0.03)
+        spread = ql.SimpleQuote(-0.01)
+        helpers = []
+        for maturity in range(1, 11):
+            helpers.append(
+                ql.SwapRateHelper(
+                    ql.QuoteHandle(quote),
+                    ql.Period(maturity, ql.Years),
+                    euribor_3m.fixingCalendar(),
+                    ql.Annual,
+                    ql.Following,
+                    ql.Thirty360(ql.Thirty360.BondBasis),
+                    euribor_3m,
+                    ql.QuoteHandle(),
+                    ql.Period(0, ql.Days),
+                    internal_ois,
+                )
+            )
+
+        accuracy = 1.0e-10
+        multi_curve = ql.MultiCurve(accuracy)
+        curve_3m = ql.GlobalLinearSimpleZeroCurve(
+            today, helpers, ql.Actual360(), ql.GlobalBootstrap(accuracy)
+        )
+        external_3m = multi_curve.addBootstrappedCurve(internal_3m, curve_3m)
+
+        curve_ois = ql.ZeroSpreadedTermStructure(
+            internal_3m, ql.QuoteHandle(spread)
+        )
+        external_ois = multi_curve.addNonBootstrappedCurve(internal_ois, curve_ois)
+
+        # The external handles keep the MultiCurve and all its members alive.
+        del multi_curve, curve_3m, curve_ois
+
+        forecast = external_3m.currentLink()
+        discount = external_ois.currentLink()
+        self.assertAlmostEqual(
+            discount.zeroRate(1.0, ql.Continuous).rate()
+            - forecast.zeroRate(1.0, ql.Continuous).rate(),
+            spread.value(),
+            delta=accuracy,
+        )
+        for helper in helpers:
+            self.assertAlmostEqual(helper.quoteError(), 0.0, delta=accuracy)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Python/test/test_multicurve.py
+++ b/Python/test/test_multicurve.py
@@ -52,7 +52,7 @@ class MultiCurveTest(unittest.TestCase):
 
         accuracy = 1.0e-10
         multi_curve = ql.MultiCurve(accuracy)
-        curve_3m = ql.GlobalLinearSimpleZeroCurve(
+        curve_3m = ql.GlobalPiecewiseLogLinearDiscount(
             today, helpers, ql.Actual360(), ql.GlobalBootstrap(accuracy)
         )
         external_3m = multi_curve.addBootstrappedCurve(internal_3m, curve_3m)

--- a/Python/test/test_multicurve.py
+++ b/Python/test/test_multicurve.py
@@ -52,8 +52,14 @@ class MultiCurveTest(unittest.TestCase):
 
         accuracy = 1.0e-10
         multi_curve = ql.MultiCurve(accuracy)
+        jump = ql.SimpleQuote(0.99)
         curve_3m = ql.GlobalPiecewiseLogLinearDiscount(
-            today, helpers, ql.Actual360(), ql.GlobalBootstrap(accuracy)
+            today,
+            helpers,
+            ql.Actual360(),
+            ql.GlobalBootstrap(accuracy),
+            [ql.QuoteHandle(jump)],
+            [ql.Date(31, ql.December, 2027)],
         )
         external_3m = multi_curve.addBootstrappedCurve(internal_3m, curve_3m)
 

--- a/SWIG/multicurve.i
+++ b/SWIG/multicurve.i
@@ -1,0 +1,54 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2026 QuantLib contributors
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#ifndef quantlib_multicurve_i
+#define quantlib_multicurve_i
+
+%include piecewiseyieldcurve.i
+
+%{
+#include <ql/termstructures/multicurve.hpp>
+using QuantLib::MultiCurve;
+%}
+
+%shared_ptr(MultiCurve);
+class MultiCurve {
+  public:
+    explicit MultiCurve(Real accuracy);
+    explicit MultiCurve(const ext::shared_ptr<OptimizationMethod>& optimizer = nullptr,
+                        const ext::shared_ptr<EndCriteria>& endCriteria = nullptr);
+
+    %extend {
+        Handle<YieldTermStructure>
+        addBootstrappedCurve(RelinkableHandle<YieldTermStructure>& internalHandle,
+                             const ext::shared_ptr<YieldTermStructure>& curve) {
+            ext::shared_ptr<YieldTermStructure> curveCopy = curve;
+            return self->addBootstrappedCurve(internalHandle, std::move(curveCopy));
+        }
+
+        Handle<YieldTermStructure>
+        addNonBootstrappedCurve(RelinkableHandle<YieldTermStructure>& internalHandle,
+                                const ext::shared_ptr<YieldTermStructure>& curve) {
+            ext::shared_ptr<YieldTermStructure> curveCopy = curve;
+            return self->addNonBootstrappedCurve(internalHandle, std::move(curveCopy));
+        }
+    }
+};
+
+#endif

--- a/SWIG/piecewiseyieldcurve.i
+++ b/SWIG/piecewiseyieldcurve.i
@@ -179,8 +179,7 @@ export_piecewise_curve(PiecewiseLogParabolicCubicDiscount,Discount,LogParabolicC
 export_piecewise_curve(PiecewiseMonotonicLogParabolicCubicDiscount,Discount,MonotonicLogParabolicCubic);
 
 
-// global boostrapper
-// hard-coded to linearly-interpolated, simply-compounded zero rates for now
+// global bootstrapper
 
 %{
 class AdditionalErrors {
@@ -228,6 +227,17 @@ struct _GlobalBootstrap {
    : additionalHelpers(additionalHelpers), additionalDates(additionalDates), accuracy(accuracy),
      optimizer(optimizer), endCriteria(endCriteria) {}
 };
+
+template <class Curve>
+inline typename Curve::bootstrap_type make_global_bootstrap(const _GlobalBootstrap& b) {
+    if (b.additionalHelpers.empty()) {
+        return typename Curve::bootstrap_type(b.accuracy, b.optimizer, b.endCriteria);
+    }
+    return typename Curve::bootstrap_type(b.additionalHelpers,
+                                          AdditionalDates(b.additionalDates),
+                                          AdditionalErrors(b.additionalHelpers),
+                                          b.accuracy, b.optimizer, b.endCriteria);
+}
 %}
 
 %rename(GlobalBootstrap) _GlobalBootstrap;
@@ -243,41 +253,74 @@ struct _GlobalBootstrap {
 };
 
 
+%define export_global_piecewise_curve(Name,Traits,Interpolator)
+
 %{
-using QuantLib::SimpleZeroYield;
-typedef PiecewiseYieldCurve<SimpleZeroYield, Linear, QuantLib::GlobalBootstrap>
-    GlobalLinearSimpleZeroCurve;
+typedef PiecewiseYieldCurve<Traits, Interpolator, QuantLib::GlobalBootstrap> Name;
 %}
 
-%shared_ptr(GlobalLinearSimpleZeroCurve);
-class GlobalLinearSimpleZeroCurve : public YieldTermStructure {
+%shared_ptr(Name);
+class Name : public YieldTermStructure {
   public:
     %extend {
-        GlobalLinearSimpleZeroCurve(
+        Name(
              const Date& referenceDate,
              const std::vector<ext::shared_ptr<RateHelper> >& instruments,
              const DayCounter& dayCounter,
              const _GlobalBootstrap& b) {
-            if (b.additionalHelpers.empty()) {
-                return new GlobalLinearSimpleZeroCurve(
-                    referenceDate, instruments, dayCounter, Linear(),
-                    GlobalLinearSimpleZeroCurve::bootstrap_type(b.accuracy, b.optimizer, b.endCriteria));
-            } else {
-                return new GlobalLinearSimpleZeroCurve(
-                    referenceDate, instruments, dayCounter, Linear(),
-                    GlobalLinearSimpleZeroCurve::bootstrap_type(b.additionalHelpers,
-                                                                AdditionalDates(b.additionalDates),
-                                                                AdditionalErrors(b.additionalHelpers),
-                                                                b.accuracy, b.optimizer, b.endCriteria));
-            }
+            return new Name(referenceDate, instruments, dayCounter, Interpolator(),
+                            make_global_bootstrap<Name>(b));
+        }
+        Name(
+             Natural settlementDays,
+             const Calendar& calendar,
+             const std::vector<ext::shared_ptr<RateHelper> >& instruments,
+             const DayCounter& dayCounter,
+             const _GlobalBootstrap& b) {
+            return new Name(settlementDays, calendar, instruments, dayCounter, Interpolator(),
+                            make_global_bootstrap<Name>(b));
         }
     }
     const std::vector<Date>& dates() const;
     const std::vector<Time>& times() const;
+    const std::vector<Real>& data() const;
     #if !defined(SWIGR)
     std::vector<std::pair<Date,Real> > nodes() const;
     #endif
+
+    void recalculate();
+    void freeze();
+    void unfreeze();
 };
+
+%enddef
+
+
+%{
+using QuantLib::SimpleZeroYield;
+%}
+
+// Keep the original name for backwards compatibility.
+export_global_piecewise_curve(GlobalLinearSimpleZeroCurve,SimpleZeroYield,Linear);
+
+export_global_piecewise_curve(GlobalPiecewiseFlatForward,ForwardRate,BackwardFlat);
+export_global_piecewise_curve(GlobalPiecewiseLogLinearDiscount,Discount,LogLinear);
+export_global_piecewise_curve(GlobalPiecewiseLinearForward,ForwardRate,Linear);
+export_global_piecewise_curve(GlobalPiecewiseLinearZero,ZeroYield,Linear);
+export_global_piecewise_curve(GlobalPiecewiseCubicZero,ZeroYield,Cubic);
+export_global_piecewise_curve(GlobalPiecewiseLogCubicDiscount,Discount,LogCubic);
+export_global_piecewise_curve(GlobalPiecewiseSplineCubicDiscount,Discount,SplineCubic);
+export_global_piecewise_curve(GlobalPiecewiseKrugerZero,ZeroYield,Kruger);
+export_global_piecewise_curve(GlobalPiecewiseKrugerLogDiscount,Discount,KrugerLog);
+export_global_piecewise_curve(GlobalPiecewiseConvexMonotoneForward,ForwardRate,ConvexMonotone);
+export_global_piecewise_curve(GlobalPiecewiseConvexMonotoneZero,ZeroYield,ConvexMonotone);
+export_global_piecewise_curve(GlobalPiecewiseNaturalCubicZero,ZeroYield,SplineCubic);
+export_global_piecewise_curve(GlobalPiecewiseNaturalLogCubicDiscount,Discount,SplineLogCubic);
+export_global_piecewise_curve(GlobalPiecewiseLogMixedLinearCubicDiscount,Discount,LogMixedLinearCubic);
+export_global_piecewise_curve(GlobalPiecewiseParabolicCubicZero,ZeroYield,ParabolicCubic);
+export_global_piecewise_curve(GlobalPiecewiseMonotonicParabolicCubicZero,ZeroYield,MonotonicParabolicCubic);
+export_global_piecewise_curve(GlobalPiecewiseLogParabolicCubicDiscount,Discount,LogParabolicCubic);
+export_global_piecewise_curve(GlobalPiecewiseMonotonicLogParabolicCubicDiscount,Discount,MonotonicLogParabolicCubic);
 
 
 %{

--- a/SWIG/piecewiseyieldcurve.i
+++ b/SWIG/piecewiseyieldcurve.i
@@ -268,8 +268,12 @@ class Name : public YieldTermStructure {
              const Date& referenceDate,
              const std::vector<ext::shared_ptr<RateHelper> >& instruments,
              const DayCounter& dayCounter,
-             const _GlobalBootstrap& b) {
-            return new Name(referenceDate, instruments, dayCounter, Interpolator(),
+             const _GlobalBootstrap& b,
+             const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
+             const std::vector<Date>& jumpDates = std::vector<Date>(),
+             const Interpolator& i = Interpolator()) {
+            return new Name(referenceDate, instruments, dayCounter,
+                            jumps, jumpDates, i,
                             make_global_bootstrap<Name>(b));
         }
         Name(
@@ -277,8 +281,12 @@ class Name : public YieldTermStructure {
              const Calendar& calendar,
              const std::vector<ext::shared_ptr<RateHelper> >& instruments,
              const DayCounter& dayCounter,
-             const _GlobalBootstrap& b) {
-            return new Name(settlementDays, calendar, instruments, dayCounter, Interpolator(),
+             const _GlobalBootstrap& b,
+             const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
+             const std::vector<Date>& jumpDates = std::vector<Date>(),
+             const Interpolator& i = Interpolator()) {
+            return new Name(settlementDays, calendar, instruments, dayCounter,
+                            jumps, jumpDates, i,
                             make_global_bootstrap<Name>(b));
         }
     }

--- a/SWIG/ql.i
+++ b/SWIG/ql.i
@@ -172,6 +172,7 @@ QL_DEPRECATED_DISABLE_WARNING
 %include options.i
 %include payoffs.i
 %include piecewiseyieldcurve.i
+%include multicurve.i
 %include randomnumbers.i
 %include ratehelpers.i
 %include rounding.i

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -688,7 +688,8 @@ class OvernightIborBasisSwapRateHelper : public RateHelper {
                                      bool endOfMonth,
                                      const ext::shared_ptr<OvernightIndex>& baseIndex,
                                      const ext::shared_ptr<IborIndex>& otherIndex,
-                                     Handle<YieldTermStructure> discountHandle = Handle<YieldTermStructure>());
+                                     Handle<YieldTermStructure> discountHandle = Handle<YieldTermStructure>(),
+                                     bool bootstrapBaseCurve = false);
     ext::shared_ptr<Swap> swap();
 };
 

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -689,7 +689,8 @@ class OvernightIborBasisSwapRateHelper : public RateHelper {
                                      const ext::shared_ptr<OvernightIndex>& baseIndex,
                                      const ext::shared_ptr<IborIndex>& otherIndex,
                                      Handle<YieldTermStructure> discountHandle = Handle<YieldTermStructure>(),
-                                     bool bootstrapBaseCurve = false);
+                                     bool bootstrapBaseCurve = false,
+                                     Integer paymentLag = 0);
     ext::shared_ptr<Swap> swap();
 };
 

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -4,7 +4,6 @@
  Copyright (C) 2009 Joseph Malicki
  Copyright (C) 2018 Matthias Lungwitz
  Copyright (C) 2021 Marcin Rybacki
- Copyright (C) 2026 Kyrylo Protsenko
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/


### PR DESCRIPTION
This PR does three small things together:
1. Accompanying SWIG for OIS-Ibor basis PR in QuantLib https://github.com/lballabio/QuantLib/pull/2674
2. Adds different interpolators for global bootstrap (Addresses issue https://github.com/lballabio/QuantLib-SWIG/issues/874 )
3. Enables true global multicurve bootstrapping (exposes the existing QuantLib functionality)