### PR TITLE
Fix missing or incorrect SWIG exports

### DIFF
--- a/SWIG/cashflows.i
+++ b/SWIG/cashflows.i
@@ -201,6 +201,7 @@ class FloatingRateCoupon : public Coupon {
     Real price(const Handle<YieldTermStructure>& discountCurve) const;
     ext::shared_ptr<InterestRateIndex> index() const;
     void setPricer(const ext::shared_ptr<FloatingRateCouponPricer>& p);
+    ext::shared_ptr<FloatingRateCouponPricer> pricer() const;
 };
 
 %inline %{
@@ -546,6 +547,7 @@ class MultipleResetsCoupon : public FloatingRateCoupon {
 %{
 using QuantLib::IborCouponPricer;
 using QuantLib::BlackIborCouponPricer;
+using QuantLib::OvernightIndexedCouponPricer;
 using QuantLib::CompoundingOvernightIndexedCouponPricer;
 using QuantLib::BlackCompoundingOvernightIndexedCouponPricer;
 using QuantLib::ArithmeticAveragedOvernightIndexedCouponPricer;
@@ -579,10 +581,34 @@ class BlackIborCouponPricer : public IborCouponPricer {
                           std::optional<bool> useIndexedCoupon = std::nullopt);
 };
 
-%shared_ptr(CompoundingOvernightIndexedCouponPricer)
-class CompoundingOvernightIndexedCouponPricer: public FloatingRateCouponPricer {
+%shared_ptr(OvernightIndexedCouponPricer)
+class OvernightIndexedCouponPricer: public FloatingRateCouponPricer {
+  private:
+    OvernightIndexedCouponPricer();
   public:
-    CompoundingOvernightIndexedCouponPricer();
+    void setCapletVolatility(
+               const Handle<OptionletVolatilityStructure>& v = {});
+    const Handle<OptionletVolatilityStructure>& capletVolatility() const;
+    void setEffectiveVolatilityInput(bool effectiveVolatilityInput);
+    bool effectiveVolatilityInput() const;
+    Real effectiveCapletVolatility() const;
+    Real effectiveFloorletVolatility() const;
+};
+
+%inline %{
+    ext::shared_ptr<OvernightIndexedCouponPricer>
+    as_overnight_indexed_coupon_pricer(
+               const ext::shared_ptr<FloatingRateCouponPricer>& pricer) {
+        return ext::dynamic_pointer_cast<OvernightIndexedCouponPricer>(pricer);
+    }
+%}
+
+%shared_ptr(CompoundingOvernightIndexedCouponPricer)
+class CompoundingOvernightIndexedCouponPricer: public OvernightIndexedCouponPricer {
+  public:
+    CompoundingOvernightIndexedCouponPricer(
+               const Handle<OptionletVolatilityStructure>& v = {},
+               bool effectiveVolatilityInput = false);
 };
 
 %shared_ptr(BlackCompoundingOvernightIndexedCouponPricer)
@@ -594,7 +620,7 @@ class BlackCompoundingOvernightIndexedCouponPricer: public CompoundingOvernightI
 };
 
 %shared_ptr(ArithmeticAveragedOvernightIndexedCouponPricer)
-class ArithmeticAveragedOvernightIndexedCouponPricer: public FloatingRateCouponPricer {
+class ArithmeticAveragedOvernightIndexedCouponPricer: public OvernightIndexedCouponPricer {
     #if !defined(SWIGJAVA) && !defined(SWIGCSHARP)
     %feature("kwargs") ArithmeticAveragedOvernightIndexedCouponPricer;
     #endif
@@ -602,7 +628,9 @@ class ArithmeticAveragedOvernightIndexedCouponPricer: public FloatingRateCouponP
     ArithmeticAveragedOvernightIndexedCouponPricer(
             Real meanReversion = 0.03,
             Real volatility = 0.00,  // NO convexity adjustment by default
-            bool byApprox = false);  // TRUE to use Katsumi Takada approximation
+            bool byApprox = false,   // TRUE to use Katsumi Takada approximation
+            const Handle<OptionletVolatilityStructure>& v = {},
+            bool effectiveVolatilityInput = false);
 };
 
 %shared_ptr(BlackAveragingOvernightIndexedCouponPricer)

--- a/SWIG/indexes.i
+++ b/SWIG/indexes.i
@@ -378,6 +378,13 @@ class SwapSpreadIndex : public InterestRateIndex {
     Real gearing2();
 };
 
+%inline %{
+    ext::shared_ptr<SwapSpreadIndex> as_swap_spread_index(
+                          const ext::shared_ptr<InterestRateIndex>& index) {
+        return ext::dynamic_pointer_cast<SwapSpreadIndex>(index);
+    }
+%}
+
 %{
 using QuantLib::EquityIndex;
 %}

--- a/SWIG/swaption.i
+++ b/SWIG/swaption.i
@@ -97,7 +97,7 @@ using QuantLib::BasketGeneratingEngine;
 %}
 
 %shared_ptr(NonstandardSwaption)
-class NonstandardSwaption : public Instrument {
+class NonstandardSwaption : public Option {
   public:
     NonstandardSwaption(const ext::shared_ptr<NonstandardSwap>& swap,
                 const ext::shared_ptr<Exercise>& exercise,
@@ -136,7 +136,7 @@ class NonstandardSwaption : public Instrument {
 };
 
 %shared_ptr(FloatFloatSwaption)
-class FloatFloatSwaption : public Instrument {
+class FloatFloatSwaption : public Option {
 public:
     FloatFloatSwaption(const ext::shared_ptr<FloatFloatSwap>& swap,
                 const ext::shared_ptr<Exercise>& exercise,

--- a/SWIG/termstructures.i
+++ b/SWIG/termstructures.i
@@ -215,6 +215,8 @@ class FlatForward : public YieldTermStructure {
                 const DayCounter& dayCounter,
                 Compounding compounding = QuantLib::Continuous,
                 Frequency frequency = QuantLib::Annual);
+    Compounding compounding() const;
+    Frequency compoundingFrequency() const;
 };
 
 

--- a/SWIG/volatilities.i
+++ b/SWIG/volatilities.i
@@ -712,16 +712,23 @@ class SwaptionVolatilityMatrix : public SwaptionVolatilityDiscrete {
                              const VolatilityType type = ShiftedLognormal,
                              const std::vector<std::vector<Real> >& shifts =
                                           std::vector<std::vector<Real> >());
-    SwaptionVolatilityMatrix(const Date& referenceDate,
-                             const Calendar& calendar,
-                             BusinessDayConvention bdc,
-                             const std::vector<Period>& optionTenors,
-                             const std::vector<Period>& swapTenors,
-                             const Matrix& vols,
-                             const DayCounter& dayCounter,
-                             const bool flatExtrapolation = false,
-                             const VolatilityType type = ShiftedLognormal,
-                             const Matrix& shifts = Matrix());
+    %extend {
+        static ext::shared_ptr<SwaptionVolatilityMatrix> forTenors(
+                const Date& referenceDate,
+                const Calendar& calendar,
+                BusinessDayConvention bdc,
+                const std::vector<Period>& optionTenors,
+                const std::vector<Period>& swapTenors,
+                const Matrix& vols,
+                const DayCounter& dayCounter,
+                const bool flatExtrapolation = false,
+                const VolatilityType type = ShiftedLognormal,
+                const Matrix& shifts = Matrix()) {
+            return ext::make_shared<SwaptionVolatilityMatrix>(
+                referenceDate, calendar, bdc, optionTenors, swapTenors, vols,
+                dayCounter, flatExtrapolation, type, shifts);
+        }
+    }
     SwaptionVolatilityMatrix(const Date& referenceDate,
                              const Calendar& calendar,
                              BusinessDayConvention bdc,

--- a/SWIG/volatilities.i
+++ b/SWIG/volatilities.i
@@ -122,6 +122,7 @@ class VolatilityTermStructure : public TermStructure {
   public:
     Real minStrike() const;
     Real maxStrike() const;
+    BusinessDayConvention businessDayConvention() const;
 };
 
 
@@ -703,6 +704,27 @@ class SwaptionVolatilityMatrix : public SwaptionVolatilityDiscrete {
     SwaptionVolatilityMatrix(const Date& referenceDate,
                              const Calendar& calendar,
                              BusinessDayConvention bdc,
+                             const std::vector<Period>& optionTenors,
+                             const std::vector<Period>& swapTenors,
+                             const std::vector<std::vector<Handle<Quote> > >& vols,
+                             const DayCounter& dayCounter,
+                             const bool flatExtrapolation = false,
+                             const VolatilityType type = ShiftedLognormal,
+                             const std::vector<std::vector<Real> >& shifts =
+                                          std::vector<std::vector<Real> >());
+    SwaptionVolatilityMatrix(const Date& referenceDate,
+                             const Calendar& calendar,
+                             BusinessDayConvention bdc,
+                             const std::vector<Period>& optionTenors,
+                             const std::vector<Period>& swapTenors,
+                             const Matrix& vols,
+                             const DayCounter& dayCounter,
+                             const bool flatExtrapolation = false,
+                             const VolatilityType type = ShiftedLognormal,
+                             const Matrix& shifts = Matrix());
+    SwaptionVolatilityMatrix(const Date& referenceDate,
+                             const Calendar& calendar,
+                             BusinessDayConvention bdc,
                              const std::vector<Date>& dates,
                              const std::vector<Period>& lengths,
                              const Matrix& vols,
@@ -872,6 +894,12 @@ class SwaptionVolatilityCube : public SwaptionVolatilityDiscrete {
     public:
         Rate atmStrike(const Date& optionDate,
                        const Period& swapTenor) const;
+        const Handle<SwaptionVolatilityStructure>& atmVol() const;
+        const std::vector<Spread>& strikeSpreads() const;
+        const std::vector<std::vector<Handle<Quote> > >& volSpreads() const;
+        ext::shared_ptr<SwapIndex> swapIndexBase() const;
+        ext::shared_ptr<SwapIndex> shortSwapIndexBase() const;
+        bool vegaWeightedSmileFit() const;
 };
 
 %feature("kwargs") SabrSwaptionVolatilityCube;
@@ -929,6 +957,7 @@ class InterpolatedSwaptionVolatilityCube : public SwaptionVolatilityCube {
                                        const ext::shared_ptr<SwapIndex>& swapIndex,
                                        const ext::shared_ptr<SwapIndex>& shortSwapIndex,
                                        bool vegaWeightedSmileFit);
+    const Matrix& volSpreads(Size i) const;
 };
 
 


### PR DESCRIPTION
Fixing missing or incorrectly represented in SWIG:
1. Correct NonstandardSwaption and FloatFloatSwaption inheritance
2. Add some vol exports
3. Add as_swap_spread_index
4. Expose FloatingRateCoupon::pricer().
5. Correct the overnight coupon-pricer export
6. Expose FlatForward compounding