### PR TITLE
Make `DiscountingSwapEngine` arguments match the C++ signature

### DIFF
--- a/SWIG/swap.i
+++ b/SWIG/swap.i
@@ -303,21 +303,20 @@ class NonstandardSwap : public Swap {
 
 %shared_ptr(DiscountingSwapEngine)
 class DiscountingSwapEngine : public PricingEngine {
+    #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
+    %feature("kwargs") DiscountingSwapEngine;
+    #endif
   public:
+    DiscountingSwapEngine(const Handle<YieldTermStructure>& discountCurve,
+                          ext::optional<bool> includeSettlementDateFlows = ext::nullopt,
+                          const Date& settlementDate = Date(),
+                          const Date& npvDate = Date());
+    #if defined(SWIGJAVA)
     DiscountingSwapEngine(const Handle<YieldTermStructure>& discountCurve,
                           bool includeSettlementDateFlows,
                           const Date& settlementDate = Date(),
                           const Date& npvDate = Date());
-    %extend {
-        DiscountingSwapEngine(const Handle<YieldTermStructure>& discountCurve,
-                              const Date& settlementDate = Date(),
-                              const Date& npvDate = Date()) {
-            return new DiscountingSwapEngine(discountCurve,
-                                             std::nullopt,
-                                             settlementDate,
-                                             npvDate);
-        }
-    }
+    #endif
 };
 
 


### PR DESCRIPTION
Also, enable kwargs.

**Note: this is a breaking change**, since it removes one of the constructor overloads.  The overload is not available in C++ and was probably here for historical reasons because we didn't have support for the `std::optional` argument back in the day.