### PR TITLE
Export new arguments for basis-swap rate helpers

### DIFF
--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -674,7 +674,8 @@ class IborIborBasisSwapRateHelper : public RateHelper {
                                 const ext::shared_ptr<IborIndex>& otherIndex,
                                 Handle<YieldTermStructure> discountHandle,
                                 bool bootstrapBaseCurve,
-                                std::optional<bool> useIndexedCoupons = std::nullopt);
+                                std::optional<bool> useIndexedCoupons = std::nullopt,
+                                DateGeneration::Rule rule = DateGeneration::Backward);
     ext::shared_ptr<Swap> swap();
 };
 
@@ -694,7 +695,8 @@ class OvernightIborBasisSwapRateHelper : public RateHelper {
                                      Integer paymentLag = 0,
                                      std::optional<Frequency> overnightPaymentFrequency = std::nullopt,
                                      std::optional<Frequency> iborPaymentFrequency = std::nullopt,
-                                     std::optional<bool> useIndexedCoupons = std::nullopt);
+                                     std::optional<bool> useIndexedCoupons = std::nullopt,
+                                     DateGeneration::Rule rule = DateGeneration::Backward);
     ext::shared_ptr<Swap> swap();
 };
 

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -4,6 +4,7 @@
  Copyright (C) 2009 Joseph Malicki
  Copyright (C) 2018 Matthias Lungwitz
  Copyright (C) 2021 Marcin Rybacki
+ Copyright (C) 2026 Kyrylo Protsenko
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/SWIG/ratehelpers.i
+++ b/SWIG/ratehelpers.i
@@ -704,7 +704,6 @@ class OvernightIborBasisSwapRateHelper : public RateHelper {
                                      bool bootstrapBaseCurve = false,
                                      Integer paymentLag = 0,
                                      std::optional<Frequency> overnightPaymentFrequency = std::nullopt,
-                                     std::optional<Frequency> iborPaymentFrequency = std::nullopt,
                                      std::optional<bool> useIndexedCoupons = std::nullopt,
                                      DateGeneration::Rule rule = DateGeneration::Backward);
     ext::shared_ptr<Swap> swap();


### PR DESCRIPTION
This PR adds arguments added by https://github.com/lballabio/QuantLib/pull/2700 and https://github.com/lballabio/QuantLib/pull/2696 in QuantLib.
