### PR TITLE
Fix for a regression

### DIFF
--- a/SWIG/optimizers.i
+++ b/SWIG/optimizers.i
@@ -390,9 +390,9 @@ class Cmaes : public OptimizationMethod {
         Cmaes(Size populationSize = 0,
               Real sigma = 0.3,
               unsigned long seed = 0,
-              Array lowerBound = {},
-              Array upperBound = {},
-              Array initialMean = {}) {
+              Array lowerBound = Array(),
+              Array upperBound = Array(),
+              Array initialMean = Array()) {
             Cmaes::Configuration cfg =
                 Cmaes::Configuration()
                 .withPopulationSize(populationSize)


### PR DESCRIPTION
PR https://github.com/lballabio/QuantLib-SWIG/pull/892 seems to have introduced a regression in SWIG versions < 4.4. The Python package can no longer be built due to the array initialisation 

Array lowerBound = {},
Array upperBound = {},
Array initialMean = {}

in optimizers.i

This PR fixes by changing it to

Array lowerBound = Array(),
Array upperBound = Array(),
Array initialMean = Array()

Note that for Swig 4.4+ both variants work. For older versions of Swig only the second variant works.