### PR TITLE
Expose `ObservableSettings`

### DIFF
--- a/SWIG/lazyobject.i
+++ b/SWIG/lazyobject.i
@@ -36,6 +36,7 @@ class LazyObject : public Observable {
     void recalculate();
     void freeze();
     void unfreeze();
+    void deepUpdate();
     %extend {
         static void forwardFirstNotificationOnly() {
             LazyObject::Defaults::instance().forwardFirstNotificationOnly();

--- a/SWIG/observer.i
+++ b/SWIG/observer.i
@@ -25,10 +25,22 @@
 %{
 using QuantLib::Observer;
 using QuantLib::Observable;
+using QuantLib::ObservableSettings;
 %}
 
 %shared_ptr(Observable);
 class Observable {};
+
+class ObservableSettings {
+  private:
+    ObservableSettings();
+  public:
+    static ObservableSettings& instance();
+    void disableUpdates(bool deferred = false);
+    void enableUpdates();
+    bool updatesEnabled();
+    bool updatesDeferred();
+};
 
 
 %extend Handle {


### PR DESCRIPTION
Expose ObservableSettings for temporarily disabling updates and then re-enabling them
Expose deepUpdate() for triggering an update only on a specific object and its components when the global updates are disabled.