### PR TITLE
Export optional rounding precision for `OvernightIndexedSwap` and `MakeOIS`

### DIFF
--- a/SWIG/swap.i
+++ b/SWIG/swap.i
@@ -390,7 +390,8 @@ class OvernightIndexedSwap : public FixedVsFloatingSwap {
             RateAveraging::Type averagingMethod = RateAveraging::Compound,
             Natural lookbackDays = Null<Natural>(),
             Natural lockoutDays = 0,
-            bool applyObservationShift = false);
+            bool applyObservationShift = false,
+            std::optional<Integer> roundingPrecision = std::nullopt);
     
     OvernightIndexedSwap(
             Type type,
@@ -407,7 +408,8 @@ class OvernightIndexedSwap : public FixedVsFloatingSwap {
             RateAveraging::Type averagingMethod = RateAveraging::Compound,
             Natural lookbackDays = Null<Natural>(),
             Natural lockoutDays = 0,
-            bool applyObservationShift = false);
+            bool applyObservationShift = false,
+            std::optional<Integer> roundingPrecision = std::nullopt);
 
     OvernightIndexedSwap(Type type,
                          const std::vector<Real>& fixedNominals,
@@ -425,7 +427,8 @@ class OvernightIndexedSwap : public FixedVsFloatingSwap {
                          RateAveraging::Type averagingMethod = RateAveraging::Compound,
                          Natural lookbackDays = Null<Natural>(),
                          Natural lockoutDays = 0,
-                         bool applyObservationShift = false);
+                         bool applyObservationShift = false,
+                         std::optional<Integer> roundingPrecision = std::nullopt);
 
     Real overnightLegBPS();
     Real overnightLegNPV();
@@ -495,6 +498,7 @@ class MakeOIS {
         MakeOIS& withLookbackDays(Natural lookbackDays);
         MakeOIS& withLockoutDays(Natural lockoutDays);
         MakeOIS& withObservationShift(bool applyObservationShift = true);
+        MakeOIS& withRoundingPrecision(std::optional<Integer> roundingPrecision);
         MakeOIS& withPricingEngine(
                               const ext::shared_ptr<PricingEngine>& engine);
 };
@@ -538,6 +542,7 @@ _MAKEOIS_METHODS = {
     "lookbackDays": "withLookbackDays",
     "lockoutDays": "withLockoutDays",
     "applyObservationShift": "withObservationShift",
+    "roundingPrecision": "withRoundingPrecision",
     "pricingEngine": "withPricingEngine",
 }
 


### PR DESCRIPTION
See https://github.com/lballabio/QuantLib/pull/2666.