### PR TITLE
Enable sessions in free-threading wheels

### DIFF
--- a/.ci/wheels/before_all_linux_nogil.sh
+++ b/.ci/wheels/before_all_linux_nogil.sh
@@ -10,6 +10,6 @@ cd ..
 
 # Build QuantLib
 cd QuantLib-1.*/
-./configure --disable-static --enable-thread-safe-observer-pattern --disable-test-suite --enable-skip-examples --enable-unity-build CXXFLAGS="${CXXQLFLAGS}"
+./configure --disable-static --enable-thread-safe-observer-pattern --enable-sessions --disable-test-suite --enable-skip-examples --enable-unity-build CXXFLAGS="${CXXQLFLAGS}"
 make -j 4 install
 cd ..

--- a/.ci/wheels/userconfig_nogil.hpp
+++ b/.ci/wheels/userconfig_nogil.hpp
@@ -73,7 +73,7 @@
    per-thread.
 */
 #ifndef QL_ENABLE_SESSIONS
-//#   define QL_ENABLE_SESSIONS
+#   define QL_ENABLE_SESSIONS
 #endif
 
 /* If defined, a thread-safe (but less performant) version of the

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -161,7 +161,7 @@ jobs:
       run: |
         tar xfz QuantLib-${{ needs.detect-version.outputs.version }}.tar.gz
         cd QuantLib-${{ needs.detect-version.outputs.version }}/
-        ./configure --disable-shared --with-boost-include=`brew --prefix`/include --enable-unity-build --enable-thread-safe-observer-pattern --disable-test-suite --enable-skip-examples
+        ./configure --disable-shared --with-boost-include=`brew --prefix`/include --enable-unity-build --enable-thread-safe-observer-pattern --enable-sessions --disable-test-suite --enable-skip-examples
         make -j3 CXXFLAGS="-std=c++17 -g0 -O3 -fno-common -dynamic -DNDEBUG -fwrapv" LDFLAGS="-fno-common -dynamic -DNDEBUG -fwrapv"
         sudo make install
     - name: Unpack QuantLib-SWIG


### PR DESCRIPTION
**Only for the free-threading wheels:** the old-style, default wheels are not affected by this.

Breaking change in behavior, but the free-threading wheels are definitely less useful without this.  What it means is that each thread will have its own evaluation date, stored index fixings etc. so you'll have to set them up.  I still advise to **not** share objects between threads, because the library is not thread-safe.