### PR TITLE
Exposing initial guess for global bootstrap and `InterpolatedSimpleZeroCurve`

### DIFF
--- a/SWIG/piecewiseyieldcurve.i
+++ b/SWIG/piecewiseyieldcurve.i
@@ -32,6 +32,7 @@ using QuantLib::Discount;
 using QuantLib::ZeroYield;
 using QuantLib::ForwardRate;
 using QuantLib::PiecewiseYieldCurve;
+using QuantLib::SimpleZeroYield;
 %}
 
 %{
@@ -148,6 +149,7 @@ class Name : public YieldTermStructure {
 %enddef
 
 
+export_piecewise_curve(PiecewiseLinearSimpleZero,SimpleZeroYield,Linear);
 export_piecewise_curve(PiecewiseFlatForward,ForwardRate,BackwardFlat);
 export_piecewise_curve(PiecewiseLogLinearDiscount,Discount,LogLinear);
 export_piecewise_curve(PiecewiseLinearForward,ForwardRate,Linear);
@@ -216,28 +218,48 @@ struct _GlobalBootstrap {
     double accuracy;
     ext::shared_ptr<OptimizationMethod> optimizer;
     ext::shared_ptr<EndCriteria> endCriteria;
+    std::vector<Real> initialGuess;
     _GlobalBootstrap(double accuracy = Null<double>(),
                      ext::shared_ptr<OptimizationMethod> optimizer = nullptr,
-                     ext::shared_ptr<EndCriteria> endCriteria = nullptr)
-    : accuracy(accuracy), optimizer(optimizer), endCriteria(endCriteria) {}
+                     ext::shared_ptr<EndCriteria> endCriteria = nullptr,
+                     const std::vector<Real>& initialGuess = std::vector<Real>())
+    : accuracy(accuracy), optimizer(optimizer), endCriteria(endCriteria),
+      initialGuess(initialGuess) {}
    _GlobalBootstrap(const std::vector<ext::shared_ptr<RateHelper> >& additionalHelpers,
                     const std::vector<Date>& additionalDates,
                     double accuracy = Null<double>(),
                     ext::shared_ptr<OptimizationMethod> optimizer = nullptr,
-                    ext::shared_ptr<EndCriteria> endCriteria = nullptr)
+                    ext::shared_ptr<EndCriteria> endCriteria = nullptr,
+                    const std::vector<Real>& initialGuess = std::vector<Real>())
    : additionalHelpers(additionalHelpers), additionalDates(additionalDates), accuracy(accuracy),
-     optimizer(optimizer), endCriteria(endCriteria) {}
+     optimizer(optimizer), endCriteria(endCriteria), initialGuess(initialGuess) {}
 };
+
+typedef std::function<Array(const std::vector<Time>&, const std::vector<Real>&)>
+    GlobalBootstrapInitialGuessFn;
+
+inline GlobalBootstrapInitialGuessFn make_initial_guess_fn(const std::vector<Real>& seed) {
+    if (seed.empty())
+        return nullptr;
+    return [seed](const std::vector<Time>& times, const std::vector<Real>&) {
+        QL_REQUIRE(!times.empty() && seed.size() == times.size() - 1,
+                   "initial guess has " << seed.size() << " values but the curve has "
+                   << (times.empty() ? 0 : times.size() - 1) << " pillars");
+        return Array(seed.begin(), seed.end());
+    };
+}
 
 template <class Curve>
 inline typename Curve::bootstrap_type make_global_bootstrap(const _GlobalBootstrap& b) {
     if (b.additionalHelpers.empty()) {
-        return typename Curve::bootstrap_type(b.accuracy, b.optimizer, b.endCriteria);
+        return typename Curve::bootstrap_type(b.accuracy, b.optimizer, b.endCriteria,
+                                              {}, make_initial_guess_fn(b.initialGuess));
     }
     return typename Curve::bootstrap_type(b.additionalHelpers,
                                           AdditionalDates(b.additionalDates),
                                           AdditionalErrors(b.additionalHelpers),
-                                          b.accuracy, b.optimizer, b.endCriteria);
+                                          b.accuracy, b.optimizer, b.endCriteria,
+                                          nullptr, {}, make_initial_guess_fn(b.initialGuess));
 }
 %}
 
@@ -245,12 +267,14 @@ inline typename Curve::bootstrap_type make_global_bootstrap(const _GlobalBootstr
 struct _GlobalBootstrap {
     _GlobalBootstrap(doubleOrNull accuracy = Null<double>(),
                      ext::shared_ptr<OptimizationMethod> optimizer = nullptr,
-                     ext::shared_ptr<EndCriteria> endCriteria = nullptr);
+                     ext::shared_ptr<EndCriteria> endCriteria = nullptr,
+                     const std::vector<Real>& initialGuess = std::vector<Real>());
     _GlobalBootstrap(const std::vector<ext::shared_ptr<RateHelper> >& additionalHelpers,
                      const std::vector<Date>& additionalDates,
                      doubleOrNull accuracy = Null<double>(),
                      ext::shared_ptr<OptimizationMethod> optimizer = nullptr,
-                     ext::shared_ptr<EndCriteria> endCriteria = nullptr);
+                     ext::shared_ptr<EndCriteria> endCriteria = nullptr,
+                     const std::vector<Real>& initialGuess = std::vector<Real>());
 };
 
 
@@ -304,10 +328,6 @@ class Name : public YieldTermStructure {
 
 %enddef
 
-
-%{
-using QuantLib::SimpleZeroYield;
-%}
 
 // Keep the original name for backwards compatibility.
 export_global_piecewise_curve(GlobalLinearSimpleZeroCurve,SimpleZeroYield,Linear);

--- a/SWIG/zerocurve.i
+++ b/SWIG/zerocurve.i
@@ -59,6 +59,31 @@ class InterpolatedZeroCurve : public YieldTermStructure {
 };
 
 %template(ZeroCurve) InterpolatedZeroCurve<Linear>;
+
+%{
+using QuantLib::InterpolatedSimpleZeroCurve;
+%}
+
+%shared_ptr(InterpolatedSimpleZeroCurve<Linear>);
+
+template <class Interpolator>
+class InterpolatedSimpleZeroCurve : public YieldTermStructure {
+  public:
+    InterpolatedSimpleZeroCurve(const std::vector<Date>& dates,
+                                const std::vector<Rate>& yields,
+                                const DayCounter& dayCounter,
+                                const Calendar& calendar = Calendar(),
+                                const Interpolator& i = Interpolator());
+    const std::vector<Time>& times() const;
+    const std::vector<Real>& data() const;
+    const std::vector<Date>& dates() const;
+    const std::vector<Rate>& zeroRates() const;
+    #if !defined(SWIGR)
+    std::vector<std::pair<Date,Rate> > nodes() const;
+    #endif
+};
+
+%template(SimpleZeroCurve) InterpolatedSimpleZeroCurve<Linear>;
 #if defined(SWIGPYTHON)
 %template(_LogLinearZeroCurve) InterpolatedZeroCurve<LogLinear>;
 %template(_LogCubicZeroCurve) InterpolatedZeroCurve<DefaultLogCubic>;


### PR DESCRIPTION
QuantLib recently gained an ability to pass a seed to the global curve bootstrapper - exposing this argument here
Also exposing the continuously compounded zero rate curve interpolation.