### PR TITLE
Fix for `QuantoForwardEuropeanEngine`

### DIFF
--- a/SWIG/options.i
+++ b/SWIG/options.i
@@ -1445,7 +1445,7 @@ using QuantLib::ForwardVanillaEngine;
 using QuantLib::QuantoEngine;
 typedef ForwardVanillaEngine<AnalyticEuropeanEngine> ForwardEuropeanEngine;
 typedef QuantoEngine<VanillaOption,AnalyticEuropeanEngine> QuantoEuropeanEngine;
-typedef QuantoEngine<ForwardVanillaOption,AnalyticEuropeanEngine> QuantoForwardEuropeanEngine;
+typedef QuantoEngine<ForwardVanillaOption,ForwardVanillaEngine<AnalyticEuropeanEngine> > QuantoForwardEuropeanEngine;
 %}
 
 


### PR DESCRIPTION
Currently incorrectly exported (error thrown "wrong engine type") - fixing the export type